### PR TITLE
Added InfluxDB Client for .NET to api.md for 0.9

### DIFF
--- a/content/influxdb/v0.9/clients/api.md
+++ b/content/influxdb/v0.9/clients/api.md
@@ -31,6 +31,7 @@ This is a list of the client libraries which have some support for InfluxDB vers
 - [InfluxDB.Client.Net](https://github.com/AdysTech/InfluxDB.Client.Net) by [mvadu](https://github.com/mvadu)
 - [MyInfluxDbClient](https://github.com/danielwertheim/myinfluxdbclient) by [danielwertheim](https://github.com/danielwertheim)
 - [InfluxData.Net](https://github.com/pootzko/InfluxData.Net) by [pootzko](https://github.com/pootzko)
+- [InfluxDB Client for .NET](https://github.com/MikaelGRA/InfluxDB.Client) by [MikaelGRA](https://github.com/MikaelGRA)
 
 ## Perfmon
 - [naf_windows_perfmon_to_influxdb](https://github.com/willemdh/naf_windows_perfmon_to_influxdb) by [willemdh](https://github.com/willemdh)


### PR DESCRIPTION
Hi,

I added my InfluxDB Client for .NET to your client libraries page for v. 0.9.