### PR TITLE
Update telegraf documentation for 0.10

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,72 +29,342 @@ SectionPagesMenu = "products"
   weight = 30
   url = "/kapacitor/"
 
+# Telegraf v0.10 Sub-Menu - Output Plugins
+[[menu.telegraf_10]]
+  name = "InfluxDB"
+  identifier = "influxdb"
+  weight = 0
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/influxdb"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "Amon"
+  identifier = "amon"
+  weight = 10
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amon"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "AMQP (RabbitMQ)"
+  identifier = "amqp"
+  weight = 20
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amqp"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "Datadog"
+  identifier = "datadog"
+  weight = 30
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/datadog"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "Apache Kafka"
+  identifier = "kafka"
+  weight = 40
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/kafka"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "Amazon Kinesis"
+  identifier = "kinesis"
+  weight = 50
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/kinesis"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "Librato"
+  identifier = "librato"
+  weight = 60
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/librato"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "MQTT"
+  identifier = "mqtt"
+  weight = 70
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/mqtt"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "NSQ"
+  identifier = "nsq"
+  weight = 80
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/nsq"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "OpenTSDB"
+  identifier = "opentsdb"
+  weight = 90
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/opentsdb"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "Prometheus"
+  identifier = "prometheus"
+  weight = 100
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/prometheus"
+  parent = "outputs"
+[[menu.telegraf_10]]
+  name = "Riemann"
+  identifier = "riemann"
+  weight = 110
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/riemann"
+  parent = "outputs"
+
+# Telegraf v0.10 Sub-Menu - Input plugins
+[[menu.telegraf_10]]
+  name = "Aerospike"
+  identifier = "aerospike"
+  weight = 0
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/aerospike"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Apache"
+  identifier = "apache"
+  weight = 10
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/apache"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Bcache"
+  identifier = "bcache"
+  weight = 20
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/bcache"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Disque"
+  identifier = "disque"
+  weight = 30
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/disque"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Elasticsearch"
+  identifier = "elasticsearch"
+  weight = 40
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/elasticsearch"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Exec (generic JSON-emitting executable plugin)"
+  identifier = "exec"
+  weight = 50
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/exec"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Haproxy"
+  identifier = "haproxy"
+  weight = 60
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/haproxy"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "HTTP-JSON (generic JSON-emitting http service plugin)"
+  identifier = "httpjson"
+  weight = 70
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/httpjson"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "InfluxDB"
+  identifier = "influxdb"
+  weight = 80
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/influxdb"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Jolokia (remote JMX with JSON over HTTP)"
+  identifier = "jolokia"
+  weight = 90
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/jolokia"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "LeoFS"
+  identifier = "leofs"
+  weight = 100
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/leofs"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Lustre2"
+  identifier = "lustre2"
+  weight = 110
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/lustre2"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Mailchimp"
+  identifier = "mailchimp"
+  weight = 120
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mailchimp"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Memcached"
+  identifier = "memcached"
+  weight = 130
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/memcached"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "MongoDB"
+  identifier = "mongodb"
+  weight = 140
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mongodb"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "MySQL"
+  identifier = "mysql"
+  weight = 150
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mysql"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "NGINX"
+  identifier = "nginx"
+  weight = 160
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/nginx"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "PHP-FPM"
+  identifier = "phpfpm"
+  weight = 170
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/phpfpm"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Ping"
+  identifier = "ping"
+  weight = 180
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/ping"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "PostgreSQL"
+  identifier = "postgresql"
+  weight = 190
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/postgresql"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Procstat"
+  identifier = "procstat"
+  weight = 200
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/procstat"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Prometheus"
+  identifier = "prometheus"
+  weight = 210
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/prometheus"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Puppet Agent"
+  identifier = "puppetagent"
+  weight = 220
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/puppetagent"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "RabbitMQ"
+  identifier = "rabbitmq"
+  weight = 230
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/rabbitmq"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Redis"
+  identifier = "redis"
+  weight = 240
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/redis"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "RethinkDB"
+  identifier = "rethinkdb"
+  weight = 250
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/rethinkdb"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "twemproxy (nutcracker)"
+  identifier = "twemproxy"
+  weight = 260
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/twemproxy"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "ZFS"
+  identifier = "zfs"
+  weight = 270
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/zfs"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "Zookeeper"
+  identifier = "zookeeper"
+  weight = 280
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/zookeeper"
+  parent = "inputs"
+[[menu.telegraf_10]]
+  name = "System (cpu, mem, net, netstat, disk, diskio, swap)"
+  identifier = "system"
+  weight = 290
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/system"
+  parent = "inputs"
+
+# Telegraf v0.10 Sub-Menu - Service Plugins
+[[menu.telegraf_10]]
+  name = "StatsD"
+  identifier = "statsd"
+  weight = 0
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/statsd"
+  parent = "services"
+[[menu.telegraf_10]]
+  name = "Kafka Consumer"
+  identifier = "kafka_consumer"
+  weight = 10
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/kafka_consumer"
+  parent = "services"
+
 # Telegraf v0.2 Sub-Menu - Output Plugins
 [[menu.telegraf_02]]
   name = "InfluxDB"
   identifier = "influxdb"
   weight = 0
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/influxdb"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/influxdb"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "NSQ"
   identifier = "nsq"
   weight = 10
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/nsq"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/nsq"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "Apache Kafka"
   identifier = "kafka"
   weight = 20
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/kafka"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/kafka"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "Datadog"
   identifier = "datadog"
   weight = 30
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/datadog"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/datadog"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "OpenTSDB"
   identifier = "opentsdb"
   weight = 40
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/opentsdb"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/opentsdb"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "AMQP (RabbitMQ)"
   identifier = "amqp"
   weight = 50
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/amqp"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amqp"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "MQTT"
   identifier = "mqtt"
   weight = 60
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/mqtt"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/mqtt"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "Librato"
   identifier = "librato"
   weight = 70
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/librato"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/librato"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "Prometheus"
   identifier = "prometheus"
   weight = 80
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/prometheus"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/prometheus"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "Amon"
   identifier = "amon"
   weight = 90
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/amon"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amon"
   parent = "outputs"
 [[menu.telegraf_02]]
   name = "Riemann"
   identifier = "riemann"
   weight = 100
-  url = "https://github.com/influxdb/telegraf/tree/master/outputs/riemann"
+  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/riemann"
   parent = "outputs"
 
 

--- a/config.toml
+++ b/config.toml
@@ -30,274 +30,318 @@ SectionPagesMenu = "products"
   url = "/kapacitor/"
 
 # Telegraf v0.10 Sub-Menu - Output Plugins
-[[menu.telegraf_10]]
+[[menu.telegraf_010]]
   name = "InfluxDB"
-  identifier = "influxdb"
+  identifier = "influxdb_output"
   weight = 0
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/influxdb"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "Amon"
-  identifier = "amon"
+[[menu.telegraf_010]]
+  name = "amon"
+  identifier = "amon_output"
   weight = 10
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amon"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amon"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "AMQP (RabbitMQ)"
-  identifier = "amqp"
+[[menu.telegraf_010]]
+  name = "AMQP"
+  identifier = "amqp_output"
   weight = 20
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amqp"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amqp"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "Datadog"
-  identifier = "datadog"
+[[menu.telegraf_010]]
+  name = "Amazon CloudWatch"
+  identifier = "cloudwatch_output"
   weight = 30
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/datadog"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/cloudwatch"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "Apache Kafka"
-  identifier = "kafka"
+[[menu.telegraf_010]]
+  name = "Datadog"
+  identifier = "datadog_output"
   weight = 40
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/kafka"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/datadog"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "Amazon Kinesis"
-  identifier = "kinesis"
+[[menu.telegraf_010]]
+  name = "Graphite"
+  identifier = "graphite_output"
   weight = 50
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/kinesis"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/graphite"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "Librato"
-  identifier = "librato"
+[[menu.telegraf_010]]
+  name = "Kafka"
+  identifier = "kafka_output"
   weight = 60
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/librato"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kafka"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "MQTT"
-  identifier = "mqtt"
+[[menu.telegraf_010]]
+  name = "Amazon Kinesis"
+  identifier = "kinesis_output"
   weight = 70
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/mqtt"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kinesis"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "NSQ"
-  identifier = "nsq"
+[[menu.telegraf_010]]
+  name = "Librato"
+  identifier = "librato_output"
   weight = 80
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/nsq"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/librato"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "OpenTSDB"
-  identifier = "opentsdb"
+[[menu.telegraf_010]]
+  name = "MQTT"
+  identifier = "mqtt_output"
   weight = 90
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/opentsdb"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/mqtt"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "Prometheus"
-  identifier = "prometheus"
+[[menu.telegraf_010]]
+  name = "NSQ"
+  identifier = "nsq_output"
   weight = 100
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/prometheus"
+  url = "ghttps://ithub.com/influxdata/telegraf/tree/master/plugins/outputs/nsq"
   parent = "outputs"
-[[menu.telegraf_10]]
-  name = "Riemann"
-  identifier = "riemann"
+[[menu.telegraf_010]]
+  name = "OpenTSDB"
+  identifier = "opentsdb_output"
   weight = 110
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/outputs/riemann"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/opentsdb"
+  parent = "outputs"
+[[menu.telegraf_010]]
+  name = "Prometheus"
+  identifier = "prometheus_client_output"
+  weight = 120
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client"
+  parent = "outputs"
+[[menu.telegraf_010]]
+  name = "Riemann"
+  identifier = "riemann_output"
+  weight = 130
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/riemann"
   parent = "outputs"
 
+
 # Telegraf v0.10 Sub-Menu - Input plugins
-[[menu.telegraf_10]]
-  name = "Aerospike"
-  identifier = "aerospike"
+[[menu.telegraf_010]]
+  name = "system"
+  identifier = "system_input"
   weight = 0
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/aerospike"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/system"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Apache"
-  identifier = "apache"
+[[menu.telegraf_010]]
+  name = "Aerospike"
+  identifier = "aerospike_input"
   weight = 10
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/apache"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/aerospike"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Bcache"
-  identifier = "bcache"
+[[menu.telegraf_010]]
+  name = "Apache"
+  identifier = "apache_input"
   weight = 20
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/bcache"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/apache"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Disque"
-  identifier = "disque"
+[[menu.telegraf_010]]
+  name = "bcache"
+  identifier = "bcache_input"
   weight = 30
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/disque"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/bcache"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Elasticsearch"
-  identifier = "elasticsearch"
+[[menu.telegraf_010]]
+  name = "Disque"
+  identifier = "disque_input"
   weight = 40
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/elasticsearch"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/disque"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Exec (generic JSON-emitting executable plugin)"
-  identifier = "exec"
+[[menu.telegraf_010]]
+  name = "Docker"
+  identifier = "docker_input"
   weight = 50
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/exec"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/docker"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Haproxy"
-  identifier = "haproxy"
+[[menu.telegraf_010]]
+  name = "Elasticsearch"
+  identifier = "elasticsearch_input"
   weight = 60
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/haproxy"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/elasticsearch"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "HTTP-JSON (generic JSON-emitting http service plugin)"
-  identifier = "httpjson"
+[[menu.telegraf_010]]
+  name = "exec"
+  identifier = "exec_input"
   weight = 70
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/httpjson"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/exec"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "InfluxDB"
-  identifier = "influxdb"
+[[menu.telegraf_010]]
+  name = "HAProxy"
+  identifier = "haproxy_input"
   weight = 80
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/influxdb"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/haproxy"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Jolokia (remote JMX with JSON over HTTP)"
-  identifier = "jolokia"
+[[menu.telegraf_010]]
+  name = "HTTPJSON"
+  identifier = "httpjson_input"
   weight = 90
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/jolokia"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/httpjson"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "LeoFS"
-  identifier = "leofs"
+[[menu.telegraf_010]]
+  name = "InfluxDB"
+  identifier = "influxdb_input"
   weight = 100
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/leofs"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Lustre2"
-  identifier = "lustre2"
+[[menu.telegraf_010]]
+  name = "Jolokia"
+  identifier = "jolokia_input"
   weight = 110
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/lustre2"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/jolokia"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Mailchimp"
-  identifier = "mailchimp"
+[[menu.telegraf_010]]
+  name = "LeoFS"
+  identifier = "leofs_input"
   weight = 120
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mailchimp"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/leofs"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Memcached"
-  identifier = "memcached"
+[[menu.telegraf_010]]
+  name = "Lustre2"
+  identifier = "lustre2_input"
   weight = 130
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/memcached"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/lustre2"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "MongoDB"
-  identifier = "mongodb"
+[[menu.telegraf_010]]
+  name = "Mailchimp"
+  identifier = "mailchimp_input"
   weight = 140
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mongodb"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mailchimp"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "MySQL"
-  identifier = "mysql"
+[[menu.telegraf_010]]
+  name = "Memcached"
+  identifier = "memcached_input"
   weight = 150
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mysql"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/memcached"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "NGINX"
-  identifier = "nginx"
+[[menu.telegraf_010]]
+  name = "MongoDB"
+  identifier = "mongodb_input"
   weight = 160
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/nginx"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mongodb"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "PHP-FPM"
-  identifier = "phpfpm"
+[[menu.telegraf_010]]
+  name = "MySQL"
+  identifier = "mysql_input"
   weight = 170
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/phpfpm"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mysql"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Ping"
-  identifier = "ping"
+[[menu.telegraf_010]]
+  name = "NGINX"
+  identifier = "nginx_input"
   weight = 180
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/ping"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nginx"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "PostgreSQL"
-  identifier = "postgresql"
+[[menu.telegraf_010]]
+  name = "NSQ"
+  identifier = "nsq_input"
   weight = 190
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/postgresql"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nsq"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Procstat"
-  identifier = "procstat"
+[[menu.telegraf_010]]
+  name = "Phusion Passenger"
+  identifier = "passenger_input"
   weight = 200
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/procstat"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/passenger"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Prometheus"
-  identifier = "prometheus"
+[[menu.telegraf_010]]
+  name = "PHP-FPM"
+  identifier = "phpfpm_input"
   weight = 210
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/prometheus"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/phpfpm"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Puppet Agent"
-  identifier = "puppetagent"
+[[menu.telegraf_010]]
+  name = "ping"
+  identifier = "ping_input"
   weight = 220
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/puppetagent"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ping"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "RabbitMQ"
-  identifier = "rabbitmq"
+[[menu.telegraf_010]]
+  name = "PostgreSQL"
+  identifier = "postgresql_input"
   weight = 230
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/rabbitmq"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/postgresql"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Redis"
-  identifier = "redis"
+[[menu.telegraf_010]]
+  name = "procstat"
+  identifier = "procstat_input"
   weight = 240
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/redis"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/procstat"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "RethinkDB"
-  identifier = "rethinkdb"
+[[menu.telegraf_010]]
+  name = "Prometheus"
+  identifier = "prometheus_input"
   weight = 250
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/rethinkdb"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/prometheus"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "twemproxy (nutcracker)"
-  identifier = "twemproxy"
+[[menu.telegraf_010]]
+  name = "Puppet Agent"
+  identifier = "puppetagent_input"
   weight = 260
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/twemproxy"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/puppetagent"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "ZFS"
-  identifier = "zfs"
+[[menu.telegraf_010]]
+  name = "RabbitMQ"
+  identifier = "rabbitmq_input"
   weight = 270
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/zfs"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rabbitmq"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "Zookeeper"
-  identifier = "zookeeper"
+[[menu.telegraf_010]]
+  name = "Redis"
+  identifier = "redis_input"
   weight = 280
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/zookeeper"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/redis"
   parent = "inputs"
-[[menu.telegraf_10]]
-  name = "System (cpu, mem, net, netstat, disk, diskio, swap)"
-  identifier = "system"
+[[menu.telegraf_010]]
+  name = "RethinkDB"
+  identifier = "rethinkdb_input"
   weight = 290
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/system"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rethinkdb"
+  parent = "inputs"
+[[menu.telegraf_010]]
+  name = "sensors"
+  identifier = "sensors_input"
+  weight = 300
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/sensors"
+  parent = "inputs"
+[[menu.telegraf_010]]
+  name = "trig"
+  identifier = "trig_input"
+  weight = 310
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/trig"
+  parent = "inputs"
+[[menu.telegraf_010]]
+  name = "twemproxy (nutcracker)"
+  identifier = "twemproxy_input"
+  weight = 320
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/twemproxy"
+  parent = "inputs"
+[[menu.telegraf_010]]
+  name = "ZFS"
+  identifier = "zfs_input"
+  weight = 330
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/zfs"
+  parent = "inputs"
+[[menu.telegraf_010]]
+  name = "Zookeeper"
+  identifier = "zookeeper_input"
+  weight = 340
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/zookeeper"
   parent = "inputs"
 
 # Telegraf v0.10 Sub-Menu - Service Plugins
-[[menu.telegraf_10]]
+[[menu.telegraf_010]]
   name = "StatsD"
-  identifier = "statsd"
+  identifier = "statsd_input"
   weight = 0
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/statsd"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd"
   parent = "services"
-[[menu.telegraf_10]]
+[[menu.telegraf_010]]
   name = "Kafka Consumer"
-  identifier = "kafka_consumer"
+  identifier = "kafka_consumer_input"
   weight = 10
-  url = "https://github.com/influxdb/telegraf/tree/master/plugins/inputs/kafka_consumer"
+  url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kafka_consumer"
   parent = "services"
+
 
 # Telegraf v0.2 Sub-Menu - Output Plugins
 [[menu.telegraf_02]]

--- a/content/telegraf/v0.10/index.md
+++ b/content/telegraf/v0.10/index.md
@@ -1,0 +1,11 @@
+---
+title: Telegraf Version 0.10 Documentation
+
+menu:
+  telegraf:
+    name: Version 0.10
+    identifier: telegraf_10
+    weight: 0
+---
+
+The Telegraf documentation is currently under construction.

--- a/content/telegraf/v0.10/index.md
+++ b/content/telegraf/v0.10/index.md
@@ -3,9 +3,19 @@ title: Telegraf Version 0.10 Documentation
 
 menu:
   telegraf:
-    name: Version 0.10
-    identifier: telegraf_10
+    name: v0.10
+    identifier: telegraf_010
     weight: 0
 ---
 
-The Telegraf documentation is currently under construction.
+Telegraf is a plugin-driven server agent for collecting & reporting metrics. Telegraf has plugins to source a variety of metrics directly from the system it's running on, pull metrics from third party APIs, or even listen for metrics via a statsd and Kafka consumer services. It also has output plugins to send metrics to a variety of other datastores, services, and message queues, including InfluxDB, Graphite, OpenTSDB, Datadog, Librato, Kafka, MQTT, NSQ, and many others.
+
+## Key Features
+
+Here are some of the features that Telegraf currently supports and make it a great choice for metrics collection.
+
+* Written entirely in Go.
+It compiles into a single binary with no external dependencies.
+* Minimal memory footprint.
+* Plugin system allows new inputs and outputs to be easily added.
+* A wide number of plugins for many popular services already exist for well known services and APIs.

--- a/content/telegraf/v0.10/inputs/index.md
+++ b/content/telegraf/v0.10/inputs/index.md
@@ -2,7 +2,7 @@
 title: Supported Input Plugins
 
 menu:
-  telegraf_10:
+  telegraf_010:
     name: Input Plugins
     identifier: inputs
     weight: 20
@@ -16,40 +16,38 @@ View usage instructions for each input by running `telegraf -usage <input-name>`
 
 ## Supported Input Plugins
 
-* [aerospike](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/aerospike)
-* [apache](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/apache)
-* [bcache](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/bcache)
-* [disque](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/disque)
-* [elasticsearch](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/elasticsearch)
-* [exec](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/exec) (generic JSON-emitting executable plugin)
-* [haproxy](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/haproxy)
-* [httpjson](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/httpjson) (generic JSON-emitting http service plugin)
-* [influxdb](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb)
-* [jolokia](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/jolokia) (remote JMX with JSON over HTTP)
-* [leofs](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/leofs)
-* [lustre2](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/lustre2)
-* [mailchimp](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mailchimp)
-* [memcached](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/memcached)
-* [mongodb](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mongodb)
-* [mysql](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mysql)
-* [nginx](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/nginx)
-* [phpfpm](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/phpfpm)
-* [ping](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/ping)
-* [postgresql](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/postgresql)
-* [procstat](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/procstat)
-* [prometheus](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/prometheus)
-* [puppetagent](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/puppetagent)
-* [rabbitmq](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/rabbitmq)
-* [redis](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/redis)
-* [rethinkdb](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/rethinkdb)
-* [twemproxy](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/twemproxy)
-* [zfs](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/zfs)
-* [zookeeper](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/zookeeper)
-* [system](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/system)
-    * cpu
-    * mem
-    * net
-    * netstat
-    * disk
-    * diskio
-    * swap
+* [system](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/system) (cpu, mem, net, netstat, disk, diskio, swap)
+* [Aerospike](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/aerospike)
+* [Apache](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/apache)
+* [bcache](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/bcache)
+* [Disque](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/disque)
+* [Docker](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/docker)
+* [Elasticsearch](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/elasticsearch)
+* [exec](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/exec) (generic JSON-emitting executable plugin)
+* [HAProxy](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/haproxy)
+* [HTTPJSON](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/httpjson) (generic JSON-emitting http service plugin)
+* [InfluxDB](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb)
+* [Jolokia](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/jolokia) (remote JMX with JSON over HTTP)
+* [LeoFS](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/leofs)
+* [Lustre2](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/lustre2)
+* [Mailchimp](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mailchimp)
+* [Memcached](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/memcached)
+* [MongoDB](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mongodb)
+* [MySQL](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mysql)
+* [NGINX](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nginx)
+* [NSQ](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nsq)
+* [Phusion Passenger](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/passenger)
+* [PHP-FPM](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/phpfpm)
+* [ping](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ping)
+* [PostgreSQL](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/postgresql)
+* [procstat](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/procstat)
+* [Prometheus](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/prometheus)
+* [Puppet Agent](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/puppetagent)
+* [RabbitMQ](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rabbitmq)
+* [Redis](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/redis)
+* [RethinkDB](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rethinkdb)
+* [sensors](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/sensors)
+* [trig](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/trig)
+* [twemproxy (nutcracker)](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/twemproxy)
+* [ZFS](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/zfs)
+* [Zookeeper](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/zookeeper)

--- a/content/telegraf/v0.10/inputs/index.md
+++ b/content/telegraf/v0.10/inputs/index.md
@@ -1,0 +1,55 @@
+---
+title: Supported Input Plugins
+
+menu:
+  telegraf_10:
+    name: Input Plugins
+    identifier: inputs
+    weight: 20
+---
+
+Telegraf is entirely input driven. It gathers all metrics from the inputs specified in the configuration file.
+
+## Usage Instructions
+
+View usage instructions for each input by running `telegraf -usage <input-name>`.
+
+## Supported Input Plugins
+
+* [aerospike](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/aerospike)
+* [apache](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/apache)
+* [bcache](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/bcache)
+* [disque](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/disque)
+* [elasticsearch](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/elasticsearch)
+* [exec](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/exec) (generic JSON-emitting executable plugin)
+* [haproxy](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/haproxy)
+* [httpjson](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/httpjson) (generic JSON-emitting http service plugin)
+* [influxdb](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb)
+* [jolokia](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/jolokia) (remote JMX with JSON over HTTP)
+* [leofs](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/leofs)
+* [lustre2](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/lustre2)
+* [mailchimp](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mailchimp)
+* [memcached](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/memcached)
+* [mongodb](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mongodb)
+* [mysql](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/mysql)
+* [nginx](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/nginx)
+* [phpfpm](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/phpfpm)
+* [ping](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/ping)
+* [postgresql](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/postgresql)
+* [procstat](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/procstat)
+* [prometheus](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/prometheus)
+* [puppetagent](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/puppetagent)
+* [rabbitmq](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/rabbitmq)
+* [redis](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/redis)
+* [rethinkdb](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/rethinkdb)
+* [twemproxy](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/twemproxy)
+* [zfs](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/zfs)
+* [zookeeper](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/zookeeper)
+* [system](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/system)
+    * cpu
+    * mem
+    * net
+    * netstat
+    * disk
+    * diskio
+    * swap

--- a/content/telegraf/v0.10/introduction/configuration.md
+++ b/content/telegraf/v0.10/introduction/configuration.md
@@ -2,9 +2,9 @@
 title: Configuring Telegraf
 
 menu:
-  telegraf_10:
+  telegraf_010:
     name: Configuring Telegraf
-    weight: 1
+    weight: 10
     parent: introduction
 ---
 

--- a/content/telegraf/v0.10/introduction/configuration.md
+++ b/content/telegraf/v0.10/introduction/configuration.md
@@ -10,14 +10,14 @@ menu:
 
 ## Configuring Telegraf
 
-### Create a configuration file with every plugin and output
+### Create a configuration file with every input and output
 ```
 telegraf -sample-config > telegraf.conf
 ```
 
-### Create a configuration file with specific plugins and outputs
+### Create a configuration file with specific inputs and outputs
 ```
-telegraf -sample-config -filter <pluginname>[:<pluginname>] -outputfilter <outputname>[:<outputname>] > telegraf.conf
+telegraf -sample-config -input-filter <pluginname>[:<pluginname>] -output-filter <outputname>[:<outputname>] > telegraf.conf
 ```
 
 > **Note:** In most cases, you will need to edit the configuration file to match your needs.

--- a/content/telegraf/v0.10/introduction/configuration.md
+++ b/content/telegraf/v0.10/introduction/configuration.md
@@ -1,0 +1,23 @@
+---
+title: Configuring Telegraf
+
+menu:
+  telegraf_10:
+    name: Configuring Telegraf
+    weight: 1
+    parent: introduction
+---
+
+## Configuring Telegraf
+
+### Create a configuration file with every plugin and output
+```
+telegraf -sample-config > telegraf.conf
+```
+
+### Create a configuration file with specific plugins and outputs
+```
+telegraf -sample-config -filter <pluginname>[:<pluginname>] -outputfilter <outputname>[:<outputname>] > telegraf.conf
+```
+
+> **Note:** In most cases, you will need to edit the configuration file to match your needs.

--- a/content/telegraf/v0.10/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.10/introduction/getting-started-telegraf.md
@@ -27,9 +27,11 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 * Standalone Binary: see the next section for how to create a configuration file
 
 ### Creating and Editing the Configuration File
-Before starting the Telegraf server you need to edit and/or create an initial configuration that specifies your desired [inputs](/telegraf/v0.10/inputs/) (where the metrics come from) and [outputs](/telegraf/v0.10/outputs/) (where the metrics go). There are [several ways](/telegraf/v0.10/introduction/configuration/) to create and edit the configuration file. Here, we'll generate a configuration file and simultaneously specify the desired inputs with the `-input-filter` flag and the desired output with the `-output-filter` flag.
+Before starting the Telegraf server you need to edit and/or create an initial configuration that specifies your desired [inputs](/telegraf/v0.10/inputs/) (where the metrics come from) and [outputs](/telegraf/v0.10/outputs/) (where the metrics go). There are [several ways](/telegraf/v0.10/introduction/configuration/) to create and edit the configuration file.
+Here, we'll generate a configuration file and simultaneously specify the desired inputs with the `-input-filter` flag and the desired output with the `-output-filter` flag.
 
-In the example below, we create a configuration file called `telegraf.conf` with two inputs: one that reads metrics about the system's cpu usage (`cpu`) and one that reads metrics about the system's memory usage (`mem`). `telegraf.conf` specifies InfluxDB as the desired output.
+In the example below, we create a configuration file called `telegraf.conf` with two inputs:
+one that reads metrics about the system's cpu usage (`cpu`) and one that reads metrics about the system's memory usage (`mem`). `telegraf.conf` specifies InfluxDB as the desired output.
 
 ```sh
 telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf.conf
@@ -55,7 +57,8 @@ systemctl start telegraf
 ## Results
 Once Telegraf is up and running it'll start collecting data and writing them to the desired output.
 
-Returning to our sample configuration, we show what the `cpu` and `mem` data look like in InfluxDB below. Note that we used the default input and output configuration settings to get these data.
+Returning to our sample configuration, we show what the `cpu` and `mem` data look like in InfluxDB below.
+Note that we used the default input and output configuration settings to get these data.
 
 * List all [measurements](https://docs.influxdata.com/influxdb/v0.9/concepts/glossary/#measurement) in the `telegraf` [database](https://docs.influxdata.com/influxdb/v0.9/concepts/glossary/#database):
 

--- a/content/telegraf/v0.10/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.10/introduction/getting-started-telegraf.md
@@ -27,12 +27,12 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 * Standalone Binary: see the next section for how to create a configuration file
 
 ### Creating and Editing the Configuration File
-Before starting the Telegraf server you need to edit and/or create an initial configuration that specifies your desired [plugins](/telegraf/v0.2/plugins/) (where the metrics come from) and [outputs](/telegraf/v0.2/outputs/) (where the metrics go). There are [several ways](../configuration/) to create and edit the configuration file. Here, we'll generate a configuration file and simultaneously specify the desired plugins with the `-filter` flag and the desired output with the `-outputfilter` flag.
+Before starting the Telegraf server you need to edit and/or create an initial configuration that specifies your desired [inputs](/telegraf/v0.10/inputs/) (where the metrics come from) and [outputs](/telegraf/v0.10/outputs/) (where the metrics go). There are [several ways](/telegraf/v0.10/introduction/configuration/) to create and edit the configuration file. Here, we'll generate a configuration file and simultaneously specify the desired inputs with the `-input-filter` flag and the desired output with the `-output-filter` flag.
 
-In the example below, we create a configuration file called `telegraf.conf` with two plugins: one that reads metrics about the system's cpu usage (`cpu`) and one that reads metrics about the system's memory usage (`mem`). `telegraf.conf` specifies InfluxDB as the desired ouput.
+In the example below, we create a configuration file called `telegraf.conf` with two inputs: one that reads metrics about the system's cpu usage (`cpu`) and one that reads metrics about the system's memory usage (`mem`). `telegraf.conf` specifies InfluxDB as the desired output.
 
 ```sh
-telegraf -sample-config -filter cpu:mem -outputfilter influxdb > telegraf.conf
+telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf.conf
 ```
 
 ## Start the Telegraf Server
@@ -55,7 +55,7 @@ systemctl start telegraf
 ## Results
 Once Telegraf is up and running it'll start collecting data and writing them to the desired output.
 
-Returning to our sample configuration, we show what the `cpu` and `mem` data look like in InfluxDB below. Note that we used the default plugin and output configuration settings to get these data.
+Returning to our sample configuration, we show what the `cpu` and `mem` data look like in InfluxDB below. Note that we used the default input and output configuration settings to get these data.
 
 * List all [measurements](https://docs.influxdata.com/influxdb/v0.9/concepts/glossary/#measurement) in the `telegraf` [database](https://docs.influxdata.com/influxdb/v0.9/concepts/glossary/#database):
 
@@ -64,40 +64,53 @@ Returning to our sample configuration, we show what the `cpu` and `mem` data loo
 name: measurements
 ------------------
 name
-cpu_usage_guest
-cpu_usage_guest_nice
-cpu_usage_idle
-cpu_usage_iowait
-cpu_usage_irq
-cpu_usage_nice
-cpu_usage_softirq
-cpu_usage_steal
-cpu_usage_system
-cpu_usage_user
-mem_available
-mem_available_percent
-mem_buffered
-mem_cached
-mem_free
-mem_total
-mem_used
-mem_used_percent
+cpu
+mem
 ```
 
-Notice that each measurement has the name of the plugin prepended to it.
-
-* Select a sample of the data in the measurement `cpu_usage_idle`:
+* List all [field keys](https://docs.influxdata.com/influxdb/v0.9/concepts/glossary/#field-key) by measurement:
 
 ```sh
-> SELECT value FROM cpu_usage_idle WHERE cpu='cpu-total' LIMIT 5
-name: cpu_usage_idle
---------------------
-time			                value
-2015-12-08T21:39:20Z	  98.04902451225612
-2015-12-08T21:39:30Z	  97.70028746406699
-2015-12-08T21:39:40Z	  98.37520309961255
-2015-12-08T21:39:50Z	  98.17522809648794
-2015-12-08T21:40:00Z	  96.84881830686507
+> SHOW FIELD KEYS
+name: cpu
+---------
+fieldKey
+usage_guest
+usage_guest_nice
+usage_idle
+usage_iowait
+usage_irq
+usage_nice
+usage_softirq
+usage_steal
+usage_system
+usage_user
+
+name: mem
+---------
+fieldKey
+available
+available_percent
+buffered
+cached
+free
+total
+used
+used_percent
+```
+
+* Select a sample of the data in the [field](https://docs.influxdata.com/influxdb/v0.9/concepts/glossary/#field) `usage_idle` in the measurement `cpu_usage_idle`:
+
+```sh
+> SELECT usage_idle FROM cpu WHERE cpu = 'cpu-total' LIMIT 5
+name: cpu
+---------
+time			               usage_idle
+2016-01-16T00:03:00Z	 97.56189047261816
+2016-01-16T00:03:10Z	 97.76305923519121
+2016-01-16T00:03:20Z	 97.32533433320835
+2016-01-16T00:03:30Z	 95.68857785553611
+2016-01-16T00:03:40Z	 98.63715928982245
 ```
 
 

--- a/content/telegraf/v0.10/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.10/introduction/getting-started-telegraf.md
@@ -2,7 +2,7 @@
 title: Getting Started with Telegraf
 
 menu:
-  telegraf_10:
+  telegraf_010:
     name: Getting Started
     weight: 0
     parent: introduction

--- a/content/telegraf/v0.10/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.10/introduction/getting-started-telegraf.md
@@ -1,0 +1,107 @@
+---
+title: Getting Started with Telegraf
+
+menu:
+  telegraf_10:
+    name: Getting Started
+    weight: 0
+    parent: introduction
+---
+
+## Getting Started with Telegraf
+Telegraf is an agent written in Go for collecting metrics and writing them into InfluxDB or other possible outputs.
+This guide will get you up and running with Telegraf.
+It walks you through the download, installation, and configuration processes, and it shows how to use Telegraf to get data into InfluxDB.
+
+> **Note:** Telegraf 0.10.x is not backwards compatible with previous versions of Telegraf.
+See the [release blog post](https://influxdata.com/blog/announcing-telegraf-0-10-0/) for more on the differences between Telegraf 0.2.x and 0.10.x.
+
+## Download and Install Telegraf
+Follow the instructions in the Telegraf section on the [Downloads page](https://influxdata.com/downloads/).
+
+## Configuration
+### Configuration file location by installation type
+
+* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
+* Standalone Binary: see the next section for how to create a configuration file
+
+### Creating and Editing the Configuration File
+Before starting the Telegraf server you need to edit and/or create an initial configuration that specifies your desired [plugins](/telegraf/v0.2/plugins/) (where the metrics come from) and [outputs](/telegraf/v0.2/outputs/) (where the metrics go). There are [several ways](../configuration/) to create and edit the configuration file. Here, we'll generate a configuration file and simultaneously specify the desired plugins with the `-filter` flag and the desired output with the `-outputfilter` flag.
+
+In the example below, we create a configuration file called `telegraf.conf` with two plugins: one that reads metrics about the system's cpu usage (`cpu`) and one that reads metrics about the system's memory usage (`mem`). `telegraf.conf` specifies InfluxDB as the desired ouput.
+
+```sh
+telegraf -sample-config -filter cpu:mem -outputfilter influxdb > telegraf.conf
+```
+
+## Start the Telegraf Server
+Start the Telegraf server and direct it to the relevant configuration file:
+### OS X [Homebrew](http://brew.sh/)
+```sh
+telegraf -config telegraf.conf
+```
+
+### Linux debian and RPM packages
+```sh
+sudo service telegraf start
+```
+
+### Ubuntu 15+
+```sh
+systemctl start telegraf
+```
+
+## Results
+Once Telegraf is up and running it'll start collecting data and writing them to the desired output.
+
+Returning to our sample configuration, we show what the `cpu` and `mem` data look like in InfluxDB below. Note that we used the default plugin and output configuration settings to get these data.
+
+* List all [measurements](https://docs.influxdata.com/influxdb/v0.9/concepts/glossary/#measurement) in the `telegraf` [database](https://docs.influxdata.com/influxdb/v0.9/concepts/glossary/#database):
+
+```sh
+> SHOW MEASUREMENTS
+name: measurements
+------------------
+name
+cpu_usage_guest
+cpu_usage_guest_nice
+cpu_usage_idle
+cpu_usage_iowait
+cpu_usage_irq
+cpu_usage_nice
+cpu_usage_softirq
+cpu_usage_steal
+cpu_usage_system
+cpu_usage_user
+mem_available
+mem_available_percent
+mem_buffered
+mem_cached
+mem_free
+mem_total
+mem_used
+mem_used_percent
+```
+
+Notice that each measurement has the name of the plugin prepended to it.
+
+* Select a sample of the data in the measurement `cpu_usage_idle`:
+
+```sh
+> SELECT value FROM cpu_usage_idle WHERE cpu='cpu-total' LIMIT 5
+name: cpu_usage_idle
+--------------------
+time			                value
+2015-12-08T21:39:20Z	  98.04902451225612
+2015-12-08T21:39:30Z	  97.70028746406699
+2015-12-08T21:39:40Z	  98.37520309961255
+2015-12-08T21:39:50Z	  98.17522809648794
+2015-12-08T21:40:00Z	  96.84881830686507
+```
+
+
+Notice that the timestamps occur at rounded ten second intervals (that is, `:00`, `:10`, `:20`, and so on) - this is a configurable setting.
+
+
+That's it! You now have the foundation for using Telegraf to collect metrics and write them to your output of choice.  

--- a/content/telegraf/v0.10/introduction/index.md
+++ b/content/telegraf/v0.10/introduction/index.md
@@ -2,7 +2,7 @@
 title: Introduction
 
 menu:
-  telegraf_10:
+  telegraf_010:
     name: Introduction
     identifier: introduction
     weight: 0

--- a/content/telegraf/v0.10/introduction/index.md
+++ b/content/telegraf/v0.10/introduction/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction
+
+menu:
+  telegraf_10:
+    name: Introduction
+    identifier: introduction
+    weight: 0
+---

--- a/content/telegraf/v0.10/outputs/index.md
+++ b/content/telegraf/v0.10/outputs/index.md
@@ -1,0 +1,26 @@
+---
+title: Supported Outputs
+
+menu:
+  telegraf_10:
+    name: Output Plugins
+    identifier: outputs
+    weight: 10
+---
+
+Telegraf allows users to specify multiple output sinks in the configuration file.
+
+## Supported Output Plugins List
+
+* [influxdb](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/influxdb)
+* [amon](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amon)
+* [amqp](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amqp) (rabbitmq)
+* [datadog](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/datadog)
+* [kafka](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/kafka)
+* [amazon kinesis](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kinesis)
+* [librato](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/librato)
+* [mqtt](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/mqtt)
+* [nsq](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/nsq)
+* [opentsdb](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/opentsdb)
+* [prometheus](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client)
+* [riemann](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/riemann)

--- a/content/telegraf/v0.10/outputs/index.md
+++ b/content/telegraf/v0.10/outputs/index.md
@@ -2,7 +2,7 @@
 title: Supported Outputs
 
 menu:
-  telegraf_10:
+  telegraf_010:
     name: Output Plugins
     identifier: outputs
     weight: 10
@@ -12,15 +12,17 @@ Telegraf allows users to specify multiple output sinks in the configuration file
 
 ## Supported Output Plugins List
 
-* [influxdb](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/influxdb)
-* [amon](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amon)
-* [amqp](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/amqp) (rabbitmq)
-* [datadog](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/datadog)
-* [kafka](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/kafka)
-* [amazon kinesis](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kinesis)
-* [librato](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/librato)
-* [mqtt](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/mqtt)
-* [nsq](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/nsq)
-* [opentsdb](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/opentsdb)
-* [prometheus](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client)
-* [riemann](https://github.com/influxdb/telegraf/tree/master/plugins/outputs/riemann)
+* [InfluxDB](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb)
+* [amon](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amon)
+* [AMQP](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amqp)
+* [Amazon CloudWatch](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/cloudwatch)
+* [Datadog](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/datadog)
+* [Graphite](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/graphite)
+* [Kafka](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kafka)
+* [Amazon Kinesis](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kinesis)
+* [Librato](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/librato)
+* [MQTT](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/mqtt)
+* [NSQ](ghttps://ithub.com/influxdata/telegraf/tree/master/plugins/outputs/nsq)
+* [OpenTSDB](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/opentsdb)
+* [Prometheus](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client)
+* [Riemann](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/riemann)

--- a/content/telegraf/v0.10/services/index.md
+++ b/content/telegraf/v0.10/services/index.md
@@ -1,0 +1,20 @@
+---
+title: Supported Service Inputs
+
+menu:
+  telegraf_10:
+    name: Service Inputs
+    identifier: services
+    weight: 30
+---
+
+Telegraf is entirely input driven. It gathers all metrics from the inputs specified in the configuration file.
+
+## Usage Instructions
+
+View usage instructions for each service input by running `telegraf -usage <service-input-name>`.
+
+## Supported Service Plugin List
+
+* [statsd](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/statsd)
+* [kafka_consumer](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/kafka_consumer)

--- a/content/telegraf/v0.10/services/index.md
+++ b/content/telegraf/v0.10/services/index.md
@@ -2,7 +2,7 @@
 title: Supported Service Inputs
 
 menu:
-  telegraf_10:
+  telegraf_010:
     name: Service Inputs
     identifier: services
     weight: 30
@@ -16,5 +16,5 @@ View usage instructions for each service input by running `telegraf -usage <serv
 
 ## Supported Service Plugin List
 
-* [statsd](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/statsd)
-* [kafka_consumer](https://github.com/influxdb/telegraf/tree/master/plugins/inputs/kafka_consumer)
+* [StatsD](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd)
+* [Kafka Consumer](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kafka_consumer)

--- a/data/default_versions.toml
+++ b/data/default_versions.toml
@@ -1,5 +1,5 @@
-telegraf = "telegraf_02"
-telegraf_semver = "v0.2"
+telegraf = "telegraf_010"
+telegraf_semver = "v0.10"
 influxdb = "influxdb_09"
 influxdb_semver = "v0.9"
 chronograf = "chronograf_04"

--- a/layouts/partials/telegraf/version.html
+++ b/layouts/partials/telegraf/version.html
@@ -1,0 +1,6 @@
+{{ if not (or (in .RelPermalink .Site.Data.default_versions.telegraf_semver) (eq .RelPermalink "/telegraf/")) }}
+<div class="flash">
+    <p><b>Warning! This page documents an old version of Telegraf, which is no longer actively developed. <a href="/telegraf/{{ .Site.Data.default_versions.telegraf_semver }}/">Telegraf {{ .Site.Data.default_versions.telegraf_semver }}</a> is the most recent version of Telegraf.</b></p>
+</div>
+<br />
+{{ end }}

--- a/layouts/telegraf/single.html
+++ b/layouts/telegraf/single.html
@@ -1,9 +1,12 @@
 {{ partial "header.html" . }}
 <div class="page" id="page-content">
-	<div class="page--title" id="page-title">
-	    <div class="page--body"><h1>{{ .Title }}</h1></div>
-	</div>
+    {{ if .Title }}
+    <div class="page--title" id="page-title">
+        <div class="page--body"><h1>{{ .Title }}</h1></div>
+    </div>
+    {{ end }}
     <div class="page--body">
+        {{ partial "telegraf/version.html" . }}
         {{ .Content }}
     </div>
     {{ partial "telegraf/contribute.html" . }}


### PR DESCRIPTION
Update the documentation with the changes in https://github.com/influxdata/telegraf/blob/master/CHANGELOG.md#v0100-2016-01-12.

A couple issues:
1) I'm not sure how to make these the default telegraf docs
2) I can't seem to get influxdb and prometheus to show up in the output plugins submenu 

Fixes https://github.com/influxdata/docs.influxdata.com/issues/146