### PR TITLE
Added disclaimer to clustering documentation

### DIFF
--- a/content/influxdb/v0.10/guides/clustering.md
+++ b/content/influxdb/v0.10/guides/clustering.md
@@ -7,6 +7,8 @@ menu:
     parent: guides
 ---
 
+> **NOTE:** Clustering is still in an alpha state, and there are still quite a few rough edges. If you encounter any issues, please [report them](https://github.com/influxdata/influxdb/issues/new).
+
 InfluxDB supports arbitrarily sized clusters and any replication
 factor from 1 to the number of nodes in the cluster. There are two
 types of nodes in an InfluxDB cluser:

--- a/content/influxdb/v0.10/guides/clustering.md
+++ b/content/influxdb/v0.10/guides/clustering.md
@@ -7,7 +7,7 @@ menu:
     parent: guides
 ---
 
-> **NOTE:** Clustering is still in an alpha state, and there are still quite a few rough edges. If you encounter any issues, please [report them](https://github.com/influxdata/influxdb/issues/new).
+> **NOTE:** Clustering is still considered _experimental_, and there are still quite a few rough edges. If you encounter any issues, please [report them](https://github.com/influxdata/influxdb/issues/new).
 
 InfluxDB supports arbitrarily sized clusters and any replication
 factor from 1 to the number of nodes in the cluster. There are two


### PR DESCRIPTION
The disclaimer was accidentally dropped with the 0.10.0 migration. It needs to be put back.