### PR TITLE
Use old influxdb link to CLA form

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -681,7 +681,7 @@ SectionPagesMenu = "products"
   name = "CLA"
   identifier = "cla"
   weight = 20
-  url = "https://influxdata.com/community/cla.html"
+  url = "https://influxdata.com/community/cla/"
   parent = "about"
 [[menu.influxdb_010]]
   name = "Licenses"


### PR DESCRIPTION
The current link on the website is a 404 for the CLA.