### PR TITLE
Remove hostname from links

### DIFF
--- a/content/influxdb/v0.10/introduction/getting_started.md
+++ b/content/influxdb/v0.10/introduction/getting_started.md
@@ -167,7 +167,7 @@ time		                        	 external	  internal	machine	type
 > 
 ```
 
-InfluxQL has many [features and keywords](http://localhost:1313/influxdb/v0.10/query_language/spec/) that are not covered here,
+InfluxQL has many [features and keywords](/influxdb/v0.10/query_language/spec/) that are not covered here,
 including support for Go-style regex. For example:
 
 ```sql

--- a/content/influxdb/v0.10/query_language/functions.md
+++ b/content/influxdb/v0.10/query_language/functions.md
@@ -1265,7 +1265,7 @@ Append `fill()` to the end of your query to alter that value.
 For a complete discussion of `fill()`, see [Data Exploration](/influxdb/v0.10/query_language/data_exploration/#the-group-by-clause-and-fill).
 
 > **Note:** `fill()` works differently with `COUNT()`.
-See [the documentation on `COUNT()`](http://localhost:1313/influxdb/v0.10/query_language/functions/#count-and-controlling-the-values-reported-for-intervals-with-no-data) for a function-specific use of `fill()`.
+See [the documentation on `COUNT()`](/influxdb/v0.10/query_language/functions/#count-and-controlling-the-values-reported-for-intervals-with-no-data) for a function-specific use of `fill()`.
 
 ## Rename the output column's title with `AS`
 

--- a/content/influxdb/v0.9/query_language/functions.md
+++ b/content/influxdb/v0.9/query_language/functions.md
@@ -1215,7 +1215,7 @@ time			               stddev
 ## Include multiple functions in a single query
 Separate multiple functions in one query with a `,`.
 
-Calculate the [minimum](http://localhost:1313/influxdb/v0.9/query_language/functions/#min) `water_level` and the [maximum](/influxdb/v0.9/query_language/functions/#max) `water_level` with a single query:
+Calculate the [minimum](/influxdb/v0.9/query_language/functions/#min) `water_level` and the [maximum](/influxdb/v0.9/query_language/functions/#max) `water_level` with a single query:
 ```sql
 > SELECT MIN(water_level), MAX(water_level) FROM h2o_feet
 ```


### PR DESCRIPTION
While browsing the InfluxDB documentation, I found a link that had `localhost:1313` in it. I fixed three occurrences after searching within the entire directory.