### PR TITLE
Update docs for 010 overwrite behavior

### DIFF
--- a/content/influxdb/v0.10/concepts/09_vs_010.md
+++ b/content/influxdb/v0.10/concepts/09_vs_010.md
@@ -14,6 +14,7 @@ There are not many breaking changes between InfluxDB version 0.9 and InfluxDB ve
 
 * Continuous Query execution is now controlled by the `CREATE CONTINUOUS QUERY` statement.
 * `tsm` is the only storage engine available in InfluxDB 0.10, although the system can still read `b1` and `bz1` shards.
+* With `tsm` it is no longer possible to overwrite the field set for a point.
 * Clustering implementation has incompatible improvements.
 
 ## Continuous Query Execution
@@ -46,6 +47,12 @@ Starting with InfluxDB 0.9.4 we added as an available storage engine the [Time S
 
 With InfluxDB 0.10, `tsm` is the only option for new shards. While InfluxDB 0.10.0 can still read the older `b1` and `bz1` shards from InfluxDB 0.9, it will only create new `tsm` shards.
 InfluxData recommends [converting](https://github.com/influxdata/influxdb/blob/master/cmd/influx_tsm/README.md) all legacy shards to `tsm` shards as soon as feasible. `tsm` is more performant and stable, and it will result in a significant reduction in disk usage.
+
+## With `tsm` it is no longer possible to overwrite the field set for a point.
+
+In InfluxDB 0.9, the system silently overwrites the field set of an old point if you write a new point with the same measurement, tag set, and timestamp.
+In InfluxDB 0.10, the system no longer overwrites the field set; the field set becomes the union of the old field set and the new field set, where any ties go to the new field set.
+See [Frequently Encountered Issues](/influxdb/v0.10/troubleshooting/frequently_encountered_issues/#writing-duplicate-points) for an example.
 
 ## Clustering
 

--- a/content/influxdb/v0.10/concepts/09_vs_010.md
+++ b/content/influxdb/v0.10/concepts/09_vs_010.md
@@ -51,8 +51,15 @@ InfluxData recommends [converting](https://github.com/influxdata/influxdb/blob/m
 ## With `tsm` it is no longer possible to overwrite the field set for a point.
 
 In InfluxDB 0.9, the system silently overwrites the field set of an old point if you write a new point with the same measurement, tag set, and timestamp.
-In InfluxDB 0.10, the system no longer overwrites the field set; the field set becomes the union of the old field set and the new field set, where any ties go to the new field set.
+This behavior functions as a delete workaround for dropping individual points.
+
+In InfluxDB 0.10, the system no longer overwrites the entire field set; if you write a new point with the same measurement, tag set, and timestamp as an old point, the field set becomes the union of the old field set and the new field set, where any ties go to the new field set.
 See [Frequently Encountered Issues](/influxdb/v0.10/troubleshooting/frequently_encountered_issues/#writing-duplicate-points) for an example.
+
+Because of this change, overwriting an old point no longer functions as a delete workaround for dropping individual points.
+In 0.10, users will need to use `DELETE SERIES`.
+See [GitHub Issue #1647](https://github.com/influxdata/influxdb/issues/1647) for developments on `DELETE SERIES`.
+
 
 ## Clustering
 

--- a/content/influxdb/v0.10/concepts/glossary.md
+++ b/content/influxdb/v0.10/concepts/glossary.md
@@ -119,7 +119,8 @@ The part of InfluxDB's data structure that consists of a single collection of fi
 Each point is uniquely identified by its series and timestamp.
 
 You cannot store more than one point with the same timestamp in the same series.
-Instead, when you write a new point to the same series with the same timestamp as an existing point in that series, InfluxDB silently overwrites the old field set with the new field set.
+Instead, when you write a new point to the same series with the same timestamp as an existing point in that series, the field set becomes the union of the old field set and the new field set, where any ties go to the new field set.
+For an example, see [Frequently Encountered Issues](/influxdb/v0.10/troubleshooting/frequently_encountered_issues/#writing-duplicate-points).
 
 Related entries: [field set](/influxdb/v0.10/concepts/glossary/#field-set), [series](/influxdb/v0.10/concepts/glossary/#series), [timestamp](/influxdb/v0.10/concepts/glossary/#timestamp)
 

--- a/content/influxdb/v0.10/concepts/insights_tradeoffs.md
+++ b/content/influxdb/v0.10/concepts/insights_tradeoffs.md
@@ -10,8 +10,8 @@ InfluxDB is a time-series database.
 Optimizing for this use-case entails some tradeoffs, primarily to increase performance at the cost of functionality.
 Below is a list of some of those design insights that lead to tradeoffs:
 
-1. For the time series use case, we assume that if the same data point is sent multiple times, it is the exact same data that a client just sent several times.
-  * *Pro:* Simplified conflict resolution increases write performance
+1. For the time series use case, we assume that if the same data is sent multiple times, it is the exact same data that a client just sent several times.
+  * *Pro:* Simplified [conflict resolution](/influxdb/v0.10/troubleshooting/frequently_encountered_issues/#writing-duplicate-points) increases write performance
   * *Con:* May lose data in rare circumstances
 1. Deletes are a rare occurrence.
 When they do occur it is almost always against large ranges of old data that are cold for writes.

--- a/content/influxdb/v0.10/query_language/continuous_queries.md
+++ b/content/influxdb/v0.10/query_language/continuous_queries.md
@@ -90,10 +90,7 @@ Because CQs run on regularly incremented time intervals you don't need to (and s
 > CREATE CONTINUOUS QUERY minnie_maximus ON world BEGIN SELECT min(mouse),max(imus) INTO min_max_mouse FROM zoo GROUP BY time(30m) END
     ```
 
-    The CQ `minnie_maximus` automatically calculates the 30 minute minimum of the field `mouse` and the 30 minute maximum of the field `imus` (both fields are in the measurement `zoo`), and it writes the results to the measurement `min_max_mouse`.
-
-    > **Note:** If we create two CQs, one CQ to calculate the minimum and one CQ to calculate the maximum and we write the results to the same measurement, the data in the destination measurement may appear to be missing data.
-    For a complete explanation, see [Frequently Encountered Issues](/influxdb/v0.10/troubleshooting/frequently_encountered_issues/#writing-more-than-one-continuous-query-to-a-single-series).   
+    The CQ `minnie_maximus` automatically calculates the 30 minute minimum of the field `mouse` and the 30 minute maximum of the field `imus` (both fields are in the measurement `zoo`), and it writes the results to the measurement `min_max_mouse`. 
 
 * Create a CQ with two functions and personalize the [field keys](/influxdb/v0.10/concepts/glossary/#field-key) in the results:
 

--- a/content/influxdb/v0.10/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.10/troubleshooting/frequently_encountered_issues.md
@@ -320,6 +320,11 @@ To store both points:
     1970-01-15T06:56:07.890000001Z	 us_west  server02	 5.24
     ```
 
+> **Note:** In InfluxDB 0.9, the system replaced the **entire** field set of an old point if you wrote a new point with the same measurement, tag set, and timestamp.
+This functioned as a delete workaround for dropping individual points.
+Because of the new 0.10 behavior described above, overwriting a point is no longer a viable workaround for deletes.
+Users will need to use `DELETE SERIES`. See [GitHub Issue #1647](https://github.com/influxdata/influxdb/issues/1647) for developments on `DELETE SERIES`.
+
 ## Getting an unexpected error when sending data over the HTTP API
 First, double check your [line protocol](/influxdb/v0.10/write_protocols/line/) syntax.
 Second, if you continue to receive errors along the lines of `bad timestamp` or `unable to parse`, verify that your newline character is line feed (`\n`, which is ASCII `0x0A`).

--- a/content/influxdb/v0.10/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.10/troubleshooting/frequently_encountered_issues.md
@@ -274,50 +274,50 @@ This is the intended behavior.
 
 For example:
 
-Old point: `cpu_load,hostname=server02,az=us_west val=24.5,feld=7 1234567890000000`
+Old point: `cpu_load,hostname=server02,az=us_west val_1=24.5,val_2=7 1234567890000000`
 
-New point: `cpu_load,hostname=server02,az=us_west val=5.24 1234567890000000`
+New point: `cpu_load,hostname=server02,az=us_west val_1=5.24 1234567890000000`
 
-After you submit the new point, InfluxDB overwrites `val` with the new field value and leaves the field `feld` alone:
+After you submit the new point, InfluxDB overwrites `val_1` with the new field value and leaves the field `val_2` alone:
 ```
 > SELECT * FROM cpu_load WHERE time = 1234567890000000
 name: cpu_load
 --------------
-time                     az       feld  hostname  val
-1970-01-15T06:56:07.89Z  us_west  7     server02  5.24
+time			                  az	      hostname	 val_1	 val_2
+1970-01-15T06:56:07.89Z	 us_west	 server02	 5.24	  7
 ```
 
 To store both points:
 
 * Introduce an arbitrary new tag to enforce uniqueness.
 
-    Old point: `cpu_load,hostname=server02,az=us_west,uniq=1 val=24.5,feld=7 1234567890000000`
+    Old point: `cpu_load,hostname=server02,az=us_west,uniq=1 val_1=24.5,val_2=7 1234567890000000`
 
-    New point: `cpu_load,hostname=server02,az=us_west,uniq=2 val=5.24 1234567890000000`
+    New point: `cpu_load,hostname=server02,az=us_west,uniq=2 val_1=5.24 1234567890000000`
 
     After writing the new point to InfluxDB:
     ```
   > SELECT * FROM cpu_load WHERE time = 1234567890000000
   name: cpu_load
   --------------
-  time                     az       feld  hostname  uniq  val
-  1970-01-15T06:56:07.89Z  us_west  7	  server02  1     24.5
-  1970-01-15T06:56:07.89Z  us_west        server02  2     5.24
+  time			            az	     hostname	uniq	val_1	val_2
+  1970-01-15T06:56:07.89Z	us_west	 server02	1	    24.5	7
+  1970-01-15T06:56:07.89Z	us_west	 server02	2	    5.24
     ```
 * Increment the timestamp by a nanosecond.
 
-    Old point: `cpu_load,hostname=server02,az=us_west val=24.5,feld=7 1234567890000000`
+    Old point: `cpu_load,hostname=server02,az=us_west val_1=24.5,val_2=7 1234567890000000`
 
-    New point: `cpu_load,hostname=server02,az=us_west val=5.24 1234567890000001`
+    New point: `cpu_load,hostname=server02,az=us_west val_1=5.24 1234567890000001`
 
     After writing the new point to InfluxDB:
     ```
     > SELECT * FROM cpu_load WHERE time >= 1234567890000000 and time <= 1234567890000001
     name: cpu_load
     --------------
-    time                            az       feld  hostname  val
-    1970-01-15T06:56:07.89Z         us_west  7     server02  24.5
-    1970-01-15T06:56:07.890000001Z  us_west        server02  5.24
+    time				             az	      hostname	 val_1	val_2
+    1970-01-15T06:56:07.89Z		     us_west  server02	 24.5	 7
+    1970-01-15T06:56:07.890000001Z	 us_west  server02	 5.24
     ```
 
 ## Getting an unexpected error when sending data over the HTTP API

--- a/content/influxdb/v0.10/write_protocols/write_syntax.md
+++ b/content/influxdb/v0.10/write_protocols/write_syntax.md
@@ -169,7 +169,7 @@ See [issue](https://github.com/influxdb/influxdb/issues/3519) for more informati
 
 If you write points in a batch all points without explicit timestamps will receive the same timestamp when inserted.
 Since a point is defined only by its measurement, tag set, and timestamp, that can lead to duplicate points.
-When InfluxDB encounters a duplicate point it silently overwrites the previous point.
+When InfluxDB encounters a duplicate point, the [field set](/influxdb/v0.10/concepts/glossary/#field-set) becomes the union of the old field set and the new field set, where any ties go to the new field set.
 It is a best practice to provide explicit timestamps with all points.
 
 Measurements, tag keys, tag values, and field keys are never quoted.


### PR DESCRIPTION
In 0.10 it is no longer possible to overwrite the field set for a point. This updates the glossary entry for point, the FEI that discusses writing duplicate points, and adds a note to `09_vs_010.md`. It also removes the FEI that talks about writing more than one CQ to a single series. 

Issues:
* The section in `09_vs_010.md` is still rough. Should I include a note about this being a workaround for deletes in 0.9 and now, with 0.10, users must wait for `DELETE SERIES` to perform deletes?

Fixes https://github.com/influxdata/docs.influxdata.com/issues/221