### PR TITLE
Harmonisation of Kapacitor introduction with InfluxDB introduction

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1495,3 +1495,11 @@ SectionPagesMenu = "products"
   weight = 100
   url = "https://github.com/CargoSense/puppet-influxdb"
   parent = "tools"
+
+# Kapacitor v0.10 Sub-Menu - Introduction
+[[menu.kapacitor_010]]
+  name = "Download"
+  identifier = "download"
+  weight = 0
+  url = "https://influxdata.com/downloads/#kapacitor"
+  parent = "introduction"

--- a/content/kapacitor/index.md
+++ b/content/kapacitor/index.md
@@ -1,4 +1,4 @@
-+++
-title = "Kapacitor"
+---
+title: "Kapacitor"
 
-+++
+---

--- a/content/kapacitor/v0.10/index.md
+++ b/content/kapacitor/v0.10/index.md
@@ -7,3 +7,20 @@ menu:
     identifier: kapacitor_010
     weight: 0
 ---
+
+Kapacitor is a time series data processing engine and the final piece of the TICK stack.  
+Kapacitor provides a way for you to define a pipeline for processing time series data.  
+
+You can use Kapacitor to perform monitoring and alerting or to do large ETL jobs.  
+Kapacitor will query data from InfluxDB on a schedule,
+as well as receive data via the line protocol and any other method InfluxDB supports.  
+
+## Key Features
+
+Here are some of the features that Kapacitor currently supports that make it a great choice for working with time series data.
+
+* Kapacitor can process both streaming data and batch data.  
+* Make your own binary/scripts interact with Kapacitor with its User Defined Function.  
+* Kapacitor can detect silent failure with its “dead man’s switches” feature.  
+* Kapacitor can perform alerting to a number of handler such as Slack, Email, HipChat, Sensu, OpsGenie, VictorOps, PagerDuty and more.  
+* Kapacitor can mapReduce your data and send it back to InfluxDB

--- a/content/kapacitor/v0.10/introduction/getting_started.md
+++ b/content/kapacitor/v0.10/introduction/getting_started.md
@@ -3,25 +3,26 @@ title: Getting Started
 
 menu:
   kapacitor_010:
-    weight: 10
+    weight: 20
     parent: introduction
 ---
 
-Kapacitor is a data processing engine.
-It can process both stream and batch data.
+Kapacitor is a data processing engine.  
+It can process both stream and batch data.  
 This guide will walk you through both workflows and teach you the basics of using
-and running a Kapacitor daemon.
+and running a Kapacitor daemon.  
+
 
 What you will need
 ------------------
 
 Don't worry about installing anything yet, instructions are found below.
 
-* [InfluxDB](/docs/v0.9/introduction/installation.html)  - While Kapacitor does not require InfluxDB it is the easiest to setup and so we will use it in this guide.
+* [InfluxDB](/influxdb/v0.10/)  - While Kapacitor does not require InfluxDB it is the easiest to setup and so we will use it in this guide.
 You will need InfluxDB >= 0.9.5
 * [Telegraf](https://github.com/influxdb/telegraf#installation) - We will use a specific Telegraf config to send data to InfluxDB so that the examples Kapacitor tasks have context.
 You will need Telegraf >= 0.10 since the names of measurements change prior to that version.
-* [Kapacitor](https://github.com/influxdb/kapacitor) - You can get the latest Kapacitor binaries for your OS at the [downloads](https://influxdata.com/downloads/#kapacitor) page.
+* [Kapacitor](/kapacitor/v0.10/) - You can get the latest Kapacitor binaries for your OS at the [downloads](https://influxdata.com/downloads/#kapacitor) page.
 * Terminal - Kapacitor's interface is via a CLI and so you will need a basic terminal to issue commands.
 
 The Use Case
@@ -43,8 +44,8 @@ Installation
 ------------
 
 Install [Kapacitor](/kapacitor/v0.10/introduction/installation/),
-[InfluxDB](/docs/v0.9/introduction/installation.html)
-and [Telegraf](https://github.com/influxdb/telegraf#installation) on the same host.
+[InfluxDB](/influxdb/v0.10/introduction/installation/)
+and [Telegraf](/telegraf/v0.10/introduction/installation/) on the same host.
 
 All examples will assume that Kapacitor is running on `http://localhost:9092` and InfluxDB on `http://localhost:8086`.
 

--- a/content/kapacitor/v0.10/introduction/index.md
+++ b/content/kapacitor/v0.10/introduction/index.md
@@ -7,20 +7,17 @@ menu:
     identifier: introduction
     weight: 0
 ---
+The introductory documentation includes all the information needed to get up and running with Kapacitor.
 
-Kapacitor is a time series data processing engine.
-Kapacitor is the final piece of the TICK stack.
 
-Kapacitor provides a way for you to define a pipeline for processing time series data.
-You can use Kapacitor to perform monitoring and alerting or to do large ETL jobs.
-Kapacitor can process both streaming data and batch data.
-Kapacitor will query data from InfluxDB on a schedule,
-as well as receive data via the line protocol and any other method InfluxDB supports.
+## [Download](https://influxdata.com/downloads/#kapacitor)
 
-* T - Telegraf -- Data collection
-* I - InfluxDB -- Data storage
-* C - Chronograf -- Data visualization
-* K - Kapacitor -- Data processing
+Provides the location to download the latest stable and nightly builds of Kapacitor.
 
-See the [getting started guides](/kapacitor/v0.10/introduction/getting_started/) for walk through on getting up and running with Kapacitor.
+## [Installation](/kapacitor/v0.10/introduction/installation/)
 
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+
+## [Getting Started](/kapacitor/v0.10/introduction/getting_started/)
+
+A introductory guide to data processing and alerting using Kapacitor.

--- a/content/kapacitor/v0.10/introduction/installation.md
+++ b/content/kapacitor/v0.10/introduction/installation.md
@@ -1,31 +1,109 @@
 ---
-title: Installing Kapacitor
+title: Installation
 
 menu:
   kapacitor_010:
-    weight: 20
+    weight: 10
     parent: introduction
 ---
+
+This page provides directions for installing, starting, and configuring Kapacitor.
+
+## Requirements
+
+Installation of the Kapacitor package may require `root` or administrator privileges in order to complete successfully.
+
+
+### Networking
+
+By default, Kapacitor uses the following network ports:
+
+- TCP port `9292` is used for Kapacitor's HTTP API Server, it serves both as a write endpoint  and as the API endpoint for all other Kapacitor calls.
+
+Kapacitor may also used the following port, if enabled
+- TCP port `25826` is used for collectd input method
+- TCP ports `4242` is  used for opentsdb input method
+
+> Note: In addition to the ports above, 
+Kapacitor also offers multiple plugins that may require custom ports.
+All port mappings can be modified through the configuration file,
+which is located at `/etc/kapacitor/kapacitor.conf` for default installations.
+
+
+## Installation
 
 Kapacitor has two binaries:
 
 * kapacitor -- a CLI program for calling the Kapacitor API.
 * kapacitord -- the Kapacitor server daemon.
 
-You can either download the binaries directly from the [downloads](https://influxdata.com/downloads/#kapacitor) page or `go get` them:
+You can either download the package, the binaries or directly `go get` them.
+
+### Go get
+
 
 ```bash
 go get github.com/influxdb/kapacitor/cmd/kapacitor
 go get github.com/influxdb/kapacitor/cmd/kapacitord
 ```
 
-### Configuration
+### Ubuntu & Debian
+Debian and Ubuntu users can install the latest nightly version of Kapacitor by downloading the 64-bit package:
+
+```bash
+wget https://s3-us-west-1.amazonaws.com/kapacitor-nightly/kapacitor_nightly_amd64.deb
+echo "18b153c1c66185fb147517b0346eeb5f  kapacitor_nightly_amd64.deb" |md5sum -c -
+sudo dpkg -i kapacitor_nightly_amd64.deb
+```
+
+### RedHat & CentOS
+RedHat and CentOS users can install the latest stable version of Kapacitor by downloading the 64-bit package
+
+```bash
+wget https://s3-us-west-1.amazonaws.com/kapacitor-nightly/kapacitor-nightly.x86_64.rpm
+echo "4087fa7d348fd8859753e19259139f79  kapacitor-nightly.x86_64.rpm" |md5sum -c -
+sudo yum localinstall kapacitor-nightly.x86_64.rpm
+```
+
+### Standalone Binaries
+64-bit linux users  can install the latest stable version of Kapacitor by downloading the 64-bit archive
+```bash
+wget https://s3-us-west-1.amazonaws.com/kapacitor-nightly/kapacitor-nightly_linux_amd64.tar.gz
+echo "102231e3d7be9c9d13001a746effd93e  kapacitor-nightly_linux_amd64.tar.gz" |md5sum -c -
+tar xvfz kapacitor-nightly_linux_amd64.tar.gz
+```
+### Mac OS X
+
+Users of OS X 64 bits can install Kapacitor by downloading the 64-bit archive
+
+```bash
+wget https://s3-us-west-1.amazonaws.com/kapacitor-nightly/kapacitor-nightly_darwin_amd64.tar.gz
+echo "59111a345c151045a7c3fbe8b890bb75  kapacitor-nightly_darwin_amd64.tar.gz" |md5sum -c -
+tar xvf kapacitor-nightly_darwin_amd64.tar.gz
+```
+
+
+## Configuration
+### Generating a Configuration File
+For non-packaged installations, it is a best practice to generate a new configuration
+for each upgrade to ensure you have the latest features and settings.
+Any changes made in the old file will need to be manually ported to the newly generated file.
+Packaged installations will come with a configuration pre-installed,
+so this step may not be needed if you installed kapacitor using a
+package manager (though it is handy to know either way).
+
+> Note: Newly generated configuration files have no knowledge of any local customizations or settings.
+Please make sure to double-check any configuration changes prior to deploying them.
+
+To generate a new configuration file, run:
+
+```bash
+kapacitor config > kapacitor.generated.conf
+```
+
+### Example
 
 An example configuration file can be found [here](https://github.com/influxdb/kapacitor/blob/master/etc/kapacitor/kapacitor.conf)
 
-Kapacitor can also provide an example config for you using this command:
-
-```bash
-kapacitord config
-```
-
+If no `-config` option is supplied, Kapacitor will use an internal default
+configuration (equivalent to the output of `kapacitor config`).


### PR DESCRIPTION
This change include:

- Adding content to the "Introduction" page (when one click the left panel menu "Introduction").
- Adding a link to the Download page on the left panel under "Introduction" sub menu
- Swapping the getting started and installation order, so you install Kapacitor before using it
- Adding a more comprehensive download procedure by adding md5sum check before installation step
- Making the top index under Kapacitor the same format as the other

