### PR TITLE
Remove erroneous spaces in bash command

### DIFF
--- a/content/influxdb/v0.10/introduction/installation.md
+++ b/content/influxdb/v0.10/introduction/installation.md
@@ -42,8 +42,8 @@ For Debian users, you can add the InfluxData repository by using the following c
 ```bash
 curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
-test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
-test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+test $VERSION_ID="7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+test $VERSION_ID="8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
 
 And then to install and start the InfluxDB service:


### PR DESCRIPTION
The spaces in the environment variable assignments ($VERSION_ID = "8" and $VERSION_ID = "7") break the commands to add the InfluxData repositories in Debian systems. Removing the spaces yields correct commands.