### PR TITLE
SEO improvements for correct version discovery

### DIFF
--- a/layouts/chronograf/single.html
+++ b/layouts/chronograf/single.html
@@ -1,9 +1,12 @@
 {{ partial "header.html" . }}
 <div class="page" id="page-content">
+    {{ if .Title }}
     <div class="page--title" id="page-title">
 	    <div class="page--body"><h1>{{ .Title }}</h1></div>
 	</div>
+    {{ end }}
 	<div class="page--body">
+        {{ partial "chronograf/version.html" . }}
         {{ .Content }}
     </div>
     {{ partial "chronograf/contribute.html" . }}

--- a/layouts/kapacitor/single.html
+++ b/layouts/kapacitor/single.html
@@ -6,6 +6,7 @@
 	</div>
 	{{ end }}
 	<div class="page--body">
+        {{ partial "kapacitor/version.html" . }}
         {{ .Content }}
     </div>
     {{ partial "kapacitor/contribute.html" . }}

--- a/layouts/partials/chronograf/version.html
+++ b/layouts/partials/chronograf/version.html
@@ -1,0 +1,6 @@
+{{ if not (or (in .RelPermalink .Site.Data.default_versions.chronograf_semver) (eq .RelPermalink "/chronograf/")) }}
+<div class="flash">
+    <p><b>Warning! This page documents an old version of Chronograf, which is no longer actively developed. <a href="/chronograf/{{ .Site.Data.default_versions.chronograf_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">Chronograf {{ .Site.Data.default_versions.chronograf_semver }}</a> is the most recent version of Chronograf.</b></p>
+</div>
+<br />
+{{ end }}

--- a/layouts/partials/influxdb/version.html
+++ b/layouts/partials/influxdb/version.html
@@ -1,7 +1,7 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.influxdb_semver) (eq .RelPermalink "/influxdb/")) }}
 <div class="flash">
 {{ if in .RelPermalink "v0.9"}}
-    <p><b>0.9 Warning! This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent version of InfluxDB.</b></p>
+    <p><b>Warning! This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent version of InfluxDB.</b></p>
 {{ else }}
     <p><b>Warning! This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent version of InfluxDB.</b></p>
 {{ end }}

--- a/layouts/partials/kapacitor/version.html
+++ b/layouts/partials/kapacitor/version.html
@@ -1,0 +1,6 @@
+{{ if not (or (in .RelPermalink .Site.Data.default_versions.kapacitor_semver) (eq .RelPermalink "/kapacitor/")) }}
+<div class="flash">
+    <p><b>Warning! This page documents an old version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent version of Kapacitor.</b></p>
+</div>
+<br />
+{{ end }}

--- a/layouts/partials/telegraf/version.html
+++ b/layouts/partials/telegraf/version.html
@@ -1,6 +1,6 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.telegraf_semver) (eq .RelPermalink "/telegraf/")) }}
 <div class="flash">
-    <p><b>Warning! This page documents an old version of Telegraf, which is no longer actively developed. <a href="/telegraf/{{ .Site.Data.default_versions.telegraf_semver }}/">Telegraf {{ .Site.Data.default_versions.telegraf_semver }}</a> is the most recent version of Telegraf.</b></p>
+    <p><b>Warning! This page documents an old version of Telegraf, which is no longer actively developed. <a href="/telegraf/{{ .Site.Data.default_versions.telegraf_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">Telegraf {{ .Site.Data.default_versions.telegraf_semver }}</a> is the most recent version of Telegraf.</b></p>
 </div>
 <br />
 {{ end }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,10 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {{ range $page := .Data.Pages }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if (or (eq .Section "") (eq .RelPermalink "/influxdb/") (eq .RelPermalink "/telegraf/") (eq .RelPermalink "/kapacitor/") (eq .RelPermalink "/chronograf/")) }}
+    <priority>1.0</priority>{{ else if (in .RelPermalink (index .Site.Data.default_versions (print .Section "_semver"))) }}
+    <priority>1.0</priority>{{else}}
+    <priority>0.1</priority>{{ end }}
+  </url>
+  {{ end }}
+</urlset>

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,7 +1,1 @@
-User-agent: *
-Disallow: /telegraf/v0.2/
-Disallow: /influxdb/v0.6/
-Disallow: /influxdb/v0.7/
-Disallow: /influxdb/v0.9/
-Disallow: /chronograf/v0.4/
-Disallow: /kapacitor/v0.2/
+Sitemap: https://docs.influxdata.com/sitemap.xml


### PR DESCRIPTION
Adds a sitemap that de-prioritizes non-current versions. The use of templates is a bit hacky.

Also adds old version warnings for Kapacitor and Chronograf.