### PR TITLE
Fix broken header linking

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <script>window.jQuery || document.write('<script src="/js/vendor/jquery-2.1.4.min.js"><\/script>')</script>
 <script src="/js/docs-interactions.js" type="text/javascript"></script>
 <script src="/js/vendor/prism.js" type="text/javascript"></script>
-<script>[].slice.call(document.querySelectorAll(".page-content--container h2")).forEach(function(el,i){var id,text;id=el.id;text=el.innerText?el.innerText:el.textContent;if(el.firstChild.tagName!='A'){el.innerHTML='<a href="#'+id+'">'+text+'</a>';}});</script>
+<script>[].slice.call(document.querySelectorAll(".page--body h2, .page--body h3")).forEach(function(el,i){var id,text;id=el.id;text=el.innerText?el.innerText:el.textContent;if(el.firstChild.tagName!='A'){el.innerHTML='<a href="#'+id+'">'+text+'</a>';}});</script>
 <script>/*<![CDATA[*/(function(w,a,b,d,s){w[a]=w[a]||{};w[a][b]=w[a][b]||{q:[],track:function(r,e,t){this.q.push({r:r,e:e,t:t||+new Date});}};var e=d.createElement(s);var f=d.getElementsByTagName(s)[0];e.async=1;e.src='//marketing.influxdb.com/cdnr/93/acton/bn/tracker/16929';f.parentNode.insertBefore(e,f);})(window,'ActOn','Beacon',document,'script');ActOn.Beacon.track();/*]]>*/</script>
 <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create', 'UA-45024174-5', 'auto');ga('send', 'pageview');</script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>

--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -120,6 +120,17 @@ a:hover {
 	font-size: 1.3em;
 	font-weight: 300;
 }
+/* Making sure anchors inside headings maintain correct font weights */
+.page--body h1 a {
+	font-weight: 200;
+}
+.page--body h2 a {
+	font-weight: 600;
+}
+.page--body h3 a,
+.page--body h4 a {
+	font-weight: 300;
+}
 .page--body h1:first-child,
 .page--body h2:first-child,
 .page--body h3:first-child,


### PR DESCRIPTION
cc @rossmcdonald @nathanielc 

This change fixes the broken header links. The CSS classes changed during the last redesign when search was added. This makes sure the javascript snippet that adds the header links refers to the correct classes.

@alexpaxton this change breaks the styling of h3 elements.