### PR TITLE
Telegraf 0.11 docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -433,85 +433,85 @@ SectionPagesMenu = "products"
         parent = "services"
 
 # Telegraf v0.10 Sub-Menu - Output Plugins
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "InfluxDB"
   identifier = "influxdb_output"
   weight = 0
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "amon"
   identifier = "amon_output"
   weight = 10
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amon"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "AMQP"
   identifier = "amqp_output"
   weight = 20
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amqp"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "Amazon CloudWatch"
   identifier = "cloudwatch_output"
   weight = 30
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/cloudwatch"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "Datadog"
   identifier = "datadog_output"
   weight = 40
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/datadog"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "Graphite"
   identifier = "graphite_output"
   weight = 50
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/graphite"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "Kafka"
   identifier = "kafka_output"
   weight = 60
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kafka"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "Amazon Kinesis"
   identifier = "kinesis_output"
   weight = 70
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kinesis"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "Librato"
   identifier = "librato_output"
   weight = 80
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/librato"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "MQTT"
   identifier = "mqtt_output"
   weight = 90
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/mqtt"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "NSQ"
   identifier = "nsq_output"
   weight = 100
   url = "ghttps://ithub.com/influxdata/telegraf/tree/master/plugins/outputs/nsq"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "OpenTSDB"
   identifier = "opentsdb_output"
   weight = 110
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/opentsdb"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "Prometheus"
   identifier = "prometheus_client_output"
   weight = 120
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client"
   parent = "outputs"
-[[menu.telegraf_011]]
+[[menu.telegraf_010]]
   name = "Riemann"
   identifier = "riemann_output"
   weight = 130

--- a/config.toml
+++ b/config.toml
@@ -29,86 +29,489 @@ SectionPagesMenu = "products"
   weight = 30
   url = "/kapacitor/"
 
+  # Telegraf v0.11 Sub-Menu - Output Plugins
+  [[menu.telegraf_011]]
+    name = "InfluxDB"
+    identifier = "influxdb_output"
+    weight = 0
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "amon"
+    identifier = "amon_output"
+    weight = 10
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amon"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "AMQP"
+    identifier = "amqp_output"
+    weight = 20
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amqp"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "Amazon CloudWatch"
+    identifier = "cloudwatch_output"
+    weight = 30
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/cloudwatch"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "Datadog"
+    identifier = "datadog_output"
+    weight = 40
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/datadog"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "Graphite"
+    identifier = "graphite_output"
+    weight = 50
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/graphite"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "Kafka"
+    identifier = "kafka_output"
+    weight = 60
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kafka"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "Amazon Kinesis"
+    identifier = "kinesis_output"
+    weight = 70
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kinesis"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "Librato"
+    identifier = "librato_output"
+    weight = 80
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/librato"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "MQTT"
+    identifier = "mqtt_output"
+    weight = 90
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/mqtt"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "NSQ"
+    identifier = "nsq_output"
+    weight = 100
+    url = "ghttps://ithub.com/influxdata/telegraf/tree/master/plugins/outputs/nsq"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "OpenTSDB"
+    identifier = "opentsdb_output"
+    weight = 110
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/opentsdb"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "Prometheus"
+    identifier = "prometheus_client_output"
+    weight = 120
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client"
+    parent = "outputs"
+  [[menu.telegraf_011]]
+    name = "Riemann"
+    identifier = "riemann_output"
+    weight = 130
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/riemann"
+    parent = "outputs"
+
+
+  # Telegraf v0.11 Sub-Menu - Input plugins
+  [[menu.telegraf_011]]
+    name = "Aerospike"
+    identifier = "aerospike_input"
+    weight = 0
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/aerospike"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Apache"
+    identifier = "apache_input"
+    weight = 10
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/apache"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "bcache"
+    identifier = "bcache_input"
+    weight = 20
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/bcache"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "CouchDB"
+    identifier = "couchdb_input"
+    weight = 30
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/couchdb"
+    parent = "inputs"
+    [[menu.telegraf_011]]
+        name = "DNS Query Time"
+        identifier = "dns_query"
+        weight = 40
+        url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/dns_query"
+        parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Disque"
+    identifier = "disque_input"
+    weight = 50
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/disque"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Docker"
+    identifier = "docker_input"
+    weight = 60
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/docker"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Dovecot"
+    identifier = "dovecot_input"
+    weight = 70
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/dovecot"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Elasticsearch"
+    identifier = "elasticsearch_input"
+    weight = 80
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/elasticsearch"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "exec"
+    identifier = "exec_input"
+    weight = 90
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/exec"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "HAProxy"
+    identifier = "haproxy_input"
+    weight = 100
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/haproxy"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "HTTPJSON"
+    identifier = "httpjson_input"
+    weight = 110
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/httpjson"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "InfluxDB"
+    identifier = "influxdb_input"
+    weight = 120
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Jolokia"
+    identifier = "jolokia_input"
+    weight = 130
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/jolokia"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "LeoFS"
+    identifier = "leofs_input"
+    weight = 140
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/leofs"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Lustre2"
+    identifier = "lustre2_input"
+    weight = 150
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/lustre2"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Mailchimp"
+    identifier = "mailchimp_input"
+    weight = 160
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mailchimp"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Memcached"
+    identifier = "memcached_input"
+    weight = 170
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/memcached"
+    parent = "inputs"
+    [[menu.telegraf_011]]
+      name = "Mesos"
+      identifier = "mesos"
+      weight = 180
+      url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mesos"
+      parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "MongoDB"
+    identifier = "mongodb_input"
+    weight = 190
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mongodb"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "MySQL"
+    identifier = "mysql_input"
+    weight = 200
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mysql"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "NGINX"
+    identifier = "nginx_input"
+    weight = 210
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nginx"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "NSQ"
+    identifier = "nsq_input"
+    weight = 220
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nsq"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "PHP-FPM"
+    identifier = "phpfpm_input"
+    weight = 230
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/phpfpm"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Phusion Passenger"
+    identifier = "passenger_input"
+    weight = 240
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/passenger"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "ping"
+    identifier = "ping_input"
+    weight = 250
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ping"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "PostgreSQL"
+    identifier = "postgresql_input"
+    weight = 260
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/postgresql"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "PowerDNS"
+    identifier = "powerdns_input"
+    weight = 270
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/powerdns"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "procstat"
+    identifier = "procstat_input"
+    weight = 280
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/procstat"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Prometheus"
+    identifier = "prometheus_input"
+    weight = 290
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/prometheus"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Puppet Agent"
+    identifier = "puppetagent_input"
+    weight = 300
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/puppetagent"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "RabbitMQ"
+    identifier = "rabbitmq_input"
+    weight = 310
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rabbitmq"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "raindrops"
+    identifier = "raindrops_input"
+    weight = 320
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/raindrops"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Redis"
+    identifier = "redis_input"
+    weight = 330
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/redis"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "RethinkDB"
+    identifier = "rethinkdb_input"
+    weight = 340
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rethinkdb"
+    parent = "inputs"
+    [[menu.telegraf_011]]
+      name = "Riak"
+      identifier = "riak"
+      weight = 350
+      url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/riak"
+      parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "sensors"
+    identifier = "sensors_input"
+    weight = 360
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/sensors"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "snmp"
+    identifier = "snmp_input"
+    weight = 370
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/snmp"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "SQL server (Microsoft)"
+    identifier = "sqlservermicrosoft_input"
+    weight = 380
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/sqlserver"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "system"
+    identifier = "system_input"
+    weight = 390
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/system"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "trig"
+    identifier = "trig_input"
+    weight = 400
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/trig"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "twemproxy (nutcracker)"
+    identifier = "twemproxy_input"
+    weight = 410
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/twemproxy"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Windows performance counters"
+    identifier = "winperfcounters_input"
+    weight = 420
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/win_perf_counters"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "ZFS"
+    identifier = "zfs_input"
+    weight = 430
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/zfs"
+    parent = "inputs"
+  [[menu.telegraf_011]]
+    name = "Zookeeper"
+    identifier = "zookeeper_input"
+    weight = 440
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/zookeeper"
+    parent = "inputs"
+
+  # Telegraf v0.11 Sub-Menu - Service Plugins
+  [[menu.telegraf_011]]
+    name = "Kafka Consumer"
+    identifier = "kafka_consumer_input"
+    weight = 0
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kafka_consumer"
+    parent = "services"
+  [[menu.telegraf_011]]
+    name = "GitHub Webhooks"
+    identifier = "github_webhooks_input"
+    weight = 10
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/github_webhooks"
+    parent = "services"
+  [[menu.telegraf_011]]
+    name = "MQTT Consumer"
+    identifier = "mqtt_consumer_input"
+    weight = 20
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mqtt_consumer"
+    parent = "services"
+  [[menu.telegraf_011]]
+    name = "NATS Consumer"
+    identifier = "nats_consumer_input"
+    weight = 30
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nats_consumer"
+    parent = "services"
+  [[menu.telegraf_011]]
+    name = "StatsD"
+    identifier = "statsd_input"
+    weight = 40
+    url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd"
+    parent = "services"
+    [[menu.telegraf_011]]
+      name = "TCP Listener"
+      identifier = "tcp_listener"
+      weight = 50
+      url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/tcp_listener"
+      parent = "services"
+      [[menu.telegraf_011]]
+        name = "UDP Listener"
+        identifier = "udp_listener"
+        weight = 60
+        url = "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/udp_listener"
+        parent = "services"
+
 # Telegraf v0.10 Sub-Menu - Output Plugins
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "InfluxDB"
   identifier = "influxdb_output"
   weight = 0
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "amon"
   identifier = "amon_output"
   weight = 10
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amon"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "AMQP"
   identifier = "amqp_output"
   weight = 20
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amqp"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "Amazon CloudWatch"
   identifier = "cloudwatch_output"
   weight = 30
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/cloudwatch"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "Datadog"
   identifier = "datadog_output"
   weight = 40
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/datadog"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "Graphite"
   identifier = "graphite_output"
   weight = 50
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/graphite"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "Kafka"
   identifier = "kafka_output"
   weight = 60
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kafka"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "Amazon Kinesis"
   identifier = "kinesis_output"
   weight = 70
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kinesis"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "Librato"
   identifier = "librato_output"
   weight = 80
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/librato"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "MQTT"
   identifier = "mqtt_output"
   weight = 90
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/mqtt"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "NSQ"
   identifier = "nsq_output"
   weight = 100
   url = "ghttps://ithub.com/influxdata/telegraf/tree/master/plugins/outputs/nsq"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "OpenTSDB"
   identifier = "opentsdb_output"
   weight = 110
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/opentsdb"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "Prometheus"
   identifier = "prometheus_client_output"
   weight = 120
   url = "https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client"
   parent = "outputs"
-[[menu.telegraf_010]]
+[[menu.telegraf_011]]
   name = "Riemann"
   identifier = "riemann_output"
   weight = 130

--- a/content/telegraf/v0.10/index.md
+++ b/content/telegraf/v0.10/index.md
@@ -5,7 +5,7 @@ menu:
   telegraf:
     name: v0.10
     identifier: telegraf_010
-    weight: 0
+    weight: 10
 ---
 
 Telegraf is a plugin-driven server agent for collecting & reporting metrics. Telegraf has plugins to source a variety of metrics directly from the system it's running on, pull metrics from third party APIs, or even listen for metrics via a statsd and Kafka consumer services. It also has output plugins to send metrics to a variety of other datastores, services, and message queues, including InfluxDB, Graphite, OpenTSDB, Datadog, Librato, Kafka, MQTT, NSQ, and many others.

--- a/content/telegraf/v0.11/index.md
+++ b/content/telegraf/v0.11/index.md
@@ -1,0 +1,21 @@
+---
+title: Telegraf Version 0.11 Documentation
+
+menu:
+  telegraf:
+    name: v0.11
+    identifier: telegraf_011
+    weight: 0
+---
+
+Telegraf is a plugin-driven server agent for collecting & reporting metrics. Telegraf has plugins to source a variety of metrics directly from the system it's running on, pull metrics from third party APIs, or even listen for metrics via a statsd and Kafka consumer services. It also has output plugins to send metrics to a variety of other datastores, services, and message queues, including InfluxDB, Graphite, OpenTSDB, Datadog, Librato, Kafka, MQTT, NSQ, and many others.
+
+## Key Features
+
+Here are some of the features that Telegraf currently supports and make it a great choice for metrics collection.
+
+* Written entirely in Go.
+It compiles into a single binary with no external dependencies.
+* Minimal memory footprint.
+* Plugin system allows new inputs and outputs to be easily added.
+* A wide number of plugins for many popular services already exist for well known services and APIs.

--- a/content/telegraf/v0.11/inputs/index.md
+++ b/content/telegraf/v0.11/inputs/index.md
@@ -1,0 +1,64 @@
+---
+title: Supported Input Plugins
+
+menu:
+  telegraf_011:
+    name: Input Plugins
+    identifier: inputs
+    weight: 20
+---
+
+Telegraf is entirely input driven. It gathers all metrics from the inputs specified in the configuration file.
+
+## Usage Instructions
+
+View usage instructions for each input by running `telegraf -usage <input-name>`.
+
+## Supported Input Plugins
+
+* [Aerospike](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/aerospike)
+* [Apache](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/apache)
+* [bcache](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/bcache)
+* [CouchDB](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/couchdb)
+* [Disque](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/disque)
+* [DNS Query Time](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/dns_query)
+* [Docker](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/docker)
+* [Dovecot](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/dovecot)
+* [Elasticsearch](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/elasticsearch)
+* [exec](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/exec) (generic JSON-emitting executable plugin)
+* [HAProxy](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/haproxy)
+* [HTTPJSON](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/httpjson) (generic JSON-emitting http service plugin)
+* [InfluxDB](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb)
+* [Jolokia](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/jolokia) (remote JMX with JSON over HTTP)
+* [LeoFS](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/leofs)
+* [Lustre2](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/lustre2)
+* [Mailchimp](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mailchimp)
+* [Memcached](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/memcached)
+* [Mesos](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mesos)
+* [MongoDB](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mongodb)
+* [MySQL](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mysql)
+* [NGINX](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nginx)
+* [NSQ](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nsq)
+* [NTPQ](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ntpq)
+* [PHP-FPM](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/phpfpm)
+* [Phusion Passenger](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/passenger)
+* [ping](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ping)
+* [PostgreSQL](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/postgresql)
+* [PowerDNS](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/powerdns)
+* [procstat](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/procstat)
+* [Prometheus](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/prometheus)
+* [Puppet Agent](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/puppetagent)
+* [RabbitMQ](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rabbitmq)
+* [raindrops](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/raindrops)
+* [Redis](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/redis)
+* [RethinkDB](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rethinkdb)
+* [Riak](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/riak)
+* [sensors](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/sensors)
+* [snmp](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/snmp)
+* [SQL server (Microsoft)](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/sqlserver)
+* [system](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/system) (cpu, mem, net, netstat, disk, diskio, swap)
+* [trig](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/trig)
+* [twemproxy (nutcracker)](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/twemproxy)
+* [Windows performance counters](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/win_perf_counters)
+* [ZFS](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/zfs)
+* [Zookeeper](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/zookeeper)

--- a/content/telegraf/v0.11/introduction/configuration.md
+++ b/content/telegraf/v0.11/introduction/configuration.md
@@ -1,0 +1,23 @@
+---
+title: Configuring Telegraf
+
+menu:
+  telegraf_011:
+    name: Configuring Telegraf
+    weight: 10
+    parent: introduction
+---
+
+## Configuring Telegraf
+
+### Create a configuration file with every input and output
+```
+telegraf -sample-config > telegraf.conf
+```
+
+### Create a configuration file with specific inputs and outputs
+```
+telegraf -sample-config -input-filter <pluginname>[:<pluginname>] -output-filter <outputname>[:<outputname>] > telegraf.conf
+```
+
+> **Note:** In most cases, you will need to edit the configuration file to match your needs.

--- a/content/telegraf/v0.11/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.11/introduction/getting-started-telegraf.md
@@ -1,0 +1,120 @@
+---
+title: Getting Started with Telegraf
+
+menu:
+  telegraf_011:
+    name: Getting Started
+    weight: 0
+    parent: introduction
+---
+
+## Getting Started with Telegraf
+Telegraf is an agent written in Go for collecting metrics and writing them into InfluxDB or other possible outputs.
+This guide will get you up and running with Telegraf.
+It walks you through the download, installation, and configuration processes, and it shows how to use Telegraf to get data into InfluxDB.
+
+## Download and Install Telegraf
+Follow the instructions in the Telegraf section on the [Downloads page](https://influxdata.com/downloads/).
+
+## Configuration
+### Configuration file location by installation type
+
+* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
+* Standalone Binary: see the next section for how to create a configuration file
+
+### Creating and Editing the Configuration File
+Before starting the Telegraf server you need to edit and/or create an initial configuration that specifies your desired [inputs](/telegraf/v0.11/inputs/) (where the metrics come from) and [outputs](/telegraf/v0.11/outputs/) (where the metrics go). There are [several ways](/telegraf/v0.11/introduction/configuration/) to create and edit the configuration file.
+Here, we'll generate a configuration file and simultaneously specify the desired inputs with the `-input-filter` flag and the desired output with the `-output-filter` flag.
+
+In the example below, we create a configuration file called `telegraf.conf` with two inputs:
+one that reads metrics about the system's cpu usage (`cpu`) and one that reads metrics about the system's memory usage (`mem`). `telegraf.conf` specifies InfluxDB as the desired output.
+
+```bash
+telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf.conf
+```
+
+## Start the Telegraf Server
+Start the Telegraf server and direct it to the relevant configuration file:
+### OS X [Homebrew](http://brew.sh/)
+```bash
+telegraf -config telegraf.conf
+```
+
+### Linux debian and RPM packages
+```bash
+sudo service telegraf start
+```
+
+### Ubuntu 15+
+```bash
+systemctl start telegraf
+```
+
+## Results
+Once Telegraf is up and running it'll start collecting data and writing them to the desired output.
+
+Returning to our sample configuration, we show what the `cpu` and `mem` data look like in InfluxDB below.
+Note that we used the default input and output configuration settings to get these data.
+
+* List all [measurements](https://docs.influxdata.com/influxdb/v0.10/concepts/glossary/#measurement) in the `telegraf` [database](https://docs.influxdata.com/influxdb/v0.10/concepts/glossary/#database):
+
+```bash
+> SHOW MEASUREMENTS
+name: measurements
+------------------
+name
+cpu
+mem
+```
+
+* List all [field keys](https://docs.influxdata.com/influxdb/v0.10/concepts/glossary/#field-key) by measurement:
+
+```bash
+> SHOW FIELD KEYS
+name: cpu
+---------
+fieldKey
+usage_guest
+usage_guest_nice
+usage_idle
+usage_iowait
+usage_irq
+usage_nice
+usage_softirq
+usage_steal
+usage_system
+usage_user
+
+name: mem
+---------
+fieldKey
+available
+available_percent
+buffered
+cached
+free
+total
+used
+used_percent
+```
+
+* Select a sample of the data in the [field](https://docs.influxdata.com/influxdb/v0.10/concepts/glossary/#field) `usage_idle` in the measurement `cpu_usage_idle`:
+
+```bash
+> SELECT usage_idle FROM cpu WHERE cpu = 'cpu-total' LIMIT 5
+name: cpu
+---------
+time			               usage_idle
+2016-01-16T00:03:00Z	 97.56189047261816
+2016-01-16T00:03:10Z	 97.76305923519121
+2016-01-16T00:03:20Z	 97.32533433320835
+2016-01-16T00:03:30Z	 95.68857785553611
+2016-01-16T00:03:40Z	 98.63715928982245
+```
+
+
+Notice that the timestamps occur at rounded ten second intervals (that is, `:00`, `:10`, `:20`, and so on) - this is a configurable setting.
+
+
+That's it! You now have the foundation for using Telegraf to collect metrics and write them to your output of choice.  

--- a/content/telegraf/v0.11/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.11/introduction/getting-started-telegraf.md
@@ -16,6 +16,8 @@ It walks you through the download, installation, and configuration processes, an
 ## Download and Install Telegraf
 Follow the instructions in the Telegraf section on the [Downloads page](https://influxdata.com/downloads/).
 
+> **Note:** Telegraf will start automatically using the default configuration when installed from a deb package.
+
 ## Configuration
 ### Configuration file location by installation type
 

--- a/content/telegraf/v0.11/introduction/index.md
+++ b/content/telegraf/v0.11/introduction/index.md
@@ -1,0 +1,9 @@
+---
+title: Introduction
+
+menu:
+  telegraf_011:
+    name: Introduction
+    identifier: introduction
+    weight: 0
+---

--- a/content/telegraf/v0.11/outputs/index.md
+++ b/content/telegraf/v0.11/outputs/index.md
@@ -1,0 +1,28 @@
+---
+title: Supported Outputs
+
+menu:
+  telegraf_011:
+    name: Output Plugins
+    identifier: outputs
+    weight: 10
+---
+
+Telegraf allows users to specify multiple output sinks in the configuration file.
+
+## Supported Output Plugins List
+
+* [InfluxDB](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb)
+* [amon](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amon)
+* [AMQP](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/amqp)
+* [Amazon CloudWatch](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/cloudwatch)
+* [Datadog](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/datadog)
+* [Graphite](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/graphite)
+* [Kafka](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kafka)
+* [Amazon Kinesis](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/kinesis)
+* [Librato](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/librato)
+* [MQTT](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/mqtt)
+* [NSQ](ghttps://ithub.com/influxdata/telegraf/tree/master/plugins/outputs/nsq)
+* [OpenTSDB](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/opentsdb)
+* [Prometheus](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client)
+* [Riemann](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/riemann)

--- a/content/telegraf/v0.11/services/index.md
+++ b/content/telegraf/v0.11/services/index.md
@@ -1,0 +1,25 @@
+---
+title: Supported Service Inputs
+
+menu:
+  telegraf_011:
+    name: Service Inputs
+    identifier: services
+    weight: 30
+---
+
+Telegraf is entirely input driven. It gathers all metrics from the inputs specified in the configuration file.
+
+## Usage Instructions
+
+View usage instructions for each service input by running `telegraf -usage <service-input-name>`.
+
+## Supported Service Plugin List
+
+* [Kafka Consumer](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kafka_consumer)
+* [GitHub Webhooks](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/github_webhooks)
+* [MQTT Consumer](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mqtt_consumer)
+* [NATS Consumer](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nats_consumer)
+* [StatsD](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd)
+* [TCP Listener](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/tcp_listener)
+* [UDP Listener](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/udp_listener)

--- a/content/telegraf/v0.2/index.md
+++ b/content/telegraf/v0.2/index.md
@@ -5,7 +5,7 @@ menu:
   telegraf:
     name: v0.2
     identifier: telegraf_02
-    weight: 0
+    weight: 20
 ---
 
 The Telegraf documentation is currently under construction.

--- a/data/default_versions.toml
+++ b/data/default_versions.toml
@@ -1,5 +1,5 @@
-telegraf = "telegraf_010"
-telegraf_semver = "v0.10"
+telegraf = "telegraf_011"
+telegraf_semver = "v0.11"
 influxdb = "influxdb_010"
 influxdb_semver = "v0.10"
 chronograf = "chronograf_010"


### PR DESCRIPTION
* Adds 0.11 docs for Telegraf
* Removes 0.10-specific references
* Updates the list of available plugins
* Makes 0.11 the default doc version for Telegraf

Fixes: https://github.com/influxdata/docs.influxdata.com/issues/315