### PR TITLE
Fix warning links from older to latest version for all products

### DIFF
--- a/layouts/partials/chronograf/version.html
+++ b/layouts/partials/chronograf/version.html
@@ -1,6 +1,10 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.chronograf_semver) (eq .RelPermalink "/chronograf/")) }}
 <div class="flash">
-    <p><b>Warning! This page documents an old version of Chronograf, which is no longer actively developed. <a href="/chronograf/{{ .Site.Data.default_versions.chronograf_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">Chronograf {{ .Site.Data.default_versions.chronograf_semver }}</a> is the most recent version of Chronograf.</b></p>
+{{ if in .RelPermalink "v0.10" }}
+    <p><b>Warning! This page documents an old version of Chronograf, which is no longer actively developed. <a href="/chronograf/{{ .Site.Data.default_versions.chronograf_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ replace .RelPermalink "/chronograf/v0.10/" "" }}{{end}}">Chronograf {{ .Site.Data.default_versions.chronograf_semver }}</a> is the most recent version of Chronograf.</b></p>
+{{ else }}
+    <p><b>Warning! This page documents an old version of Chronograf, which is no longer actively developed. <a href="/chronograf/{{ .Site.Data.default_versions.chronograf_semver }}/">Chronograf {{ .Site.Data.default_versions.chronograf_semver }}</a> is the most recent version of Chronograf.</b></p>
+{{ end }}
 </div>
 <br />
 {{ end }}

--- a/layouts/partials/influxdb/version.html
+++ b/layouts/partials/influxdb/version.html
@@ -1,7 +1,7 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.influxdb_semver) (eq .RelPermalink "/influxdb/")) }}
 <div class="flash">
 {{ if in .RelPermalink "v0.10"}}
-    <p><b>Warning! This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent version of InfluxDB.</b></p>
+    <p><b>Warning! This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 16 }}{{end}}">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent version of InfluxDB.</b></p>
 {{ else }}
     <p><b>Warning! This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent version of InfluxDB.</b></p>
 {{ end }}

--- a/layouts/partials/kapacitor/version.html
+++ b/layouts/partials/kapacitor/version.html
@@ -1,6 +1,12 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.kapacitor_semver) (eq .RelPermalink "/kapacitor/")) }}
 <div class="flash">
-    <p><b>Warning! This page documents an old version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent version of Kapacitor.</b></p>
+{{ if in .RelPermalink "v0.10" }}
+    <p><b>Warning! This page documents an old version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ replace .RelPermalink "/kapacitor/v0.10/" "" }}{{end}}">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent version of Kapacitor.</b></p>
+{{ else if in .RelPermalink "v0.2"}}
+    <p><b>Warning! This page documents an old version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ replace .RelPermalink "/kapacitor/v0.2/" "" }}{{end}}">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent version of Kapacitor.</b></p>
+{{ else }}
+    <p><b>Warning! This page documents an old version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent version of Kapacitor.</b></p>
+{{ end }}
 </div>
 <br />
 {{ end }}

--- a/layouts/partials/telegraf/version.html
+++ b/layouts/partials/telegraf/version.html
@@ -1,6 +1,10 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.telegraf_semver) (eq .RelPermalink "/telegraf/")) }}
 <div class="flash">
-    <p><b>Warning! This page documents an old version of Telegraf, which is no longer actively developed. <a href="/telegraf/{{ .Site.Data.default_versions.telegraf_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">Telegraf {{ .Site.Data.default_versions.telegraf_semver }}</a> is the most recent version of Telegraf.</b></p>
+{{ if in .RelPermalink "v0.10" }}
+    <p><b>Warning! This page documents an old version of Telegraf, which is no longer actively developed. <a href="/telegraf/{{ .Site.Data.default_versions.telegraf_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ replace .RelPermalink "/telegraf/v0.10/" "" }}{{end}}">Telegraf {{ .Site.Data.default_versions.telegraf_semver }}</a> is the most recent version of Telegraf.</b></p>
+{{ else }}
+    <p><b>Warning! This page documents an old version of Telegraf, which is no longer actively developed. <a href="/telegraf/{{ .Site.Data.default_versions.telegraf_semver }}/">Telegraf {{ .Site.Data.default_versions.telegraf_semver }}</a> is the most recent version of Telegraf.</b></p>
+{{ end }}
 </div>
 <br />
 {{ end }}


### PR DESCRIPTION
Warning links for old versions are currently broken for all products.
This branch redirects the warning link for all v0.10 products to the same url path for latest / v0.11.
For versions older than 0.10 it just redirects to the root path of latest / v0.11 - with the exception of Kapacitor's webpage for 0.2 which also redirects to the full paths of latest / v0.11.

@rkuchan @gunnaraasen  staging for this branch:
http://docs.staging.influxdata.com:31006/