### PR TITLE
List 'ms' as valid unit for time()

### DIFF
--- a/content/influxdb/v0.12/query_language/data_exploration.md
+++ b/content/influxdb/v0.12/query_language/data_exploration.md
@@ -358,6 +358,7 @@ Note that unless you specify a different upper and lower bound for the time rang
 * Valid units for `time()` are:  
 <br>
     `u` microseconds  
+    `ms` milliseconds
     `s` seconds  
     `m` minutes  
     `h` hours  


### PR DESCRIPTION
Milliseconds `ms` are also a valid unit for time().