### PR TITLE
Fixing a couple issues

### DIFF
--- a/content/influxdb/v0.10/query_language/data_exploration.md
+++ b/content/influxdb/v0.10/query_language/data_exploration.md
@@ -343,6 +343,7 @@ Note that unless you specify a different upper and lower bound for the time rang
 * Valid units for `time()` are:  
 <br>
     `u` microseconds  
+    `ms` milliseconds  
     `s` seconds  
     `m` minutes  
     `h` hours  
@@ -787,8 +788,9 @@ Query data that occur between epoch 0 and 1,000 days from `now()`:
 * Note the whitespace between the operator and the time duration.
 Leaving that whitespace out can cause InfluxDB to return no results or an `error parsing query` error .
 
-The other options for specifying time durations with `now()` are listed below.
+The other options for specifying time durations with `now()` are listed below.  
 `u` microseconds  
+`ms` milliseconds  
 `s` seconds  
 `m` minutes  
 `h` hours  

--- a/content/influxdb/v0.10/write_protocols/line.md
+++ b/content/influxdb/v0.10/write_protocols/line.md
@@ -102,7 +102,7 @@ If the timestamp is not provided the point will inherit the server's local times
 
 Some write APIs allow passing a lower precision.
 If the API supports a lower precision, the timestamp may also be an integer epoch in microseconds, milliseconds, seconds, minutes or hours.
-We recommend using the smallest precision possible as this can result in
+We recommend using the least precise precision possible as this can result in
 significant improvements in compression.
 
 ## Full Example

--- a/content/influxdb/v0.10/write_protocols/line.md
+++ b/content/influxdb/v0.10/write_protocols/line.md
@@ -102,6 +102,8 @@ If the timestamp is not provided the point will inherit the server's local times
 
 Some write APIs allow passing a lower precision.
 If the API supports a lower precision, the timestamp may also be an integer epoch in microseconds, milliseconds, seconds, minutes or hours.
+We recommend using the smallest precision possible as this can result in
+significant improvements in compression.
 
 ## Full Example
 A full example is shown below.

--- a/content/influxdb/v0.10/write_protocols/write_syntax.md
+++ b/content/influxdb/v0.10/write_protocols/write_syntax.md
@@ -54,7 +54,9 @@ When no timestamp is provided the server will insert the point with the local se
 timestamp.
 If a timestamp is provided it must be separated from the field(s) by a space.
 Timestamps must be in Unix time and are assumed to be in nanoseconds.
-A different precision can be specified, see the HTTP syntax for details.
+A different precision can be specified, see the [HTTP syntax](/influxdb/v0.10/write_protocols/write_syntax/#http) for details.
+We recommend using the smallest precision possible as this can result in
+significant improvements in compression.
 
 ### Key-value Separator
 

--- a/content/influxdb/v0.10/write_protocols/write_syntax.md
+++ b/content/influxdb/v0.10/write_protocols/write_syntax.md
@@ -55,7 +55,7 @@ timestamp.
 If a timestamp is provided it must be separated from the field(s) by a space.
 Timestamps must be in Unix time and are assumed to be in nanoseconds.
 A different precision can be specified, see the [HTTP syntax](/influxdb/v0.10/write_protocols/write_syntax/#http) for details.
-We recommend using the smallest precision possible as this can result in
+We recommend using the least precise precision possible as this can result in
 significant improvements in compression.
 
 ### Key-value Separator

--- a/content/influxdb/v0.11/query_language/data_exploration.md
+++ b/content/influxdb/v0.11/query_language/data_exploration.md
@@ -358,6 +358,7 @@ Note that unless you specify a different upper and lower bound for the time rang
 * Valid units for `time()` are:  
 <br>
     `u` microseconds  
+    `ms` milliseconds    
     `s` seconds  
     `m` minutes  
     `h` hours  
@@ -823,6 +824,7 @@ Leaving that whitespace out can cause InfluxDB to return no results or an `error
 
 The other options for specifying time durations with `now()` are listed below.  
 `u` microseconds  
+`ms` milliseconds  
 `s` seconds  
 `m` minutes  
 `h` hours  

--- a/content/influxdb/v0.11/write_protocols/line.md
+++ b/content/influxdb/v0.11/write_protocols/line.md
@@ -102,7 +102,7 @@ If the timestamp is not provided the point will inherit the server's local times
 
 Some write APIs allow passing a lower precision.
 If the API supports a lower precision, the timestamp may also be an integer epoch in microseconds, milliseconds, seconds, minutes or hours.
-We recommend using the smallest precision possible as this can result in
+We recommend using the least precise precision possible as this can result in
 significant improvements in compression.
 
 ## Full Example

--- a/content/influxdb/v0.11/write_protocols/line.md
+++ b/content/influxdb/v0.11/write_protocols/line.md
@@ -102,6 +102,8 @@ If the timestamp is not provided the point will inherit the server's local times
 
 Some write APIs allow passing a lower precision.
 If the API supports a lower precision, the timestamp may also be an integer epoch in microseconds, milliseconds, seconds, minutes or hours.
+We recommend using the smallest precision possible as this can result in
+significant improvements in compression.
 
 ## Full Example
 A full example is shown below.

--- a/content/influxdb/v0.11/write_protocols/write_syntax.md
+++ b/content/influxdb/v0.11/write_protocols/write_syntax.md
@@ -55,7 +55,7 @@ timestamp.
 If a timestamp is provided it must be separated from the field(s) by a space.
 Timestamps must be in Unix time and are assumed to be in nanoseconds.
 A different precision can be specified, see the [HTTP syntax](/influxdb/v0.11/write_protocols/write_syntax/#http) for details.
-We recommend using the smallest precision possible as this can result in
+We recommend using the least precise precision possible as this can result in
 significant improvements in compression.
 
 ### Key-value Separator

--- a/content/influxdb/v0.11/write_protocols/write_syntax.md
+++ b/content/influxdb/v0.11/write_protocols/write_syntax.md
@@ -54,7 +54,9 @@ When no timestamp is provided the server will insert the point with the local se
 timestamp.
 If a timestamp is provided it must be separated from the field(s) by a space.
 Timestamps must be in Unix time and are assumed to be in nanoseconds.
-A different precision can be specified, see the HTTP syntax for details.
+A different precision can be specified, see the [HTTP syntax](/influxdb/v0.11/write_protocols/write_syntax/#http) for details.
+We recommend using the smallest precision possible as this can result in
+significant improvements in compression.
 
 ### Key-value Separator
 

--- a/content/influxdb/v0.12/query_language/data_exploration.md
+++ b/content/influxdb/v0.12/query_language/data_exploration.md
@@ -357,8 +357,8 @@ Other things to note about `GROUP BY time()`:
 Note that unless you specify a different upper and lower bound for the time range, `GROUP BY` uses `epoch 0` as the lower bound and `now()` as the upper bound for the query.
 * Valid units for `time()` are:  
 <br>
-    `u` microseconds  
-    `ms` milliseconds
+    `u` microseconds    
+    `ms` milliseconds  
     `s` seconds  
     `m` minutes  
     `h` hours  
@@ -824,6 +824,7 @@ Leaving that whitespace out can cause InfluxDB to return no results or an `error
 
 The other options for specifying time durations with `now()` are listed below.  
 `u` microseconds  
+`ms` milliseconds  
 `s` seconds  
 `m` minutes  
 `h` hours  

--- a/content/influxdb/v0.12/query_language/spec.md
+++ b/content/influxdb/v0.12/query_language/spec.md
@@ -85,6 +85,7 @@ The rules:
 
 - double quoted identifiers can contain any unicode character other than a new line
 - double quoted identifiers can contain escaped `"` characters (i.e., `\"`)
+- double quoted identifiers can contain InfluxQL [keywords](/influxdb/v0.12/query_language/spec/#keywords)
 - unquoted identifiers must start with an upper or lowercase ASCII character or "_"
 - unquoted identifiers may contain only ASCII letters, decimal digits, and "_"
 

--- a/content/influxdb/v0.12/write_protocols/line.md
+++ b/content/influxdb/v0.12/write_protocols/line.md
@@ -102,7 +102,7 @@ If the timestamp is not provided the point will inherit the server's local times
 
 Some write APIs allow passing a lower precision.
 If the API supports a lower precision, the timestamp may also be an integer epoch in microseconds, milliseconds, seconds, minutes or hours.
-We recommend using the smallest precision possible as this can result in
+We recommend using the least precise precision possible as this can result in
 significant improvements in compression.
 
 ## Full Example

--- a/content/influxdb/v0.12/write_protocols/line.md
+++ b/content/influxdb/v0.12/write_protocols/line.md
@@ -102,6 +102,8 @@ If the timestamp is not provided the point will inherit the server's local times
 
 Some write APIs allow passing a lower precision.
 If the API supports a lower precision, the timestamp may also be an integer epoch in microseconds, milliseconds, seconds, minutes or hours.
+We recommend using the smallest precision possible as this can result in
+significant improvements in compression.
 
 ## Full Example
 A full example is shown below.

--- a/content/influxdb/v0.12/write_protocols/write_syntax.md
+++ b/content/influxdb/v0.12/write_protocols/write_syntax.md
@@ -54,7 +54,9 @@ When no timestamp is provided the server will insert the point with the local se
 timestamp.
 If a timestamp is provided it must be separated from the field(s) by a space.
 Timestamps must be in Unix time and are assumed to be in nanoseconds.
-A different precision can be specified, see the HTTP syntax for details.
+A different precision can be specified, see the [HTTP syntax](/influxdb/v0.12/write_protocols/write_syntax/#http) for details.
+We recommend using the smallest precision possible as this can result in
+significant improvements in compression.
 
 ### Key-value Separator
 

--- a/content/influxdb/v0.12/write_protocols/write_syntax.md
+++ b/content/influxdb/v0.12/write_protocols/write_syntax.md
@@ -55,7 +55,7 @@ timestamp.
 If a timestamp is provided it must be separated from the field(s) by a space.
 Timestamps must be in Unix time and are assumed to be in nanoseconds.
 A different precision can be specified, see the [HTTP syntax](/influxdb/v0.12/write_protocols/write_syntax/#http) for details.
-We recommend using the smallest precision possible as this can result in
+We recommend using the least precise precision possible as this can result in
 significant improvements in compression.
 
 ### Key-value Separator

--- a/content/influxdb/v0.9/query_language/data_exploration.md
+++ b/content/influxdb/v0.9/query_language/data_exploration.md
@@ -343,6 +343,7 @@ Note that unless you specify a different upper and lower bound for the time rang
 * Valid units for `time()` are:  
 <br>
     `u` microseconds  
+    `ms` milliseconds  
     `s` seconds  
     `m` minutes  
     `h` hours  
@@ -787,8 +788,9 @@ Query data that occur between epoch 0 and 1,000 days from `now()`:
 * Note the whitespace between the operator and the time duration.
 Leaving that whitespace out can cause InfluxDB to return no results or an `error parsing query` error .
 
-The other options for specifying time durations with `now()` are listed below.
+The other options for specifying time durations with `now()` are listed below.  
 `u` microseconds  
+`ms` milliseconds  
 `s` seconds  
 `m` minutes  
 `h` hours  


### PR DESCRIPTION
* `data_exploration.md` was missing `ms` as a possible time precision - pointed out in https://github.com/influxdata/docs.influxdata.com/pull/377. This adds it to another place in 0.12 and to previous versions: 0.9, 0.10, and 0.11.

* Adds a note about double quoting identifiers if they contain a keyword to `spec.md`. Fixes https://github.com/influxdata/docs.influxdata.com/issues/354

* Adds a recommendation to use the smallest precision possible when writing data for compression purposed to 0.10, 0.11, and 0.12. Fixes 
https://github.com/influxdata/docs.influxdata.com/issues/372