### PR TITLE
Fix funky formatting

### DIFF
--- a/content/influxdb/v0.10/query_language/database_management.md
+++ b/content/influxdb/v0.10/query_language/database_management.md
@@ -143,7 +143,7 @@ CREATE RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <dur
 ```
 
 * `DURATION` determines how long InfluxDB keeps the data - the options for specifying the duration of the retention policy are listed below.
-Note that the minimum retention period is one hour.
+Note that the minimum retention period is one hour.  
 `m` minutes  
 `h` hours  
 `d` days  

--- a/content/influxdb/v0.11/query_language/database_management.md
+++ b/content/influxdb/v0.11/query_language/database_management.md
@@ -165,7 +165,7 @@ CREATE RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <dur
 ```
 
 * `DURATION` determines how long InfluxDB keeps the data - the options for specifying the duration of the retention policy are listed below.
-Note that the minimum retention period is one hour.
+Note that the minimum retention period is one hour.  
 `m` minutes  
 `h` hours  
 `d` days  

--- a/content/influxdb/v0.12/query_language/database_management.md
+++ b/content/influxdb/v0.12/query_language/database_management.md
@@ -161,7 +161,7 @@ CREATE RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <dur
 
 * `DURATION` determines how long InfluxDB keeps the data.
 The options for specifying the duration of the retention policy are listed below.
-Note that the minimum retention period is one hour.
+Note that the minimum retention period is one hour.  
 `m` minutes  
 `h` hours  
 `d` days  

--- a/content/influxdb/v0.9/query_language/database_management.md
+++ b/content/influxdb/v0.9/query_language/database_management.md
@@ -152,7 +152,7 @@ CREATE RETENTION POLICY <retention_policy_name> ON <database_name> DURATION <dur
 ```
 
 * `DURATION` determines how long InfluxDB keeps the data - the options for specifying the duration of the retention policy are listed below.
-Note that the minimum retention period is one hour.
+Note that the minimum retention period is one hour.  
 `m` minutes  
 `h` hours  
 `d` days  


### PR DESCRIPTION
Fixes the `DURATION` formatting in verisons 0.9-0.12.

Fixes https://github.com/influxdata/docs.influxdata.com/issues/402