### PR TITLE
Fix link formatting

### DIFF
--- a/content/telegraf/v0.12/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.12/introduction/getting-started-telegraf.md
@@ -59,7 +59,7 @@ Once Telegraf is up and running it'll start collecting data and writing them to 
 Returning to our sample configuration, we show what the `cpu` and `mem` data look like in InfluxDB below.
 Note that we used the default input and output configuration settings to get these data.
 
-* List all [measurements](https://docs.influxdata.com/influxdb/v0.10/concepts/glossary/#measurement) in the `telegraf` [database](https://docs.influxdata.com/influxdb/v0.10/concepts/glossary/#database):
+* List all [measurements](/influxdb/v0.12/concepts/glossary/#measurement) in the `telegraf` [database](/influxdb/v0.12/concepts/glossary/#database):
 
 ```bash
 > SHOW MEASUREMENTS
@@ -70,7 +70,7 @@ cpu
 mem
 ```
 
-* List all [field keys](https://docs.influxdata.com/influxdb/v0.10/concepts/glossary/#field-key) by measurement:
+* List all [field keys](/influxdb/v0.12/concepts/glossary/#field-key) by measurement:
 
 ```bash
 > SHOW FIELD KEYS
@@ -101,7 +101,7 @@ used
 used_percent
 ```
 
-* Select a sample of the data in the [field](https://docs.influxdata.com/influxdb/v0.10/concepts/glossary/#field) `usage_idle` in the measurement `cpu_usage_idle`:
+* Select a sample of the data in the [field](/influxdb/v0.12/concepts/glossary/#field) `usage_idle` in the measurement `cpu_usage_idle`:
 
 ```bash
 > SELECT usage_idle FROM cpu WHERE cpu = 'cpu-total' LIMIT 5


### PR DESCRIPTION
Links to relative doc should be like:
/influxdb/v0.12/concepts/glossary/#measurement
Instead of absolute URL to previous versions
https://docs.influxdata.com/influxdb/v0.10/concepts/glossary/#measurement

###### URL for relevant page?
https://docs.influxdata.com/telegraf/v0.12/introduction/getting-started-telegraf/

###### What products and version are you using?
telegraf

###### Where did you look before opening the issue?
content/telegraf/v0.12/introduction/getting-started-telegraf.md