### PR TITLE
Add note about permissions to upgrading.md

### DIFF
--- a/content/influxdb/v0.12/administration/upgrading.md
+++ b/content/influxdb/v0.12/administration/upgrading.md
@@ -95,6 +95,13 @@ Restore `/tmp/backup` to the meta directory in `/var/lib/influxdb/meta`:
 Using metastore snapshot: /tmp/backup/meta.00
 ```
 
+> **Note:** If you run `influxd restore` as the root user, you will need to
+change the permissions on the `meta.db` file:
+>
+```
+sudo chown influxdb:influxdb /var/lib/influxdb/meta/*
+```
+
 **5.** Generate a new configuration file.
 
 InfluxDB 0.12 has several new settings in the [configuration file](/influxdb/v0.12/administration/config/).


### PR DESCRIPTION
@kostasb pointed this out:

The command that imports the meta directory in 0.12:

```
influxd restore -metadir=<path_to_012_meta_directory> <path_to_metastore_backup>
```

if run by the root user, will leave the `/var/lib/influxdb/meta/meta.db` file owned by root without write permission from anyone else.  I suspect that the InfluxDB service may not be able to write in the meta database if it starts with such permissions, but I’ve not seen or heard any issues so far. We should add a `chown influxdb:influxdb /var/lib/influxdb/meta/*` command.

