### PR TITLE
Introducing 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,10 @@
+{{partial "header.html" . }}
+    <div class="documentation-home--hero">
+        <div class="documentation-home--title"><b>Page not found.</b><br><br>We're sorry but we can't find the page you were looking for.<br></div>
+    </div>
+    <div class="documentation-home--menu">
+        {{ range .Site.Menus.products }}
+        <a class="documentation-home--menu-item" href="{{ .URL }}{{ index $.Site.Data.default_versions (print .Identifier "_semver") }}/">{{ .Name }}</a>
+	{{ end}}
+    </div>
+{{ partial "footer.html" . }}


### PR DESCRIPTION
Added a 404 page which includes the search bar and the main index of products. 
Fixes #192 .

<img width="1519" alt="404" src="https://cloud.githubusercontent.com/assets/15780449/15074893/45a0743c-13aa-11e6-8f35-7e64ac5f98a5.png">

@beckettsean @gunnaraasen @rkuchan 