### PR TITLE
Update Data Exploration

### DIFF
--- a/content/influxdb/v0.13/query_language/data_exploration.md
+++ b/content/influxdb/v0.13/query_language/data_exploration.md
@@ -375,7 +375,7 @@ See [Frequently Encountered Issues](/influxdb/v0.13/troubleshooting/frequently_e
 `GROUP BY time()` also allows you to alter the default rounded calendar time
 boundaries by including an offset interval.
 
-Example:
+Examples:
 
 [`COUNT()`](/influxdb/v0.13/query_language/functions/#count) the number of `water_level` points between August 19, 2015 at midnight and August 27 at 5:00pm at three day intervals, and offset
 the time boundary by one day:
@@ -404,6 +404,39 @@ August 21 - August 23         August 22 - August 24
 August 24 - August 26         August 25 - August 27
 August 27 - August 29         
 ```
+
+[`COUNT()`](/influxdb/v0.13/query_language/functions/#count) the number of
+`water_level` points between August 19, 2015 at midnight and August 27 at 5:00pm
+at three day intervals, and offset
+the time boundary by -2 days:
+```
+> SELECT COUNT(water_level) FROM h2o_feet WHERE time >= '2015-08-19T00:00:00Z' AND time <= '2015-08-27T17:00:00Z' AND location='coyote_creek' GROUP BY time(3d,-2d)
+```
+
+CLI response:
+```
+name: h2o_feet
+--------------
+time			               count
+2015-08-19T00:00:00Z	 720
+2015-08-22T00:00:00Z	 720
+2015-08-25T00:00:00Z	 651
+```
+
+The  `-2d` offset interval alters the default three day time interval boundaries  
+from:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to:
+```
+August 18 - August 20         August 16 - August 18
+August 21 - August 23         August 19 - August 21
+August 24 - August 26         August 22 - August 24
+August 27 - August 29         August 25 - August 27
+```
+InfluxDB does not return results for the first time interval
+(August 16 - August 18), because it is completely outside the time range in the
+query's `WHERE` clause.
 
 ### GROUP BY tag values AND a time interval
 

--- a/content/influxdb/v0.13/query_language/data_exploration.md
+++ b/content/influxdb/v0.13/query_language/data_exploration.md
@@ -32,7 +32,7 @@ Limit and sort your results:
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Limit the number of series returned with `SLIMIT`](/influxdb/v0.13/query_language/data_exploration/#limit-the-number-of-series-returned-with-slimit)  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Limit the number of points and series returned with `LIMIT` and `SLIMIT`](/influxdb/v0.13/query_language/data_exploration/#limit-the-number-of-points-and-series-returned-with-limit-and-slimit)
 * [Sort query returns with `ORDER BY time DESC`](/influxdb/v0.13/query_language/data_exploration/#sort-query-returns-with-order-by-time-desc)
-* [Paginate query returns with `OFFSET`](/influxdb/v0.13/query_language/data_exploration/#paginate-query-returns-with-offset)
+* [Paginate query returns with `OFFSET` and `SOFFSET`](/influxdb/v0.13/query_language/data_exploration/#paginate-query-returns-with-offset-and-soffset)
 
 General tips on query syntax:
 
@@ -765,8 +765,10 @@ time			               water_level
 2015-09-18T16:00:00Z	 3.599
 ```
 
-## Paginate query returns with OFFSET
-Use `OFFSET` to paginate the results returned.
+## Paginate query returns with OFFSET and SOFFSET
+
+### Use `OFFSET` to paginate the results returned
+---
 For example, get the first three points written to a series:
 
 ```sql
@@ -777,10 +779,10 @@ CLI response:
 ```bash
 name: h2o_feet
 ----------
-time			water_level
-2015-08-18T00:00:00Z	8.12
-2015-08-18T00:06:00Z	8.005
-2015-08-18T00:12:00Z	7.887
+time			               water_level
+2015-08-18T00:00:00Z	 8.12
+2015-08-18T00:06:00Z	 8.005
+2015-08-18T00:12:00Z	 7.887
 ```
 
 Then get the second three points from that same series:
@@ -793,10 +795,45 @@ CLI response:
 ```bash
 name: h2o_feet
 ----------
-time			water_level
-2015-08-18T00:18:00Z	7.762
-2015-08-18T00:24:00Z	7.635
-2015-08-18T00:30:00Z	7.5
+time			               water_level
+2015-08-18T00:18:00Z	 7.762
+2015-08-18T00:24:00Z	 7.635
+2015-08-18T00:30:00Z	 7.5
+```
+
+### Use `SOFFSET` to paginate the series returned
+---
+
+For example, get the first three points from a single series:
+```
+> SELECT water_level FROM h2o_feet GROUP BY * LIMIT 3 SLIMIT 1
+```
+
+CLI response:
+```
+name: h2o_feet
+tags: location=coyote_creek
+time			               water_level
+----			               -----------
+2015-08-18T00:00:00Z	 8.12
+2015-08-18T00:06:00Z	 8.005
+2015-08-18T00:12:00Z	 7.887
+```
+
+Then get the first three points from the next series:
+```
+> SELECT water_level FROM h2o_feet GROUP BY * LIMIT 3 SLIMIT 1 SOFFSET 1
+```
+
+CLI response:
+```
+name: h2o_feet
+tags: location=santa_monica
+time			               water_level
+----			               -----------
+2015-08-18T00:00:00Z	 2.064
+2015-08-18T00:06:00Z	 2.116
+2015-08-18T00:12:00Z	 2.028
 ```
 
 ## Multiple statements in queries

--- a/content/influxdb/v0.13/query_language/schema_exploration.md
+++ b/content/influxdb/v0.13/query_language/schema_exploration.md
@@ -269,16 +269,16 @@ location
 The `SHOW TAG VALUES` query returns the set of [tag values](/influxdb/v0.13/concepts/glossary/#tag-value) for a specific tag key across all measurements in the database.
 Syntax for specifying a single tag key:
 ```sql
-SHOW TAG VALUES [FROM <measurement_name>] WITH KEY = <tag_key>
+SHOW TAG VALUES [FROM <measurement_name>] WITH KEY = "<tag_key>"
 ```
 Syntax for specifying more than one tag key:
 ```sql
-SHOW TAG VALUES [FROM <measurement_name>] WITH KEY IN (<tag_key1>,<tag_key2)
+SHOW TAG VALUES [FROM <measurement_name>] WITH KEY IN ("<tag_key1>","<tag_key2")
 ```
 
 Return the tag values for a single tag key (`randtag`) across all measurements in the database `NOAA_water_database`:
 ```sql
-> SHOW TAG VALUES WITH KEY = randtag
+> SHOW TAG VALUES WITH KEY = "randtag"
 ```
 
 CLI response:
@@ -293,7 +293,7 @@ randtag	 2
 
 Return the tag values for two tag keys (`location` and `randtag`) across all measurements in the database `NOAA_water_database`:
 ```sql
-> SHOW TAG VALUES WITH KEY IN (location,randtag)
+> SHOW TAG VALUES WITH KEY IN ("location","randtag")
 ```
 
 CLI response:
@@ -338,7 +338,7 @@ location	 santa_monica
 
 Return the tag values for the tag key `randtag` for a specific measurement in the `NOAA_water_database` database:
 ```sql
-> SHOW TAG VALUES FROM average_temperature WITH KEY = randtag
+> SHOW TAG VALUES FROM average_temperature WITH KEY = "randtag"
 ```
 
 CLI response:

--- a/content/influxdb/v0.13/query_language/spec.md
+++ b/content/influxdb/v0.13/query_language/spec.md
@@ -738,13 +738,13 @@ show_tag_values_stmt = "SHOW TAG VALUES" [ from_clause ] with_tag_clause [ where
 
 ```sql
 -- show all tag values across all measurements for the region tag
-SHOW TAG VALUES WITH KEY = 'region'
+SHOW TAG VALUES WITH KEY = "region"
 
 -- show tag values from the cpu measurement for the region tag
-SHOW TAG VALUES FROM cpu WITH KEY = 'region'
+SHOW TAG VALUES FROM cpu WITH KEY = "region"
 
 -- show tag values from the cpu measurement for region & host tag keys where service = 'redis'
-SHOW TAG VALUES FROM cpu WITH KEY IN (region, host) WHERE service = 'redis'
+SHOW TAG VALUES FROM cpu WITH KEY IN ("region", "host") WHERE service = 'redis'
 ```
 
 ### SHOW USERS


### PR DESCRIPTION
This adds a description of `SOFFSET` and an example of a negative offset interval in a `GROUP BY time()` query to `data_exploration.md`.

It also fixes the syntax in `spec.md` for the SHOW TAG VALUES query. It adds the double quotes to `data_exploration.md` as well.

Fixes https://github.com/influxdata/docs.influxdata.com/issues/453, https://github.com/influxdata/docs.influxdata.com/issues/456, and https://github.com/influxdata/docs.influxdata.com/issues/460.