### PR TITLE
Avoid using a keyword as a measurement name in an example.

### DIFF
--- a/content/influxdb/v0.13/write_protocols/write_syntax.md
+++ b/content/influxdb/v0.13/write_protocols/write_syntax.md
@@ -17,7 +17,7 @@ The syntax for the line protocol is
 For example:
 
 ```bash
-measurement,tkey1=tval1,tkey2=tval2 fkey=fval,fkey2=fval2 1234567890000000000
+a_measurement,tkey1=tval1,tkey2=tval2 fkey=fval,fkey2=fval2 1234567890000000000
 ```
 
 ### Whitespace
@@ -30,21 +30,21 @@ There must also be whitespace between the field(s) and the timestamp, if one is 
 
 Valid (`value` and `otherval` are fields, `foo` and `bat` are tags)
 ```bash
-measurement value=12
-measurement value=12 1439587925
-measurement,foo=bar value=12
-measurement,foo=bar value=12 1439587925
-measurement,foo=bar,bat=baz value=12,otherval=21 1439587925
+a_measurement value=12
+a_measurement value=12 1439587925
+a_measurement,foo=bar value=12
+a_measurement,foo=bar value=12 1439587925
+a_measurement,foo=bar,bat=baz value=12,otherval=21 1439587925
 ```
 
 Invalid
 ```bash
-measurement,value=12
-measurement value=12,1439587925
-measurement foo=bar value=12
-measurement,foo=bar,value=12 1439587925
-measurement,foo=bar
-measurement,foo=bar 1439587925
+a_measurement,value=12
+a_measurement value=12,1439587925
+a_measurement foo=bar value=12
+a_measurement,foo=bar,value=12 1439587925
+a_measurement,foo=bar
+a_measurement,foo=bar 1439587925
 ```
 
 ### Timestamps


### PR DESCRIPTION
If the reader attempts to use a measurement with a name of "measurement"
in a query then they will likely omit the required double-quoting of
measurement where it is used as a measurement name and then receive a
confusing report of syntax error as a result.

With this change, the measurement name used in the example will not
require quoting if subsequently used.

See https://github.com/influxdata/influxdb/issues/6785

Signed-off-by: Jon Seymour <jon@wildducktheories.com>