### PR TITLE
-- Fix Grammatical Issue --

### DIFF
--- a/content/influxdb/v0.13/guides/writing_data.md
+++ b/content/influxdb/v0.13/guides/writing_data.md
@@ -84,7 +84,7 @@ InfluxDB will still attempt to write the points after that time out but there wi
 ---
 InfluxDB is a schemaless database.
 You can add new measurements, tags, and fields at any time.
-Note that if you attempt to write data with a different type than previously used (for example, writing a string to a field that previously accepted integers), InfluxDB will reject those data.
+Note that if you attempt to write data with a different type than previously used (for example, writing a string to a field that previously accepted integers), InfluxDB will reject that data.
 
 ### A note on REST...
 ---


### PR DESCRIPTION
* You can not use those in this case. Switched it to that. The data is referred to as a whole as "that data".
  
Example: That data is corrupt and *not* those data is corrupt

fixes issue #516 