### PR TITLE
A couple small fixes

### DIFF
--- a/content/influxdb/v0.11/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.11/troubleshooting/frequently_encountered_issues.md
@@ -28,7 +28,8 @@ Where applicable, it links to outstanding issues on GitHub.
 
 **Writing data**  
 
-* [Writing integers](/influxdb/v0.11/troubleshooting/frequently_encountered_issues/#writing-integers)   
+* [Writing integers](/influxdb/v0.11/troubleshooting/frequently_encountered_issues/#writing-integers)  
+* [Writing data with negative timestamps](/influxdb/v0.11/troubleshooting/frequently_encountered_issues/#writing-data-with-negative-timestamps)   
 * [Writing duplicate points](/influxdb/v0.11/troubleshooting/frequently_encountered_issues/#writing-duplicate-points)  
 * [Getting an unexpected error when sending data over the HTTP API](/influxdb/v0.11/troubleshooting/frequently_encountered_issues/#getting-an-unexpected-error-when-sending-data-over-the-http-api)
 * [Words and characters to avoid](/influxdb/v0.11/troubleshooting/frequently_encountered_issues/#words-and-characters-to-avoid)  
@@ -248,6 +249,19 @@ If you do not provide the `i`, InfluxDB will treat the field value as a float.
 
 Writes an integer: `value=100i`  
 Writes a float: `value=100`
+
+## Writing data with negative timestamps
+InfluxDB accepts writes with negative timestamps but you will not be able
+to query those points.
+
+Example:
+```
+> INSERT waybackwhen value=1 -1
+> SELECT * FROM "waybackwhen"
+>
+```
+
+This issue has been fixed in version 1.0.
 
 ## Writing duplicate points
 In InfluxDB 0.11 a point is uniquely identified by the measurement name, [tag set](/influxdb/v0.11/concepts/glossary/#tag-set), and the nanosecond timestamp.

--- a/content/influxdb/v0.12/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.12/troubleshooting/frequently_encountered_issues.md
@@ -28,7 +28,8 @@ Where applicable, it links to outstanding issues on GitHub.
 
 **Writing data**  
 
-* [Writing integers](/influxdb/v0.12/troubleshooting/frequently_encountered_issues/#writing-integers)   
+* [Writing integers](/influxdb/v0.12/troubleshooting/frequently_encountered_issues/#writing-integers)  
+* [Writing data with negative timestamps](/influxdb/v0.12/troubleshooting/frequently_encountered_issues/#writing-data-with-negative-timestamps)   
 * [Writing duplicate points](/influxdb/v0.12/troubleshooting/frequently_encountered_issues/#writing-duplicate-points)  
 * [Getting an unexpected error when sending data over the HTTP API](/influxdb/v0.12/troubleshooting/frequently_encountered_issues/#getting-an-unexpected-error-when-sending-data-over-the-http-api)
 * [Words and characters to avoid](/influxdb/v0.12/troubleshooting/frequently_encountered_issues/#words-and-characters-to-avoid)  
@@ -260,6 +261,19 @@ If you do not provide the `i`, InfluxDB will treat the field value as a float.
 
 Writes an integer: `value=100i`  
 Writes a float: `value=100`
+
+## Writing data with negative timestamps
+InfluxDB accepts writes with negative timestamps but you will not be able
+to query those points.
+
+Example:
+```
+> INSERT waybackwhen value=1 -1
+> SELECT * FROM "waybackwhen"
+>
+```
+
+This issue has been fixed in version 1.0.
 
 ## Writing duplicate points
 In InfluxDB 0.12 a point is uniquely identified by the measurement name, [tag set](/influxdb/v0.12/concepts/glossary/#tag-set), and the nanosecond timestamp.

--- a/content/influxdb/v0.13/concepts/clusters.md
+++ b/content/influxdb/v0.13/concepts/clusters.md
@@ -1,0 +1,12 @@
+---
+title: Clustering
+menu:
+  influxdb_013:
+    weight: 100
+    parent: concepts
+---
+
+Open-source InfluxDB does not support clustering.
+For high availability or horizontal scaling of InfluxDB, please investigate our
+commercial clustered offering,
+[InfluxEnterprise](https://portal.influxdata.com/).

--- a/content/influxdb/v0.13/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.13/troubleshooting/frequently_encountered_issues.md
@@ -27,7 +27,8 @@ Where applicable, it links to outstanding issues on GitHub.
 
 **Writing data**  
 
-* [Writing integers](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#writing-integers)   
+* [Writing integers](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#writing-integers)
+* [Writing data with negative timestamps](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#writing-data-with-negative-timestamps)     
 * [Writing duplicate points](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#writing-duplicate-points)  
 * [Getting an unexpected error when sending data over the HTTP API](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#getting-an-unexpected-error-when-sending-data-over-the-http-api)
 * [Words and characters to avoid](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#words-and-characters-to-avoid)  
@@ -248,6 +249,19 @@ If you do not provide the `i`, InfluxDB will treat the field value as a float.
 
 Writes an integer: `value=100i`  
 Writes a float: `value=100`
+
+## Writing data with negative timestamps
+InfluxDB accepts writes with negative timestamps but you will not be able
+to query those points.
+
+Example:
+```
+> INSERT waybackwhen value=1 -1
+> SELECT * FROM "waybackwhen"
+>
+```
+
+This issue has been fixed in version 1.0.
 
 ## Writing duplicate points
 In InfluxDB 0.13 a point is uniquely identified by the measurement name, [tag set](/influxdb/v0.13/concepts/glossary/#tag-set), and timestamp.

--- a/content/influxdb/v1.0/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v1.0/troubleshooting/frequently_encountered_issues.md
@@ -14,7 +14,6 @@ Where applicable, it links to outstanding issues on GitHub.
 
 * [Understanding the time intervals returned from `GROUP BY time()` queries](#understanding-the-time-intervals-returned-from-group-by-time-queries)    
 * [Querying after `now()`](#querying-after-now)  
-* [Querying a time range that spans epoch 0](#querying-a-time-range-that-spans-epoch-0)  
 * [Querying with booleans](#querying-with-booleans)  
 * [Querying `SELECT *` with field type discrepancies](#querying-select-with-field-type-discrepancies)
 * [Working with really big or really small integers](#working-with-really-big-or-really-small-integers)
@@ -97,12 +96,6 @@ The second query asks InfluxDB to return everything from `hillvalley` that occur
 
 `SELECT * FROM "hillvalley"`  
 `SELECT * FROM "hillvalley" WHERE time < now() + 1000d`
-
-## Querying a time range that spans epoch 0
-Currently, InfluxDB can return results for queries that cover either the time range before epoch 0 or the time range after epoch 0, not both.
-A query with a time range that spans epoch 0 returns partial results.
-
-<dt> [GitHub Issue #2703](https://github.com/influxdb/influxdb/issues/2703)  </dt>
 
 ## Querying with booleans
 Acceptable boolean syntax differs for data writes and data queries.


### PR DESCRIPTION
Fixes:

* https://github.com/influxdata/docs.influxdata.com/issues/552 (Adds cluster page to 0.13 docs)
* https://github.com/influxdata/docs.influxdata.com/issues/583 (Adds FEI about negative timestamps being write-able but not query-able to versions 0.11 through 0.13)
* https://github.com/influxdata/docs.influxdata.com/issues/592 (Removes FEI about not being able to query timestamps that span epoch 0)