### PR TITLE
fix fieldtype alignment

### DIFF
--- a/content/telegraf/v1.0/introduction/getting_started.md
+++ b/content/telegraf/v1.0/introduction/getting_started.md
@@ -90,10 +90,10 @@ usage_user		            float
 
 name: mem
 ---------
-fieldKey                    fieldType
-active			            integer
-available		            integer
-available_percent	        float
+fieldKey                   fieldType
+active			                integer
+available		               integer
+available_percent	       float
 buffered		            integer
 cached			            integer
 free			            integer

--- a/content/telegraf/v1.0/introduction/getting_started.md
+++ b/content/telegraf/v1.0/introduction/getting_started.md
@@ -90,16 +90,16 @@ usage_user		            float
 
 name: mem
 ---------
-fieldKey                   fieldType
+fieldKey                fieldType
 active			                integer
-available		               integer
+available		              integer
 available_percent	       float
-buffered		            integer
-cached			            integer
-free			            integer
+buffered		                integer
+cached			                 integer
+free			                   integer
 inactive		            integer
-total			            integer
-used			            integer
+total			                  integer
+used			                   integer
 used_percent		        float
 ```
 

--- a/content/telegraf/v1.0/introduction/getting_started.md
+++ b/content/telegraf/v1.0/introduction/getting_started.md
@@ -78,10 +78,10 @@ name: cpu
 ---------
 fieldKey                fieldType
 usage_guest             float
-usage_guest_nice	    float
-usage_idle		        float
-usage_iowait		    float
-usage_irq		        float
+usage_guest_nice	        float
+usage_idle		             float
+usage_iowait		           float
+usage_irq		                 float
 usage_nice		        float
 usage_softirq		    float
 usage_steal		        float

--- a/content/telegraf/v1.0/introduction/getting_started.md
+++ b/content/telegraf/v1.0/introduction/getting_started.md
@@ -76,31 +76,31 @@ mem
 > SHOW FIELD KEYS
 name: cpu
 ---------
-fieldKey            fieldType
-usage_guest         float
-usage_guest_nice	float
-usage_idle		    float
-usage_iowait		float
-usage_irq		    float
-usage_nice		    float
-usage_softirq		float
-usage_steal		    float
-usage_system		float
-usage_user		    float
+fieldKey                fieldType
+usage_guest             float
+usage_guest_nice	    float
+usage_idle		        float
+usage_iowait		    float
+usage_irq		        float
+usage_nice		        float
+usage_softirq		    float
+usage_steal		        float
+usage_system		    float
+usage_user		        float
 
 name: mem
 ---------
-fieldKey		    fieldType
-active			    integer
-available		    integer
-available_percent	float
-buffered		    integer
-cached			    integer
-free			    integer
-inactive		    integer
-total			    integer
-used			    integer
-used_percent		float
+fieldKey		        fieldType
+active			        integer
+available		          integer
+available_percent	    float
+buffered		        integer
+cached			        integer
+free			        integer
+inactive		        integer
+total			        integer
+used			        integer
+used_percent		    float
 ```
 
 * Select a sample of the data in the [field](/influxdb/v1.0/concepts/glossary/#field) `usage_idle` in the measurement `cpu_usage_idle`:

--- a/content/telegraf/v1.0/introduction/getting_started.md
+++ b/content/telegraf/v1.0/introduction/getting_started.md
@@ -91,16 +91,16 @@ usage_user		            float
 name: mem
 ---------
 fieldKey                fieldType
-active			                integer
-available		              integer
-available_percent	       float
-buffered		                integer
-cached			                 integer
-free			                   integer
-inactive		            integer
-total			                  integer
-used			                   integer
-used_percent		        float
+active			               integer
+available		             integer
+available_percent	      float
+buffered		              integer
+cached			               integer
+free			                 integer
+inactive		              integer
+total			                integer
+used			                 integer
+used_percent		          float
 ```
 
 * Select a sample of the data in the [field](/influxdb/v1.0/concepts/glossary/#field) `usage_idle` in the measurement `cpu_usage_idle`:

--- a/content/telegraf/v1.0/introduction/getting_started.md
+++ b/content/telegraf/v1.0/introduction/getting_started.md
@@ -78,29 +78,29 @@ name: cpu
 ---------
 fieldKey                fieldType
 usage_guest             float
-usage_guest_nice	        float
-usage_idle		             float
-usage_iowait		           float
-usage_irq		                 float
-usage_nice		        float
-usage_softirq		    float
-usage_steal		        float
-usage_system		    float
-usage_user		        float
+usage_guest_nice	       float
+usage_idle		            float
+usage_iowait		          float
+usage_irq		            float
+usage_nice		            float
+usage_softirq		        float
+usage_steal		            float
+usage_system		        float
+usage_user		            float
 
 name: mem
 ---------
 fieldKey		        fieldType
-active			        integer
-available		        integer
-available_percent	    float
-buffered		        integer
-cached			        integer
-free			        integer
-inactive		        integer
-total			        integer
-used			        integer
-used_percent		    float
+active			         integer
+available		         integer
+available_percent	     float
+buffered		         integer
+cached			         integer
+free			         integer
+inactive		         integer
+total			         integer
+used			         integer
+used_percent		     float
 ```
 
 * Select a sample of the data in the [field](/influxdb/v1.0/concepts/glossary/#field) `usage_idle` in the measurement `cpu_usage_idle`:

--- a/content/telegraf/v1.0/introduction/getting_started.md
+++ b/content/telegraf/v1.0/introduction/getting_started.md
@@ -61,7 +61,7 @@ Note that we used the default input and output configuration settings to get the
 
 * List all [measurements](/influxdb/v1.0/concepts/glossary/#measurement) in the `telegraf` [database](/influxdb/v1.0/concepts/glossary/#database):
 
-```bash
+```
 > SHOW MEASUREMENTS
 name: measurements
 ------------------
@@ -72,7 +72,7 @@ mem
 
 * List all [field keys](/influxdb/v1.0/concepts/glossary/#field-key) by measurement:
 
-```bash
+```
 > SHOW FIELD KEYS
 name: cpu
 ---------
@@ -92,7 +92,7 @@ name: mem
 ---------
 fieldKey		        fieldType
 active			        integer
-available		          integer
+available		        integer
 available_percent	    float
 buffered		        integer
 cached			        integer

--- a/content/telegraf/v1.0/introduction/getting_started.md
+++ b/content/telegraf/v1.0/introduction/getting_started.md
@@ -81,26 +81,26 @@ usage_guest             float
 usage_guest_nice	       float
 usage_idle		            float
 usage_iowait		          float
-usage_irq		            float
+usage_irq		             float
 usage_nice		            float
-usage_softirq		        float
-usage_steal		            float
-usage_system		        float
+usage_softirq		         float
+usage_steal		           float
+usage_system		          float
 usage_user		            float
 
 name: mem
 ---------
-fieldKey		        fieldType
-active			         integer
-available		         integer
-available_percent	     float
-buffered		         integer
-cached			         integer
-free			         integer
-inactive		         integer
-total			         integer
-used			         integer
-used_percent		     float
+fieldKey                    fieldType
+active			            integer
+available		            integer
+available_percent	        float
+buffered		            integer
+cached			            integer
+free			            integer
+inactive		            integer
+total			            integer
+used			            integer
+used_percent		        float
 ```
 
 * Select a sample of the data in the [field](/influxdb/v1.0/concepts/glossary/#field) `usage_idle` in the measurement `cpu_usage_idle`:


### PR DESCRIPTION
The code format messes up alignment on show field keys output on telegraf's getting started page. Had to manually fix spacing.