### PR TITLE
Rk some fixes

### DIFF
--- a/content/influxdb/v0.13/high_availability/clusters.md
+++ b/content/influxdb/v0.13/high_availability/clusters.md
@@ -1,9 +1,9 @@
 ---
 title: Clustering
 menu:
-  influxdb_1_0:
-    weight: 100
-    parent: concepts
+  influxdb_013:
+    weight: 0
+    parent: high_availability
 ---
 
 Open-source InfluxDB does not support clustering.

--- a/content/influxdb/v0.13/high_availability/index.md
+++ b/content/influxdb/v0.13/high_availability/index.md
@@ -8,7 +8,6 @@ For high availability or horizontal scaling of InfluxDB, please investigate our
 commercial clustered offering,
 [InfluxEnterprise](https://portal.influxdata.com/).
 
-
 ## [Relay](/influxdb/v0.13/high_availability/relay/)
 Relay adds a basic high availability layer to InfluxDB.
 With the right architecture and disaster recovery processes, this achieves a

--- a/content/influxdb/v0.13/high_availability/index.md
+++ b/content/influxdb/v0.13/high_availability/index.md
@@ -2,6 +2,13 @@
 title: High Availability
 ---
 
+## [Clustering](/influxdb/v0.13/high_availability/relay/)
+Open-source InfluxDB does not support clustering.
+For high availability or horizontal scaling of InfluxDB, please investigate our
+commercial clustered offering,
+[InfluxEnterprise](https://portal.influxdata.com/).
+
+
 ## [Relay](/influxdb/v0.13/high_availability/relay/)
 Relay adds a basic high availability layer to InfluxDB.
 With the right architecture and disaster recovery processes, this achieves a

--- a/content/influxdb/v0.13/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.13/troubleshooting/frequently_encountered_issues.md
@@ -18,8 +18,7 @@ Where applicable, it links to outstanding issues on GitHub.
 * [Querying with booleans](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#querying-with-booleans)  
 * [Working with really big or really small integers](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#working-with-really-big-or-really-small-integers)
 * [Doing math on timestamps](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#doing-math-on-timestamps)  
-* [Getting an unexpected epoch 0 timestamp in query returns](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#getting-an-unexpected-epoch-0-timestamp-in-query-returns)  
-* [Getting large query returns in batches when using the HTTP API](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#getting-large-query-returns-in-batches-when-using-the-http-api)  
+* [Getting an unexpected epoch 0 timestamp in query returns](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#getting-an-unexpected-epoch-0-timestamp-in-query-returns)   
 * [Getting the `expected identifier` error, unexpectedly](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#getting-the-expected-identifier-error-unexpectedly)
 * [Identifying write precision from returned timestamps](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#identifying-write-precision-from-returned-timestamps)  
 * [Single quoting and double quoting in queries](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#single-quoting-and-double-quoting-in-queries)  
@@ -131,15 +130,6 @@ All time calculations must be carried out by the client receiving the query resu
 ## Getting an unexpected epoch 0 timestamp in query returns
 In InfluxDB, epoch 0  (`1970-01-01T00:00:00Z`)  is often used as a null timestamp equivalent.
 If you request a query that has no timestamp to return, such as an aggregation function with an unbounded time range, InfluxDB returns epoch 0 as the timestamp.
-
-## Getting large query returns in batches when using the HTTP API
-InfluxDB returns large query results in batches of 10,000 points unless you use the query string parameter `chunk_size` to explicitly set the batch size.
-For example, get results in batches of 20,000 points with:
-
-`curl -G 'http://localhost:8086/query' --data-urlencode "db=deluge" --data-urlencode "chunk_size=20000" --data-urlencode "q=SELECT * FROM liters"`
-
-<dt> See [GitHub Issue #3242](https://github.com/influxdb/influxdb/issues/3242) for more information on the challenges that this can cause, especially with Grafana visualization.
-</dt>
 
 ## Getting the `expected identifier` error, unexpectedly
 Receiving the error `ERR: error parsing query: found [WORD], expected identifier[, string, number, bool]` is often a gentle reminder that you forgot to include something in your query, as is the case in the following examples:

--- a/content/influxdb/v1.0/high_availability/clusters.md
+++ b/content/influxdb/v1.0/high_availability/clusters.md
@@ -1,9 +1,9 @@
 ---
 title: Clustering
 menu:
-  influxdb_013:
-    weight: 100
-    parent: concepts
+  influxdb_1_0:
+    weight: 0
+    parent: high_availability
 ---
 
 Open-source InfluxDB does not support clustering.

--- a/content/influxdb/v1.0/high_availability/index.md
+++ b/content/influxdb/v1.0/high_availability/index.md
@@ -2,6 +2,12 @@
 title: High Availability
 ---
 
+## [Clustering](/influxdb/v1.0/high_availability/relay/)
+Open-source InfluxDB does not support clustering.
+For high availability or horizontal scaling of InfluxDB, please investigate our
+commercial clustered offering,
+[InfluxEnterprise](https://portal.influxdata.com/).
+
 ## [Relay](/influxdb/v1.0/high_availability/relay/)
 Relay adds a basic high availability layer to InfluxDB.
 With the right architecture and disaster recovery processes, this achieves a

--- a/content/influxdb/v1.0/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v1.0/troubleshooting/frequently_encountered_issues.md
@@ -18,8 +18,7 @@ Where applicable, it links to outstanding issues on GitHub.
 * [Querying `SELECT *` with field type discrepancies](#querying-select-with-field-type-discrepancies)
 * [Working with really big or really small integers](#working-with-really-big-or-really-small-integers)
 * [Doing math on timestamps](#doing-math-on-timestamps)  
-* [Getting an unexpected epoch 0 timestamp in query returns](#getting-an-unexpected-epoch-0-timestamp-in-query-returns)  
-* [Getting large query returns in batches when using the HTTP API](#getting-large-query-returns-in-batches-when-using-the-http-api)  
+* [Getting an unexpected epoch 0 timestamp in query returns](#getting-an-unexpected-epoch-0-timestamp-in-query-returns)   
 * [Getting the `expected identifier` error, unexpectedly](#getting-the-expected-identifier-error-unexpectedly)
 * [Identifying write precision from returned timestamps](#identifying-write-precision-from-returned-timestamps)  
 * [Single quoting and double quoting in queries](#single-quoting-and-double-quoting-in-queries)  
@@ -178,17 +177,6 @@ All time calculations must be carried out by the client receiving the query resu
 ## Getting an unexpected epoch 0 timestamp in query returns
 In InfluxDB, epoch 0  (`1970-01-01T00:00:00Z`)  is often used as a null timestamp equivalent.
 If you request a query that has no timestamp to return, such as an aggregation function with an unbounded time range, InfluxDB returns epoch 0 as the timestamp.
-
-## Getting large query returns in batches when using the HTTP API
-InfluxDB returns large query results in batches of 10,000 points unless you use the query string parameter `chunk_size` to explicitly set the batch size.
-For example, get results in batches of 20,000 points with:
-
-```
-curl -G 'http://localhost:8086/query?db=deluge' --data-urlencode "chunk_size=20000" --data-urlencode 'q=SELECT * FROM "liters"'
-```
-
-<dt> See [GitHub Issue #3242](https://github.com/influxdb/influxdb/issues/3242) for more information on the challenges that this can cause, especially with Grafana visualization.
-</dt>
 
 ## Getting the `expected identifier` error, unexpectedly
 Receiving the error `ERR: error parsing query: found [WORD], expected identifier[, string, number, bool]` is often a gentle reminder that you forgot to include something in your query, as is the case in the following examples:


### PR DESCRIPTION
Moves the clustering page to the HA section and removes the FEI about the outdated `chunk_size` query string parameter.

Fixes: #621 and #623  