### PR TITLE
Remove hugo urls

### DIFF
--- a/content/enterprise/v1.0/guides/migration.md
+++ b/content/enterprise/v1.0/guides/migration.md
@@ -197,7 +197,7 @@ Added data node y at the-hostname:8088
 ```
 ### 2. Rebalance the cluster
 
-Increase the [replication factor](http://localhost:1313/enterprise/v1.0/concepts/glossary/#replication-factor) on all existing retention polices to the number of data nodes in your cluster.
+Increase the [replication factor](/enterprise/v1.0/concepts/glossary/#replication-factor) on all existing retention polices to the number of data nodes in your cluster.
 You can do this with [ALTER RETENTION POLICY](https://docs.influxdata.com/influxdb/v1.0/query_language/database_management/#modify-retention-policies-with-alter-retention-policy).
 
 Next, [rebalance](/enterprise/v1.0/features/web-console-features/#cluster-rebalancing) your cluster using the `Rebalance` button on the `Tasks` page.

--- a/content/influxdb/v0.12/guides/index.md
+++ b/content/influxdb/v0.12/guides/index.md
@@ -8,4 +8,4 @@ title: Guides
 
 ## [Downsampling and Data Retention](/influxdb/v0.12/guides/downsampling_and_retention/)
 
-## [Hardware Sizing Guidelines](http://localhost:1313/influxdb/v0.12/guides/hardware_sizing/)
+## [Hardware Sizing Guidelines](/influxdb/v0.12/guides/hardware_sizing/)

--- a/content/influxdb/v0.13/administration/index.md
+++ b/content/influxdb/v0.13/administration/index.md
@@ -17,7 +17,7 @@ Procedures to backup data created by InfluxDB and to restore from a backup.
 
 ## [Differences between InfluxDB 0.13 and 0.12](/influxdb/v0.13/administration/012_vs_013/)
 
-## [Differences between InfluxDB 0.13 and versions prior to 0.12](http://localhost:1313/influxdb/v0.13/administration/013_vs_previous/)
+## [Differences between InfluxDB 0.13 and versions prior to 0.12](/influxdb/v0.13/administration/013_vs_previous/)
 
 ## [Upgrading](/influxdb/v0.13/administration/upgrading/)
 

--- a/content/influxdb/v0.13/guides/index.md
+++ b/content/influxdb/v0.13/guides/index.md
@@ -8,4 +8,4 @@ title: Guides
 
 ## [Downsampling and Data Retention](/influxdb/v0.13/guides/downsampling_and_retention/)
 
-## [Hardware Sizing Guidelines](http://localhost:1313/influxdb/v0.13/guides/hardware_sizing/)
+## [Hardware Sizing Guidelines](/influxdb/v0.13/guides/hardware_sizing/)

--- a/content/influxdb/v1.0/administration/index.md
+++ b/content/influxdb/v1.0/administration/index.md
@@ -17,7 +17,7 @@ Procedures to backup data created by InfluxDB and to restore from a backup.
 
 ## [Differences between InfluxDB 1.0 and 0.123](/influxdb/v1.0/administration/013_vs_1/)
 
-## [Differences between InfluxDB 1.00 and versions prior to 0.13](http://localhost:1313/influxdb/v1.0/administration/1_vs_previous/)
+## [Differences between InfluxDB 1.00 and versions prior to 0.13](/influxdb/v1.0/administration/1_vs_previous/)
 
 ## [Upgrading](/influxdb/v1.0/administration/upgrading/)
 

--- a/content/influxdb/v1.0/guides/downsampling_and_retention.md
+++ b/content/influxdb/v1.0/guides/downsampling_and_retention.md
@@ -34,8 +34,8 @@ A single database can have several RPs and RPs are unique per database.
 This guide will not go into detail about the syntax for creating and managing
 CQs and RPs.
 If you're new to both concepts, we recommend looking over the detailed
-[CQ documentation](/influxdb/v/influxdb/v1.0//query_language/continuous_queries/) and
-[RP documentation](http://localhost:1313/influxdb/v1.0/query_language/database_management/#retention-policy-management).
+[CQ documentation](/influxdb/v1.0/query_language/continuous_queries/) and
+[RP documentation](/influxdb/v1.0/query_language/database_management/#retention-policy-management).
 
 ### Sample data
 This section uses fictional real-time data that track the number of food orders

--- a/content/influxdb/v1.0/guides/index.md
+++ b/content/influxdb/v1.0/guides/index.md
@@ -8,4 +8,4 @@ title: Guides
 
 ## [Downsampling and Data Retention](/influxdb/v1.0/guides/downsampling_and_retention/)
 
-## [Hardware Sizing Guidelines](http://localhost:1313/influxdb/v1.0/guides/hardware_sizing/)
+## [Hardware Sizing Guidelines](/influxdb/v1.0/guides/hardware_sizing/)

--- a/content/influxdb/v1.0/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.0/write_protocols/line_protocol_reference.md
@@ -224,7 +224,7 @@ it can cause
 
 ## Line Protocol in Practice
 
-See the [Tools](http://localhost:1313/influxdb/v1.0/tools/) section for how to
+See the [Tools](/influxdb/v1.0/tools/) section for how to
 write Line Protocol to the database.
 
 ### Duplicate points

--- a/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
@@ -373,7 +373,7 @@ it can cause
 Now that you know all about Line Protocol, how do you actually get the
 Line Protocol to InfluxDB?
 Here, we'll give two quick examples and then point you to the
-[Tools](http://localhost:1313/influxdb/v1.0/tools/) sections for further
+[Tools](/influxdb/v1.0/tools/) sections for further
 information.
 
 #### HTTP API
@@ -403,7 +403,7 @@ You can also use the CLI to
 Protocol from a file.
 
 There are several ways to write data to InfluxDB.
-See the [Tools](http://localhost:1313/influxdb/v1.0/tools/) section for more
+See the [Tools](/influxdb/v1.0/tools/) section for more
 on the [HTTP API](/influxdb/v1.0/tools/api/#write), the
 [CLI](/influxdb/v1.0/tools/shell/), and the available Service Plugins (
 [UDP](/influxdb/v1.0/tools/udp/),


### PR DESCRIPTION
There are a number of pages which had calls back to localhost:1313,
which causes issues when trying to read the docs online.

I've gone through and done a mass grep for localhost:1313 to fix these
in the content/ folder.

Also fixed the CQ link on the downsampling and retention page.

CLA is signed