### PR TITLE
Link to influxdata.com/downloads

### DIFF
--- a/content/enterprise/v1.0/introduction/download.md
+++ b/content/enterprise/v1.0/introduction/download.md
@@ -1,11 +1,8 @@
 ---
-title: Downloads
+title: Download
 menu:
   enterprise_1_0:
     weight: 0
     parent: Introduction
+    url: https://www.influxdata.com/downloads/
 ---
-
-Please visit [InfluxPortal](https://portal.influxdata.com/) to view pricing options and
-get a license key. See the [Installation](/enterprise/v1.0/introduction/installation/) documentation to access the downloads. You will
-need a valid license to run a cluster.


### PR DESCRIPTION
Might conflict with https://github.com/influxdata/docs.influxdata.com/pull/662 but this links the Enterprise downloads page direcltly to influxdata.com/downloads.

To be merged when the Enterprise downloads are on that page.
