### PR TITLE
Fix a couple issues

### DIFF
--- a/content/enterprise/v1.0/administration/upgrading.md
+++ b/content/enterprise/v1.0/administration/upgrading.md
@@ -198,7 +198,7 @@ In each meta node’s configuration file (`/etc/influxdb/influxdb-meta.conf`), s
 ```
 reporting-disabled = false
 bind-address = ""
-hostname = "rk-enterprise-beta-meta-01"
+hostname = "enterprise-meta-01"
 
 [enterprise]
   registration-enabled = true #✨

--- a/content/enterprise/v1.0/introduction/installation.md
+++ b/content/enterprise/v1.0/introduction/installation.md
@@ -46,11 +46,11 @@ Add your servers' hostnames and IP addresses to **each** server's `/etc/hosts`
 file (the hostnames are representative):
 
 ```
-<Meta_1_IP> enterprise-beta-meta-01
-<Meta_2_IP> enterprise-beta-meta-02
-<Meta_3_IP> enterprise-beta-meta-03
-<Data_1_IP> enterprise-beta-data-01
-<Data_2_IP> enterprise-beta-data-02
+<Meta_1_IP> enterprise-meta-01
+<Meta_2_IP> enterprise-meta-02
+<Meta_3_IP> enterprise-meta-03
+<Data_1_IP> enterprise-data-01
+<Data_2_IP> enterprise-data-02
 ```
 
 ### Set up, configure, and start the meta servers
@@ -83,7 +83,7 @@ In `/etc/influxdb/influxdb-meta.conf`, set:
 ```
 reporting-disabled = false
 bind-address = ""
-hostname = "<enterprise-beta-meta-0x>" #✨
+hostname = "<enterprise-meta-0x>" #✨
 
 [enterprise]
  registration-enabled = true #✨
@@ -160,7 +160,7 @@ In `/etc/influxdb/influxdb.conf`, set:
 ```
 # Change this option to true to disable reporting.
 reporting-disabled = false
-hostname="enterprise-beta-data-0x" #✨
+hostname="enterprise-data-0x" #✨
 meta-tls-enabled = false
 
 [enterprise]
@@ -226,18 +226,18 @@ Move on to the next section to join all servers to a cluster.
 
 #### 1. Connect the meta nodes to the cluster
 
-From `enterprise-beta-meta-01`, enter:
+From `enterprise-meta-01`, enter:
 ```
-influxd-ctl join enterprise-beta-meta-01:8091
+influxd-ctl join enterprise-meta-01:8091
 
-influxd-ctl join enterprise-beta-meta-02:8091
+influxd-ctl join enterprise-meta-02:8091
 
-influxd-ctl join enterprise-beta-meta-03:8091
+influxd-ctl join enterprise-meta-03:8091
 ```
 
 The expected output of those commands is:
 ```
-Added meta node x at enterprise-beta-meta-0x:8091
+Added meta node x at enterprise-meta-0x:8091
 ```
 
 > **Note:** Please make sure that you specify the fully qualified host name of
@@ -255,9 +255,9 @@ The expected output is:
 Meta Nodes
 ==========
 TCP Address
-enterprise-beta-meta-01:8091
-enterprise-beta-meta-02:8091
-enterprise-beta-meta-03:8091
+enterprise-meta-01:8091
+enterprise-meta-02:8091
+enterprise-meta-03:8091
 ```
 
 Note that your cluster must have at least three meta nodes.
@@ -266,16 +266,16 @@ the cluster.
 
 #### 3. Connect the data nodes to the cluster
 
-From `enterprise-beta-meta-01`, enter:
+From `enterprise-meta-01`, enter:
 ```
-influxd-ctl add-data enterprise-beta-data-01:8088
+influxd-ctl add-data enterprise-data-01:8088
 
-influxd-ctl add-data enterprise-beta-data-02:8088
+influxd-ctl add-data enterprise-data-02:8088
 ```
 
 The expected output of those commands is:
 ```
-Added data node y at enterprise-beta-data-0x:8088
+Added data node y at enterprise-data-0x:8088
 ```
 
 #### 4. Verify that the data nodes are part of the cluster
@@ -290,15 +290,15 @@ The expected output is:
 Data Nodes
 ==========
 ID   TCP Address
-4    enterprise-beta-data-01:8088
-5    enterprise-beta-data-02:8088
+4    enterprise-data-01:8088
+5    enterprise-data-02:8088
 
 Meta Nodes
 ==========
 TCP Address
-enterprise-beta-meta-01:8091
-enterprise-beta-meta-02:8091
-enterprise-beta-meta-03:8091
+enterprise-meta-01:8091
+enterprise-meta-02:8091
+enterprise-meta-03:8091
 ```
 
 Note that your cluster must have at least two data nodes.

--- a/content/enterprise/v1.0/troubleshooting/reporting-issues.md
+++ b/content/enterprise/v1.0/troubleshooting/reporting-issues.md
@@ -13,7 +13,7 @@ support team.
 
 Please include the following in your email:
 
-* the version of InfluxEnterprise, e.g. 1.0.0-beta2-c1.0.0
+* the version of InfluxEnterprise, e.g. 1.0.0-c1.0.0
 * the version of Telegraf or Kapacitor, if applicable
 * what you expected to happen
 * what did happen

--- a/content/influxdb/v1.0/guides/downsampling_and_retention.md
+++ b/content/influxdb/v1.0/guides/downsampling_and_retention.md
@@ -175,7 +175,7 @@ two measurements: `orders` and `downsampled_orders`.
 
 ```bash
 > SELECT * FROM "orders" LIMIT 5
-name: cpu
+name: orders
 ---------
 time			                phone  website
 2016-05-13T23:00:00Z	  10     30
@@ -185,7 +185,7 @@ time			                phone  website
 2016-05-13T23:00:40Z	  17     32
 
 > SELECT * FROM "a_year"."downsampled_orders" LIMIT 5
-name: downsampled_cpu
+name: downsampled_orders
 ---------------------
 time			                mean_phone  mean_website
 2016-05-13T15:00:00Z	  12          23

--- a/content/influxdb/v1.0/query_language/data_exploration.md
+++ b/content/influxdb/v1.0/query_language/data_exploration.md
@@ -529,7 +529,10 @@ time			                 mean
 ✨
 ```
 
-> **Note:** If you're `GROUP(ing) BY` several things (for example, both tags and a time interval) `fill()` must go at the end of the `GROUP BY` clause.
+> **Notes:**
+>
+* `fill()` must go at the end of the `GROUP BY` clause if you're `GROUP(ing) BY` several things (for example, both tags and a time interval).
+* `fill(previous)` doesn’t fill the result for a time bucket if the previous value is outside the query’s time range. See [Frequently Encountered Issues](/influxdb/v1.0/troubleshooting/frequently_encountered_issues/#getting-empty-results-with-fill-previous) for more information.
 
 ## The INTO clause
 ### Relocate data


### PR DESCRIPTION
* Removes `beta` from the hostnames in the Enterprise documentation
* Fixes the typo in the downsampling guide, https://github.com/influxdata/docs.influxdata.com/issues/658
* Adds an FEI about `fill(previous)` and links to that FEI from the data exploration page, https://github.com/influxdata/docs.influxdata.com/issues/522