### PR TITLE
Updates docs with the new definition of a series

### DIFF
--- a/content/influxdb/v1.0/concepts/glossary.md
+++ b/content/influxdb/v1.0/concepts/glossary.md
@@ -42,17 +42,21 @@ Related entries: [retention policy](/influxdb/v1.0/concepts/glossary/#retention-
 
 ## field
 The key-value pair in InfluxDB's data structure that records metadata and the actual data value.
-Fields are required in InfluxDB's data structure and they are not indexed - queries on field values scan all points that match the specified time range and, as a result, are not performant relative to tags.
-
-*Query tip:* Compare fields to tags; tags are indexed.
+Fields are required in InfluxDB's data structure.
 
 Related entries: [field key](/influxdb/v1.0/concepts/glossary/#field-key), [field set](/influxdb/v1.0/concepts/glossary/#field-set), [field value](/influxdb/v1.0/concepts/glossary/#field-value), [tag](/influxdb/v1.0/concepts/glossary/#tag)
 
 ## field key
 The key part of the key-value pair that makes up a field.
 Field keys are strings and they store metadata.
+Field keys are indexed.
 
-Related entries: [field](/influxdb/v1.0/concepts/glossary/#field), [field set](/influxdb/v1.0/concepts/glossary/#field-set), [field value](/influxdb/v1.0/concepts/glossary/#field-value), [tag key](/influxdb/v1.0/concepts/glossary/#tag-key)
+Related entries:
+[field](#field),
+[field set](#field_set),
+[field value](#field-value),
+[series](#series),
+[tag key](#tag-key)
 
 ## field set
 The collection of field keys and field values on a point.
@@ -64,7 +68,7 @@ The value part of the key-value pair that makes up a field.
 Field values are the actual data; they can be strings, floats, integers, or booleans.
 A field value is always associated with a timestamp.
 
-Field values are not indexed - queries on field values scan all points that match the specified time range and, as a result, are not performant.
+Field values are not indexed - queries on field values scan all points that match the specified time range and, as a result, are not as performant as queries on tag values.
 
 *Query tip:* Compare field values to tag values; tag values are indexed.
 
@@ -89,7 +93,37 @@ The text based format for writing points to InfluxDB. See [Line Protocol](/influ
 The part of InfluxDB's structure that describes the data stored in the associated fields.
 Measurements are strings.
 
-Related entries: [field](/influxdb/v1.0/concepts/glossary/#field), [series](/influxdb/v1.0/concepts/glossary/#series)
+Related entries:
+[field](#field),
+[metaseries](#metaseries),
+[series](#series)
+
+## metaseries
+The collection of data in InfluxDB's data structure that share a measurement and tag set.
+
+The sample data below has three metaseries:
+
+| Arbitrary metaseries number | Measurement        | Tag set    |
+| :-------------------------- | :----------------- |:-----------|
+| metaseries 1                | `measurement_name` | `tag_key_1 = alpha`,`tagkey_2 = true` |
+| metaseries 2                | `measurement_name` | `tag_key_1 = alpha`,`tagkey_2 = false` |
+| metaseries 3                | `measurement_name` | `tag_key_1 = beta`,`tagkey_2 = true` |
+
+Sample data:
+```
+name: measurement_name
+--------------
+time                   field_key_1   field_key_2  tag_key_1   tag_key_2
+2015-08-18T00:00:00Z   2             18           alpha       true     
+2015-08-18T00:00:10Z   3             76           alpha       false
+2015-08-18T00:00:20Z   3             58           beta        true
+2015-08-18T00:00:30Z   5                          beta        true
+```
+
+Related entries:
+[measurement](#measurement),
+[series](#series),
+[tag set](#tag-set)
 
 ## metastore
 Contains internal information about the status of the system. That includes user information, database and shard metadata, and which retention policies are enabled.
@@ -102,20 +136,16 @@ An independent `influxd` process.
 Related entries: [server](/influxdb/v1.0/concepts/glossary/#server)
 
 ## point   
-The part of InfluxDB's data structure that consists of a single collection of fields in a series.
-Each point is uniquely identified by its series and timestamp.
+The part of InfluxDB's data structure identified by its series and timestamp.
 
 You cannot store more than one point with the same timestamp in the same series.
-Instead, when you write a new point to the same series with the same timestamp as an existing point in that series, the field set becomes the union of the old field set and the new field set, where any ties go to the new field set.
-For an example, see [Frequently Encountered Issues](/influxdb/v1.0/troubleshooting/frequently_encountered_issues/#writing-duplicate-points).
+When you write a new point to the same series with the same timestamp, InfluxDB overwrites the existing the point with the new data.
 
 Related entries: [field set](/influxdb/v1.0/concepts/glossary/#field-set), [series](/influxdb/v1.0/concepts/glossary/#series), [timestamp](/influxdb/v1.0/concepts/glossary/#timestamp)
 
 ## points per second
-A deprecated measurement of the rate at which data are persisted to InfluxDB.
-The schema allows and even encourages the recording of multiple metric vales per point, rendering points per second ambiguous.
-
-Write speeds are generally quoted in values per second, a more precise metric.
+The preferred measurement of the rate at which data are persisted to InfluxDB.
+Write speeds are generally quoted in points per second.
 
 Related entries: [point](/influxdb/v1.0/concepts/glossary/#point), [schema](/influxdb/v1.0/concepts/glossary/#schema), [values per second](/influxdb/v1.0/concepts/glossary/#values-per-second)
 
@@ -134,9 +164,9 @@ Related entries: [duration](/influxdb/v1.0/concepts/glossary/#duration), [node](
 
 ## retention policy (RP)
 The part of InfluxDB's data structure that describes for how long InfluxDB keeps data (duration), how many copies of those data are stored in the cluster (replication factor), and the time range covered by shard groups (shard group duration).
-RPs are unique per database and along with the measurement and tag set define a series.
+RPs are unique per database.
 
-When you create a database, InfluxDB automatically creates a retention policy called `autogen` with an infinite duration, a replication factor set to one, and a shard group duration set to seven days.
+When you create a database, InfluxDB automatically creates a retention policy called `autogen` with an infinite duration, a replication factor set to one or to the number of data nodes in the cluster, and a shard group duration set to seven days.
 See [Database Management](/influxdb/v1.0/query_language/database_management/#retention-policy-management) for retention policy management.
 
 <dt> Replication factors do not serve a purpose with single node instances.
@@ -158,51 +188,78 @@ See [InfluxQL Functions](/influxdb/v1.0/query_language/functions/#selectors) for
 Related entries: [aggregation](/influxdb/v1.0/concepts/glossary/#aggregation), [function](/influxdb/v1.0/concepts/glossary/#function), [transformation](/influxdb/v1.0/concepts/glossary/#transformation)
 
 ## series  
-The collection of data in InfluxDB's data structure that share a measurement, tag set, and retention policy.
+The collection of data in InfluxDB's data structure that share a measurement, tag set, and field key.
 
+The sample data below has six series:
 
-> **Note:** The field set is not part of the series identification!
+| Arbitrary series number | Measurement        | Tag set    | Field key |
+| :---------------------- | :----------------- |:-----------|:-----------|
+| series 1                | `measurement_name` | `tag_key_1 = alpha`,`tagkey_2 = true` | `field_key_1` |
+| series 2                | `measurement_name` | `tag_key_1 = alpha`,`tagkey_2 = true` | `field_key_2` |
+| series 3                | `measurement_name` | `tag_key_1 = alpha`,`tagkey_2 = false` | `field_key_1` |
+| series 4                | `measurement_name` | `tag_key_1 = alpha`,`tagkey_2 = false` | `field_key_2` |
+| series 5                | `measurement_name` | `tag_key_1 = beta`,`tagkey_2 = true` | `field_key_1` |
+| series 6                | `measurement_name` | `tag_key_1 = beta`,`tagkey_2 = true` | `field_key_2` |
 
-Related entries: [field set](/influxdb/v1.0/concepts/glossary/#field-set), [measurement](/influxdb/v1.0/concepts/glossary/#measurement), [retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp), [tag set](/influxdb/v1.0/concepts/glossary/#tag-set)
+Sample data:
+```
+name: measurement_name
+--------------
+time                   field_key_1   field_key_2  tag_key_1   tag_key_2
+2015-08-18T00:00:00Z   2             18           alpha       true     
+2015-08-18T00:00:10Z   3             76           alpha       false
+2015-08-18T00:00:20Z   3             58           beta        true
+2015-08-18T00:00:30Z   5                          beta        true
+```
+
+Related entries:
+[field key](#field-key),
+[measurement](#measurement),
+[metaseries](#metaseries),
+[series cardinality](#series-cardinality),
+[tag set](#tag-set)
 
 ## series cardinality
-The number of unique database, measurement, and tag set combinations in an InfluxDB instance.
+The number of unique database, measurement, tag set, and field key combinations in an InfluxDB instance.
 
-For example, assume that an InfluxDB instance has a single database and one measurement.
-The single measurement has two tag keys: `email` and `status`.
-If there are three different `email`s, and each email address is associated with two
-different `status`es then the series cardinality for the measurement is 6
-(3 * 2 = 6):
+For example, assume that an InfluxDB instance has a single datbase and one measurement.
+The single measurement has two tag keys (`email` and `status`) and one field key (`mood_index`).
+The tag key `email` has three tag values (`lorr@influxdata.com`,`marv@influxdata.com`,`cliff@influxdata.com`) and
+the tag key `status` has two tag values (`start`,`finish`).
+If every point includes the field key `mood_index` then the series cardinality for the measurement is 6
+(3 * 2 * 1 = 6):
 
-| email                 | status |
-| :-------------------- | :----- |
-| lorr@influxdata.com | start  |
-| lorr@influxdata.com | finish |
-| marv@influxdata.com     | start  |
-| marv@influxdata.com     | finish |
-| cliff@influxdata.com | start  |
-| cliff@influxdata.com | finish |
+| tag set | field key |
+| :-------| :----- |
+| `email = lorr@influxdata.com`,  `status = start`  | `mood_index` |
+| `email = lorr@influxdata.com`,  `status = finish` | `mood_index` |
+| `email = marv@influxdata.com`,  `status = start`  | `mood_index` |
+| `email = marv@influxdata.com`,  `status = finish` | `mood_index` |
+| `email = cliff@influxdata.com`, `status = start` | `mood_index` |
+| `email = cliff@influxdata.com`, `status = finish` | `mood_index` |
 
 Note that, in some cases, simply performing that multiplication may overestimate series cardinality because of the presence of dependent tags.
 Dependent tags are tags that are scoped by another tag and do not increase series
 cardinality.
 If we add the tag `firstname` to the example above, the series cardinality
-would not be 18 (3 * 2 * 3 = 18).
+would not be 18 (3 * 2 * 3 * 1 = 18).
 It would remain unchanged at 6, as `firstname` is already scoped by the `email` tag:
 
-| email                 | status | firstname |
-| :-------------------- | :----- | :-------- |
-| lorr@influxdata.com | start  | lorraine  |
-| lorr@influxdata.com | finish | lorraine  |
-| marv@influxdata.com     | start  | marvin      |
-| marv@influxdata.com     | finish | marvin      |
-| cliff@influxdata.com | start  | clifford  |
-| cliff@influxdata.com | finish | clifford  |
+| tag set | field key |
+| :-------| :----- |
+| `email = lorr@influxdata.com`,  `status = start`,  `firstname = lorraine`  | `mood_index` |
+| `email = lorr@influxdata.com`,  `status = finish`, `firstname = lorraine`  | `mood_index` |
+| `email = marv@influxdata.com`,  `status = start`,  `firstname = marvin`    | `mood_index` |
+| `email = marv@influxdata.com`,  `status = finish`, `firstname = marvin`    | `mood_index` |
+| `email = cliff@influxdata.com`, `status = start`,  `firstname = clifford`  | `mood_index` |
+| `email = cliff@influxdata.com`, `status = finish`, `firstname = clifford`  | `mood_index` |
 
-See [Frequently Encountered Issues](/influxdb/v1.0/troubleshooting/frequently_encountered_issues/#querying-for-series-cardinality) for how to query InfluxDB for series
-cardinality.
 
-Related entries: [tag set](/influxdb/v1.0/concepts/glossary/#tag-set), [measurement](/influxdb/v1.0/concepts/glossary/#measurement), [tag key](/influxdb/v1.0/concepts/glossary/#tag-key)
+Related entries:
+[field key](#field-key),
+[measurement](#measurement),
+[tag key](#tag-key),
+[tag set](#tag-set)
 
 ## server  
 A machine, virtual or physical, that is running InfluxDB.
@@ -236,30 +293,34 @@ Related entries: [database](/influxdb/v1.0/concepts/glossary/#database), [retent
 
 ## tag  
 The key-value pair in InfluxDB's data structure that records metadata.
-Tags are an optional part of InfluxDB's data structure but they are useful for storing commonly-queried metadata; tags are indexed so queries on tags are performant.
-*Query tip:* Compare tags to fields; fields are not indexed.
+Tags are an optional part of InfluxDB's data structure but they are useful for storing commonly-queried metadata.
 
 Related entries: [field](/influxdb/v1.0/concepts/glossary/#field), [tag key](/influxdb/v1.0/concepts/glossary/#tag-key), [tag set](/influxdb/v1.0/concepts/glossary/#tag-set), [tag value](/influxdb/v1.0/concepts/glossary/#tag-value)
 
 ## tag key  
 The key part of the key-value pair that makes up a tag.
 Tag keys are strings and they store metadata.
-Tag keys are indexed so queries on tag keys are performant.
-
-*Query tip:* Compare tag keys to field keys; field keys are not indexed.
+Tag keys are indexed.
 
 Related entries: [field key](/influxdb/v1.0/concepts/glossary/#field-key), [tag](/influxdb/v1.0/concepts/glossary/#tag), [tag set](/influxdb/v1.0/concepts/glossary/#tag-set), [tag value](/influxdb/v1.0/concepts/glossary/#tag-value)
 
 ## tag set
 The collection of tag keys and tag values on a point.
 
-Related entries: [point](/influxdb/v1.0/concepts/glossary/#point), [series](/influxdb/v1.0/concepts/glossary/#series), [tag](/influxdb/v1.0/concepts/glossary/#tag), [tag key](/influxdb/v1.0/concepts/glossary/#tag-key), [tag value](/influxdb/v1.0/concepts/glossary/#tag-value)
+Related entries:
+[metaseries](#metaseries),
+[point](#point),
+[series](#series),
+[tag](#tag),
+[tag key](#tag-key),
+[tag value](#tag-value)
 
 ## tag value  
 The value part of the key-value pair that makes up a tag.
 Tag values are strings and they store metadata.
-Tag values are indexed so queries on tag values are performant.
+Tag values are indexed so queries on tag values are more performant than queries on field values.
 
+*Query tip:* Compare field values to tag values; tag values are indexed.
 
 Related entries: [tag](/influxdb/v1.0/concepts/glossary/#tag), [tag key](/influxdb/v1.0/concepts/glossary/#tag-key), [tag set](/influxdb/v1.0/concepts/glossary/#tag-set)
 
@@ -291,9 +352,7 @@ When authentication is enabled, InfluxDB only executes HTTP requests that are se
 See [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/).
 
 ## values per second
-The preferred measurement of the rate at which data are persisted to InfluxDB. Write speeds are generally quoted in values per second.
-
-To calculate the values per second rate, multiply the number of points written per second by the number of values stored per point. For example, if the points have four fields each, and a batch of 5000 points is written 10 times per second, then the values per second rate is `4 field values per point * 5000 points per batch * 10 batches per second = 200,000 values per second`.
+See points per second.
 
 Related entries: [batch](/influxdb/v1.0/concepts/glossary/#batch), [field](/influxdb/v1.0/concepts/glossary/#field), [point](/influxdb/v1.0/concepts/glossary/#point), [points per second](/influxdb/v1.0/concepts/glossary/#points-per-second)
 

--- a/content/influxdb/v1.0/concepts/glossary.md
+++ b/content/influxdb/v1.0/concepts/glossary.md
@@ -222,7 +222,7 @@ Related entries:
 ## series cardinality
 The number of unique database, measurement, tag set, and field key combinations in an InfluxDB instance.
 
-For example, assume that an InfluxDB instance has a single datbase and one measurement.
+For example, assume that an InfluxDB instance has a single database and one measurement.
 The single measurement has two tag keys (`email` and `status`) and one field key (`mood_index`).
 The tag key `email` has three tag values (`lorr@influxdata.com`,`marv@influxdata.com`,`cliff@influxdata.com`) and
 the tag key `status` has two tag values (`start`,`finish`).

--- a/content/influxdb/v1.0/concepts/key_concepts.md
+++ b/content/influxdb/v1.0/concepts/key_concepts.md
@@ -19,17 +19,22 @@ We've provided a list below of all the terms we'll cover, but we recommend readi
   <tr>
     <td><a href="/influxdb/v1.0/concepts/key_concepts/#field-value">field value</a></td>
     <td><a href="/influxdb/v1.0/concepts/key_concepts/#measurement">measurement</a></td>
-    <td><a href="/influxdb/v1.0/concepts/key_concepts/#point">point</a></td>
+    <td><a href="/influxdb/v1.0/concepts/key_concepts/#metaseries">metaseries</a></td>
   </tr>
-    <tr>
+  <tr>
+    <td><a href="/influxdb/v1.0/concepts/key_concepts/#point">point</a></td>
     <td><a href="/influxdb/v1.0/concepts/key_concepts/#retention-policy">retention policy</a></td>
     <td><a href="/influxdb/v1.0/concepts/key_concepts/#series">series</a></td>
-    <td><a href="/influxdb/v1.0/concepts/key_concepts/#tag-key">tag key</a></td>
   </tr>
-    <tr>
+  <tr>
+    <td><a href="/influxdb/v1.0/concepts/key_concepts/#tag-key">tag key</a></td>
     <td><a href="/influxdb/v1.0/concepts/key_concepts/#tag-set">tag set</a></td>
     <td><a href="/influxdb/v1.0/concepts/key_concepts/#tag-value">tag value</a></td>
+  </tr>
+  <tr>
     <td><a href="/influxdb/v1.0/concepts/key_concepts/#timestamp">timestamp</a></td>
+    <td><a href=""></a></td>
+    <td><a href=""></a></td>
   </tr>
 </table>
 
@@ -60,13 +65,13 @@ Now that you've seen some sample data in InfluxDB this section covers what it al
 
 InfluxDB is a time series database so it makes sense to start with what is at the root of everything we do: time.
 In the data above there's a column called `time` - all data in InfluxDB have that column.
-`time` stores timestamps, and the <a name="timestamp"></a>*timestamp* shows the date and time, in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) UTC, associated with particular data.
+`time` stores timestamps, and the <a name="timestamp"></a>**timestamp** shows the date and time, in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) UTC, associated with particular data.
 
 The next two columns, called `butterflies` and `honeybees`, are fields.
 Fields are made up of field keys and field values.
-<a name="field-key"></a>*Field keys* (`butterflies` and `honeybees`) are strings and they store metadata; the field key `butterflies` tells us that the field values `12`-`7` refer to butterflies and the field key `honeybees` tells us that the field values `23`-`22` refer to, well, honeybees.
+<a name="field-key"></a>**Field keys** (`butterflies` and `honeybees`) are strings and they store metadata; the field key `butterflies` tells us that the field values `12`-`7` refer to butterflies and the field key `honeybees` tells us that the field values `23`-`22` refer to, well, honeybees.
 
-<a name="field-value"></a>*Field values* are your data; they can be strings, floats, integers, or booleans, and, because InfluxDB is a time series database, a field value is always associated with a timestamp.
+<a name="field-value"></a>**Field values** are your data; they can be strings, floats, integers, or booleans, and, because InfluxDB is a time series database, a field value is always associated with a timestamp.
 The field values in the sample data are:
 
 ```
@@ -80,7 +85,7 @@ The field values in the sample data are:
 7    22
 ```
 
-In the data above, the collection of field-key and field-value pairs make up a <a name="field-set"></a>*field set*.
+In the data above, the collection of field-key and field-value pairs make up a <a name="field-set"></a>**field set**.
 Here are all eight field sets in the sample data:
 
 * `butterflies = 12   honeybees = 23`
@@ -93,20 +98,19 @@ Here are all eight field sets in the sample data:
 * `butterflies = 7    honeybees = 22`
 
 Fields are a required piece of InfluxDB's data structure - you cannot have data in InfluxDB without fields.
-It's also important to note that fields are not indexed.
+It's also important to note that field values are not indexed.
 [Queries](/influxdb/v1.0/concepts/glossary/#query) that use field values as filters must scan all values that match the other conditions in the query.
 As a result, those queries are not performant relative to queries on tags (more on tags below).
 In general, fields should not contain commonly-queried metadata.
 
-
 The last two columns in the sample data, called `location` and `scientist`, are tags.
 Tags are made up of tag keys and tag values.
-Both <a name="tag-key"></a>*tag keys* and <a name="tag-value"></a>*tag values* are stored as strings and record metadata.
+Both <a name="tag-key"></a>**tag keys** and <a name="tag-value"></a>**tag values** are stored as strings and record metadata.
 The tag keys in the sample data are `location` and `scientist`.
 The tag key `location` has two tag values: `1` and `2`.
 The tag key `scientist` also has two tag values: `langstroth` and `perpetua`.
 
-In the data above, the <a name="tag-set"></a>*tag set* is the different combinations of all the tag key-value pairs.
+In the data above, the <a name="tag-set"></a>**tag set** is the different combinations of all the tag key-value pairs.
 The four tag sets in the sample data are:
 
 * `location = 1`, `scientist = langstroth`
@@ -125,7 +129,7 @@ This means that queries on tags are faster and that tags are ideal for storing c
 > `SELECT * FROM "census" WHERE "butterflies" = 1`  
 > `SELECT * FROM "census" WHERE "honeybees" = 23`
 
-> Because fields aren't indexed, InfluxDB scans every value of `butterflies`  in the first query and every value of `honeybees` in the second query before it provides a response.
+> Because field values aren't indexed, InfluxDB scans every value of `butterflies`  in the first query and every value of `honeybees` in the second query before it provides a response.
 That behavior can hurt query response times - especially on a much larger scale.
 To optimize your queries, it may be beneficial to rearrange your [schema](/influxdb/v1.0/concepts/glossary/#schema) such that the fields (`butterflies` and `honeybees`) become the tags and the tags (`location` and `scientist`) become the fields:
 
@@ -143,48 +147,60 @@ time&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbs
 
 > Now that `butterflies` and `honeybees` are tags, InfluxDB won't have to scan every one of their values when it performs the queries above - this means that your queries are even faster.
 
-The <a name=measurement></a>*measurement* acts as a container for tags, fields, and the `time` column, and the measurement name is the description of the data that are stored in the associated fields.
+The <a name=measurement></a>**measurement** acts as a container for tags, fields, and the `time` column, and the measurement name is the description of the data that are stored in the associated fields.
 Measurement names are strings, and, for any SQL users out there, a measurement is conceptually similar to a table.
 The only measurement in the sample data is `census`.
 The name `census` tells us that the field values record the number of `butterflies` and `honeybees` - not their size, direction, or some sort of happiness index.
 
 A single measurement can belong to different retention policies.
-A <a name="retention-policy"></a>*retention policy* describes how long InfluxDB keeps data (`DURATION`) and how many copies of those data are stored in the cluster (`REPLICATION`).
+A <a name="retention-policy"></a>**retention policy** describes how long InfluxDB keeps data (`DURATION`).
+If you're working with a [cluster](https://docs.influxdata.com/enterprise/v1.0/) the retention policy also determines how many copies of those data are stored in the cluster (`REPLICATION`).
 If you're interested in reading more about retention policies, check out [Database Management](/influxdb/v1.0/query_language/database_management/#retention-policy-management).
 
-<dt> Replication factors do not serve a purpose with single node instances.
-</dt>
-
 In the sample data, everything in the `census` measurement belongs to the `autogen` retention policy.
-InfluxDB automatically creates that retention policy; it has an infinite duration and a replication factor set to one.
+InfluxDB automatically creates that retention policy; it has an infinite duration and a replication factor set to one
+or to the number of data nodes in the cluster.
 
-Now that you're familiar with measurements, tag sets, and retention policies it's time to discuss series.
-In InfluxDB, a <a name=series></a>*series* is the collection of data that share a retention policy, measurement, and tag set.
-The data above consist of four series:
+Now that you're familiar with measurements, tag sets, and field keys it's time to discuss metaseries and series.
+In InfluxDB, a <a name=metaseries></a>**metaseries** is the collection of data that share a measurement and tag set.
+The data above consist of four metaseries:
 
-| Arbitrary series number  |  Retention policy | Measurement  |  Tag set |
+| Arbitrary metaseries number | Measurement  |  Tag set |
+|---|---|---|
+| series 1  | `census`  | `location = 1`,`scientist = langstroth` |
+| series 2 |  `census` |  `location = 2`,`scientist = langstroth` |
+| series 3 | `census`  | `location = 1`,`scientist = perpetua` |
+| series 4 |  `census` |  `location = 2`,`scientist = perpetua` |
+
+A <a name=series></a>**series** is the collection of data that share a measurement, tag set, and field key.
+The data above consist of eight series:
+
+| Arbitrary series number | Measurement  |  Tag set | Field key |
 |---|---|---|---|
-| series 1  | `autogen` | `census`  | `location = 1`,`scientist = langstroth` |
-| series 2 | `autogen` |  `census` |  `location = 2`,`scientist = langstroth` |
-| series 3  | `autogen` | `census`  | `location = 1`,`scientist = perpetua` |
-| series 4 | `autogen` |  `census` |  `location = 2`,`scientist = perpetua` |
+| series 1  | `census`  | `location = 1`,`scientist = langstroth` | `butterflies` |
+| series 2  | `census`  | `location = 1`,`scientist = langstroth` | `honeybees` |
+| series 3 |  `census` |  `location = 2`,`scientist = langstroth` | `butterflies` |
+| series 4 |  `census` |  `location = 2`,`scientist = langstroth` | `honeybees` |
+| series 5 | `census`  | `location = 1`,`scientist = perpetua` | `butterflies` |
+| series 6 | `census`  | `location = 1`,`scientist = perpetua` | `honeybees` |
+| series 7 |  `census` |  `location = 2`,`scientist = perpetua` | `butterflies` |
+| series 8 |  `census` |  `location = 2`,`scientist = perpetua` | `honeybees` |
 
 Understanding the concept of a series is essential when designing your [schema](/influxdb/v1.0/concepts/glossary/#schema) and when working with your data in InfluxDB.
+Having a [very large](/influxdb/v1.0/guides/hardware_sizing/#general-hardware-guidelines-for-a-single-node) number of series in your database can lead to [unsustainable RAM usage](/influxdb/v1.0/troubleshooting/frequently_encountered_issues/#process-consuming-too-much-memory).
 
-Finally, a <a name="point"></a>*point* is the field set in the same series with the same timestamp.
+Finally, a <a name="point"></a>**point** is a single observation identified by its series and timestamp.
 For example, here's a single point:
 ```
-name: census
------------------
-time			               butterflies	 honeybees	 location	 scientist
-2015-08-18T00:00:00Z	 1		          30		       1		       perpetua
+time                   butterflies   location   scientist
+2015-08-18T00:00:00Z   1             1          perpetua
 ```
 
-The series in the example is defined by the retention policy (`autogen`), the measurement (`census`), and the tag set (`location = 1`, `scientist = perpetua`).
+The series in the example is defined by the measurement (`census`), tag set (`location = 1`, `scientist = perpetua`), and `field key` (`butterflies`).
 The timestamp for the point is `2015-08-18T00:00:00Z`.
 
 All of the stuff we've just covered is stored in a database - the sample data are in the database `my_database`.
-An InfluxDB <a name=database></a>*database* is similar to traditional relational databases and serves as a logical container for users, retention policies, continuous queries, and, of course, your time series data.
+An InfluxDB <a name=database></a>**database** is similar to traditional relational databases and serves as a logical container for users, retention policies, continuous queries, and, of course, your time series data.
 See [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/) and [Continuous Queries](/influxdb/v1.0/query_language/continuous_queries/) for more on those topics.
 
 Databases can have several users, continuous queries, retention policies, and measurements.

--- a/content/influxdb/v1.0/guides/writing_data.md
+++ b/content/influxdb/v1.0/guides/writing_data.md
@@ -28,10 +28,10 @@ The data consist of the [measurement](/influxdb/v1.0/concepts/glossary/#measurem
 ```bash
 curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
-When writing points, you must specify an existing database in the `db` query parameter.
+When writing data, you must specify an existing database in the `db` query parameter.
 See the [HTTP section](/influxdb/v1.0/write_protocols/write_syntax/#http) on the Write Syntax page for a complete list of the available query parameters.
 
-The body of the POST - we call this the [Line Protocol](/influxdb/v1.0/concepts/glossary/#line-protocol) - contains the time-series data that you wish to store.
+The body of the POST - we call this the [Line Protocol](/influxdb/v1.0/concepts/glossary/#line-protocol) - contains the data that you wish to store.
 They consist of a measurement, tags, fields, and a timestamp.
 InfluxDB requires a measurement name.
 Strictly speaking, tags are optional but most series include tags to differentiate data sources and to make querying both easy and efficient.
@@ -43,13 +43,15 @@ Anything that has to do with time in InfluxDB is always UTC.
 
 ### Writing multiple points
 ---
-Post multiple points to multiple series at the same time by separating each point with a new line.
+Post multiple points at the same time by separating each point with a new line.
 Batching points in this manner results in much higher performance.
 
 The following example writes three points to the database `mydb`.
-The first point belongs to the series with the measurement `cpu_load_short` and tag set `host=server02` and has the server's local timestamp.
-The second point belongs to the series with the measurement `cpu_load_short` and tag set `host=server02,region=us-west` and has the specified timestamp `1422568543702900257`.
-The third point has the same specified timestamp as the second point, but it is written to the series with the measurement `cpu_load_short` and tag set `direction=in,host=server01,region=us-west`.
+The first point belongs to the series with the measurement `cpu_load_short`, tag set `host=server02`, and field key `value`.
+It has the server's local timestamp.
+The second point belongs to the series with the measurement `cpu_load_short`, tag set `host=server02,region=us-west`, and field key `value`.
+It has the specified timestamp `1422568543702900257`.
+The third point has the same specified timestamp as the second point, but it's written to the series with the measurement `cpu_load_short`, tag set `direction=in,host=server01,region=us-west`, and field key `value`.
 <br>
 
 ```bash
@@ -58,9 +60,9 @@ cpu_load_short,host=server02,region=us-west value=0.55 1422568543702900257
 cpu_load_short,direction=in,host=server01,region=us-west value=2.0 1422568543702900257'
 ```
 
-### Writing points from a file
+### Writing data from a file
 ---
-Write points from a file by passing `@filename` to `curl`.
+Write data from a file by passing `@filename` to `curl`.
 The data in the file should follow InfluxDB's [line protocol syntax](/influxdb/v1.0/write_protocols/write_syntax/).
 
 Example of a properly-formatted file (`cpu_data.txt`):  

--- a/content/influxdb/v1.0/query_language/data_exploration.md
+++ b/content/influxdb/v1.0/query_language/data_exploration.md
@@ -28,16 +28,17 @@ The basics:
 Limit and sort your results:
 
 * [Limit query returns with `LIMIT` and `SLIMIT`](/influxdb/v1.0/query_language/data_exploration/#limit-query-returns-with-limit-and-slimit)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Limit results per series with `LIMIT`](/influxdb/v1.0/query_language/data_exploration/#limit-the-number-of-results-returned-per-series-with-limit)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Limit the number of series returned with `SLIMIT`](/influxdb/v1.0/query_language/data_exploration/#limit-the-number-of-series-returned-with-slimit)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Limit the number of points and series returned with `LIMIT` and `SLIMIT`](/influxdb/v1.0/query_language/data_exploration/#limit-the-number-of-points-and-series-returned-with-limit-and-slimit)
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Limit results per metaseries with `LIMIT`](/influxdb/v1.0/query_language/data_exploration/#limit-the-number-of-results-returned-per-metaseries-with-limit)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Limit the number of metaseries returned with `SLIMIT`](/influxdb/v1.0/query_language/data_exploration/#limit-the-number-of-metaseries-returned-with-slimit)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Limit the number of points and metaseries returned with `LIMIT` and `SLIMIT`](/influxdb/v1.0/query_language/data_exploration/#limit-the-number-of-points-and-metaseries-returned-with-limit-and-slimit)
 * [Sort query returns with `ORDER BY time DESC`](/influxdb/v1.0/query_language/data_exploration/#sort-query-returns-with-order-by-time-desc)
 * [Paginate query returns with `OFFSET` and `SOFFSET`](/influxdb/v1.0/query_language/data_exploration/#paginate-query-returns-with-offset-and-soffset)
 
 General tips on query syntax:
 
 * [Multiple statements in queries](/influxdb/v1.0/query_language/data_exploration/#multiple-statements-in-queries)
-* [Merge series in queries](/influxdb/v1.0/query_language/data_exploration/#merge-series-in-queries)
+Finally, use `GROUP BY` with `ORDER BY time DESC` to return the last five points from each measuremnt and tag set combination  
+* [Merge metaseries in queries](/influxdb/v1.0/query_language/data_exploration/#merge-metaseries-in-queries)
 * [Time syntax in queries](/influxdb/v1.0/query_language/data_exploration/#time-syntax-in-queries)  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Relative time](/influxdb/v1.0/query_language/data_exploration/#relative-time)  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Absolute time](/influxdb/v1.0/query_language/data_exploration/#absolute-time)
@@ -73,7 +74,7 @@ time			                level description	      location	       water_level
 2015-08-18T00:24:00Z	  below 3 feet		          santa_monica	   2.041
 ```
 
-The [series](/influxdb/v1.0/concepts/glossary/#series) are made up of the [measurement](/influxdb/v1.0/concepts/glossary/#measurement) `h2o_feet` and the [tag key](/influxdb/v1.0/concepts/glossary/#tag-key) `location` with the [tag values](/influxdb/v1.0/concepts/glossary/#tag-value) `santa_monica` and `coyote_creek`.
+The data are made up of the [measurement](/influxdb/v1.0/concepts/glossary/#measurement) `h2o_feet` and the [tag key](/influxdb/v1.0/concepts/glossary/#tag-key) `location` with the [tag values](/influxdb/v1.0/concepts/glossary/#tag-value) `santa_monica` and `coyote_creek`.
 There are two [fields](/influxdb/v1.0/concepts/glossary/#field): `water_level` which stores floats and `level description` which stores strings.
 All of the data are in the `NOAA_water_database` database.
 
@@ -129,7 +130,7 @@ In addition, you can specify a field's [type](/influxdb/v1.0/write_protocols/wri
 We'll go into detail about this functionality in the
 [casting section](#data-types-and-cast-operations-in-queries) of this document.
 
-Query **D** selects everything form `h2o_feet` by fully qualifying the measurement
+Query **D** selects everything from `h2o_feet` by fully qualifying the measurement
 `h2o_feet`.
 Fully qualify a measurement by specifying its database and
 [retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp) in
@@ -667,15 +668,15 @@ Use [fill()](/influxdb/v1.0/query_language/data_exploration/#the-group-by-clause
 ## Limit query returns with LIMIT and SLIMIT
 InfluxQL supports two different clauses to limit your query results:
 
-* `LIMIT <N>` returns the first \<N> [points](/influxdb/v1.0/concepts/glossary/#point) from each [series](/influxdb/v1.0/concepts/glossary/#series) in the specified measurement.
-* `SLIMIT <N>` returns every point from \<N> series in the specified measurement.
-* `LIMIT <N>` followed by `SLIMIT <N>` returns the first \<N> points from \<N> series in the specified measurement.
+* `LIMIT <N>` returns the first \<N> [points](/influxdb/v1.0/concepts/glossary/#point) from each [metaseries](/influxdb/v1.0/concepts/glossary/#metaseries) in the specified measurement.
+* `SLIMIT <N>` returns every point from \<N> metaseries in the specified measurement.
+* `LIMIT <N>` followed by `SLIMIT <N>` returns the first \<N> points from \<N> metaseries in the specified measurement.
 
-### Limit the number of results returned per series with `LIMIT`
+### Limit the number of results returned per metaseries with `LIMIT`
 ---
-Use `LIMIT <N>` with `SELECT` and `GROUP BY *` to return the first \<N> points from each series.
+Use `LIMIT <N>` with `SELECT` and `GROUP BY *` to return the first \<N> points from each [metaseries](/influxdb/v1.0/concepts/glossary/#metaseries).
 
-Return the three oldest points from each series associated with the measurement `h2o_feet`:
+Return the three oldest points from each metaseries associated with the measurement `h2o_feet`:
 ```sql
 > SELECT "water_level" FROM "h2o_feet" GROUP BY * LIMIT 3
 ```
@@ -699,13 +700,13 @@ time			              water_level
 2015-08-18T00:12:00Z	2.028
 ```
 
-> **Note:** If \<N> is greater than the number of points in the series, InfluxDB returns all points in the series.
+> **Note:** If \<N> is greater than the number of points in the metaseries, InfluxDB returns all points in the metaseries.
 
-### Limit the number of series returned with `SLIMIT`
+### Limit the number of metaseries returned with `SLIMIT`
 ---
-Use `SLIMIT <N>` with `SELECT` and `GROUP BY *` to return every point from \<N> series.
+Use `SLIMIT <N>` with `SELECT` and `GROUP BY *` to return every point from \<N> [metaseries](/influxdb/v1.0/concepts/glossary/#metaseries).
 
-Return everything from one of the series associated with the measurement `h2o_feet`:
+Return everything from one of the metaseries associated with the measurement `h2o_feet`:
 ```sql
 > SELECT "water_level" FROM "h2o_feet" GROUP BY * SLIMIT 1
 ```
@@ -725,13 +726,13 @@ time			              water_level
 2015-09-18T16:24:00Z	3.235
 ```
 
-> **Note:** If \<N> is greater than the number of series associated with the specified measurement, InfluxDB returns all points from every series.
+> **Note:** If \<N> is greater than the number of metaseries associated with the specified measurement, InfluxDB returns all points from every metaseries.
 
-### Limit the number of points and series returned with `LIMIT` and `SLIMIT`
+### Limit the number of points and metaseries returned with `LIMIT` and `SLIMIT`
 ---
-Use `LIMIT <N1>` followed by `SLIMIT <N2>` with `GROUP BY *` to return \<N1> points from \<N2> series.
+Use `LIMIT <N1>` followed by `SLIMIT <N2>` with `GROUP BY *` to return \<N1> points from \<N2> [metaseries](/influxdb/v1.0/concepts/glossary/#metaseries).
 
-Return the three oldest points from one of the series associated with the measurement `h2o_feet`:
+Return the three oldest points from one of the metaseries associated with the measurement `h2o_feet`:
 ```sql
 > SELECT "water_level" FROM "h2o_feet" GROUP BY * LIMIT 3 SLIMIT 1
 ```
@@ -747,8 +748,8 @@ time			               water_level
 2015-08-18T00:12:00Z	 7.887
 ```
 
-> **Note:** If \<N1> is greater than the number of points in the series, InfluxDB returns all points in the series.
-If \<N2> is greater than the number of series associated with the specified measurement, InfluxDB returns points from every series.
+> **Note:** If \<N1> is greater than the number of points in the metaseries, InfluxDB returns all points in the metaseries.
+If \<N2> is greater than the number of metaseries associated with the specified measurement, InfluxDB returns points from every metaseries.
 
 ## Sort query returns with ORDER BY time DESC
 By default, InfluxDB returns results in ascending time order - so the first points that are returned are the oldest points by timestamp.
@@ -852,10 +853,10 @@ time			               water_level
 2015-08-18T00:30:00Z	 7.5
 ```
 
-### Use `SOFFSET` to paginate the series returned
+### Use `SOFFSET` to paginate the metaseries returned
 ---
 
-For example, get the first three points from a single series:
+For example, get the first three points from one [metaseries](/influxdb/v1.0/concepts/glossary/#metaseries):
 ```sql
 > SELECT "water_level" FROM "h2o_feet" GROUP BY * LIMIT 3 SLIMIT 1
 ```
@@ -871,7 +872,7 @@ time			               water_level
 2015-08-18T00:12:00Z	 7.887
 ```
 
-Then get the first three points from the next series:
+Then get the first three points from the next metaseries:
 ```sql
 > SELECT "water_level" FROM "h2o_feet" GROUP BY * LIMIT 3 SLIMIT 1 SOFFSET 1
 ```
@@ -897,15 +898,15 @@ For example:
 > SELECT MEAN("water_level") FROM "h2o_feet" WHERE time > now() - 2w GROUP BY "location",time(24h) fill(none); SELECT COUNT("water_level") FROM "h2o_feet" WHERE time > now() - 2w GROUP BY "location",time(24h) fill(80)
 ```
 
-## Merge series in queries
+## Merge metaseries in queries
 
-In InfluxDB, queries merge series automatically.
+In InfluxDB, queries merge [metaseries](/influxdb/v1.0/concepts/glossary/#metaseries) automatically.
 
-The `NOAA_water_database` database has two [series](/influxdb/v1.0/concepts/glossary/#series).
-The first series is made up of the measurement `h2o_feet` and the tag key `location` with the tag value `coyote_creek`.
-The second series is made of up the measurement `h2o_feet` and the tag key `location` with the tag value `santa_monica`.
+The `NOAA_water_database` database has two metaseries.
+The first metaseries is made up of the measurement `h2o_feet` and the tag key `location` with the tag value `coyote_creek`.
+The second metaseries is made of up the measurement `h2o_feet` and the tag key `location` with the tag value `santa_monica`.
 
-The following query automatically merges those two series when it calculates the [average](/influxdb/v1.0/query_language/functions/#mean) `water_level`:
+The following query automatically merges those two metaseries when it calculates the [average](/influxdb/v1.0/query_language/functions/#mean) `water_level`:
 
 ```sql
 > SELECT MEAN("water_level") FROM "h2o_feet"
@@ -919,7 +920,7 @@ time			               mean
 1970-01-01T00:00:00Z	 4.442107025822521
 ```
 
-If you only want the `MEAN()` `water_level` for the first series, specify the tag set in the `WHERE` clause:
+If you only want the `MEAN()` `water_level` for the first metaseries, specify the tag set in the `WHERE` clause:
 ```sql
 > SELECT MEAN("water_level") FROM "h2o_feet" WHERE "location" = 'coyote_creek'
 ```

--- a/content/influxdb/v1.0/query_language/database_management.md
+++ b/content/influxdb/v1.0/query_language/database_management.md
@@ -12,8 +12,8 @@ InfluxQL offers a full suite of administrative commands.
 * [Data management](/influxdb/v1.0/query_language/database_management/#data-management)  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Create a database with `CREATE DATABASE`](/influxdb/v1.0/query_language/database_management/#create-a-database-with-create-database)  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Delete a database with `DROP DATABASE`](/influxdb/v1.0/query_language/database_management/#delete-a-database-with-drop-database)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Drop series from the index with `DROP SERIES`](/influxdb/v1.0/query_language/database_management/#drop-series-from-the-index-with-drop-series)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Delete series with `DELETE`](/influxdb/v1.0/query_language/database_management/#delete-series-with-delete)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Drop metaseries from the index with `DROP SERIES`](/influxdb/v1.0/query_language/database_management/#drop-metaseries-from-the-index-with-drop-series)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Delete data with `DELETE`](/influxdb/v1.0/query_language/database_management/#delete-data-with-delete)  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Delete measurements with `DROP MEASUREMENT`](/influxdb/v1.0/query_language/database_management/#delete-measurements-with-drop-measurement)  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Delete a shard with `DROP SHARD`](/influxdb/v1.0/query_language/database_management/#delete-a-shard-with-drop-shard)
 
@@ -82,14 +82,14 @@ Drop the database NOAA_water_database:
 A successful `DROP DATABASE` query returns an empty result.
 If you attempt to drop a database that does not exist, InfluxDB does not return an error.
 
-### Drop series from the index with DROP SERIES
+### Drop metaseries from the index with DROP SERIES
 ---
-The `DROP SERIES` query deletes all points from a [series](/influxdb/v1.0/concepts/glossary/#series) in a database,
-and it drops the series from the index.
+The `DROP SERIES` query deletes all points from a [metaseries](/influxdb/v1.0/concepts/glossary/#metaseries) in a database,
+and it drops the metaseries from the index.
 
 > **Note:** `DROP SERIES` does not support time intervals in the `WHERE` clause.
 See
-[`DELETE`](/influxdb/v1.0/query_language/database_management/#delete-series-with-delete)
+[`DELETE`](/influxdb/v1.0/query_language/database_management/#delete-data-with-delete)
 for that functionality.
 
 The query takes the following form, where you must specify either the `FROM` clause or the `WHERE` clause:
@@ -97,29 +97,28 @@ The query takes the following form, where you must specify either the `FROM` cla
 DROP SERIES FROM <measurement_name[,measurement_name]> WHERE <tag_key>='<tag_value>'
 ```
 
-Drop all series from a single measurement:
+Drop all metaseries from a single measurement:
 ```sql
 > DROP SERIES FROM "h2o_feet"
 ```
 
-Drop series with a specific tag pair from a single measurement:
+Drop metaseries with a specific tag pair from a single measurement:
 ```sql
 > DROP SERIES FROM "h2o_feet" WHERE "location" = 'santa_monica'
 ```
 
-Drop all points in the series that have a specific tag pair from all measurements in the database:
+Drop all points in the metaseries that have a specific tag pair from all measurements in the database:
 ```sql
 > DROP SERIES WHERE "location" = 'santa_monica'
 ```
 
 A successful `DROP SERIES` query returns an empty result.
 
-### Delete series with DELETE
+### Delete data with DELETE
 ---
-The `DELETE` query deletes all points from a
-[series](/influxdb/v1.0/concepts/glossary/#series) in a database.
+The `DELETE` query deletes all specified data from a database.
 Unlike
-[`DROP SERIES`](/influxdb/v1.0/query_language/database_management/#drop-series-from-the-index-with-drop-series), it does not drop the series from the index and it supports time intervals
+[`DROP SERIES`](/influxdb/v1.0/query_language/database_management/#drop-metaseries-from-the-index-with-drop-series), `DELETE` does not drop the [metaseries](/influxdb/v1.0/concepts/glossary/#metaseries) from the index and it supports time intervals
 in the `WHERE` clause.
 
 The query takes the following form where you must include either the `FROM`

--- a/content/influxdb/v1.0/query_language/functions.md
+++ b/content/influxdb/v1.0/query_language/functions.md
@@ -963,7 +963,7 @@ In the case of a tie, InfluxDB returns the value with the earlier timestamp.
 </dt>
 
 ## DERIVATIVE()
-Returns the rate of change for the values in a single [field](/influxdb/v1.0/concepts/glossary/#field) in a [series](/influxdb/v1.0/concepts/glossary/#series).
+Returns the rate of change for the values in a single [field](/influxdb/v1.0/concepts/glossary/#field).
 InfluxDB calculates the difference between chronological field values and converts those results into the rate of change per `unit`.
 The `unit` argument is optional and, if not specified, defaults to one second (`1s`).
 
@@ -1413,7 +1413,7 @@ values; the first result in the `moving_average` column the average of `2.064`
 and `2.028`, and the second result is the average of `2.028` and `2.041`.
 
 ## NON_NEGATIVE_DERIVATIVE()
-Returns the non-negative rate of change for the values in a single [field](/influxdb/v1.0/concepts/glossary/#field) in a [series](/influxdb/v1.0/concepts/glossary/#series).
+Returns the non-negative rate of change for the values in a single [field](/influxdb/v1.0/concepts/glossary/#field).
 InfluxDB calculates the difference between chronological field values and converts those results into the rate of change per `unit`.
 The `unit` argument is optional and, if not specified, defaults to one second (`1s`).
 

--- a/content/influxdb/v1.0/query_language/schema_exploration.md
+++ b/content/influxdb/v1.0/query_language/schema_exploration.md
@@ -11,7 +11,7 @@ The following sections cover useful query syntax for exploring your schema (that
 
 * [See all databases with `SHOW DATABASES`](/influxdb/v1.0/query_language/schema_exploration/#see-all-databases-with-show-databases)
 * [Explore retention policies with `SHOW RETENTION POLICIES`](/influxdb/v1.0/query_language/schema_exploration/#explore-retention-policies-with-show-retention-policies)
-* [Explore series with `SHOW SERIES`](/influxdb/v1.0/query_language/schema_exploration/#explore-series-with-show-series)
+* [Explore metaseries with `SHOW SERIES`](/influxdb/v1.0/query_language/schema_exploration/#explore-metaseries-with-show-series)
 * [Explore measurements with `SHOW MEASUREMENTS`](/influxdb/v1.0/query_language/schema_exploration/#explore-measurements-with-show-measurements)
 * [Explore tag keys with `SHOW TAG KEYS`](/influxdb/v1.0/query_language/schema_exploration/#explore-tag-keys-with-show-tag-keys)
 * [Explore tag values with `SHOW TAG VALUES`](/influxdb/v1.0/query_language/schema_exploration/#explore-tag-values-with-show-tag-values)
@@ -70,14 +70,14 @@ one_day_only	    24h0m0s		 1h0m0s			           1		       false
 three_days_only	 72h0m0s		 24h0m0s			          1		       true
 ```
 
-## Explore series with `SHOW SERIES`
-The `SHOW SERIES` query returns the distinct [series](/influxdb/v1.0/concepts/glossary/#series) in your database and takes the following form, where the `FROM` and `WHERE` clauses are optional:
+## Explore metaseries with `SHOW SERIES`
+The `SHOW SERIES` query returns the distinct [metaseries](/influxdb/v1.0/concepts/glossary/#metaseries) in your database and takes the following form, where the `FROM` and `WHERE` clauses are optional:
 
 ```sql
 SHOW SERIES [FROM <measurement_name> [WHERE <tag_key> [= '<tag_value>' | =~ <regular_expression>]]]
 ```
 
-Return all series in the database `NOAA_water_database`:
+Return all metaseries in the database `NOAA_water_database`:
 ```sql
 > SHOW SERIES
 ```
@@ -101,16 +101,16 @@ h2o_temperature,location=coyote_creek
 h2o_temperature,location=santa_monica
 ```
 
-`SHOW SERIES` organizes its output similar to the [line protocol](/influxdb/v1.0/write_protocols/line/) format.
+`SHOW SERIES` organizes its output similar to the [line protocol](/influxdb/v1.0/concepts/glossary/#line-protocol) format.
 Everything before the first comma is the [measurement](/influxdb/v1.0/concepts/glossary/#measurement) name.
 Everything after the first comma is either a [tag key](/influxdb/v1.0/concepts/glossary/#tag-key) or a [tag value](/influxdb/v1.0/concepts/glossary/#tag-value).
 
-From the output above you can see that the data in the database `NOAA_water_database` have five different measurements and 14 different series.
+From the output above you can see that the data in the database `NOAA_water_database` have five different measurements and 14 different metaseries.
 The measurements are `average_temperature`, `h2o_feet`, `h2o_pH`, `h2o_quality`, and `h2o_temperature`.
-Every measurement has the tag key `location` with the tag values `coyote_creek` and `santa_monica` - that makes 10 series.
-The measurement `h2o_quality` has the additional tag key `randtag` with the tag values `1`,`2`, and `3` - that makes 14 series.
+Every measurement has the tag key `location` with the tag values `coyote_creek` and `santa_monica` - that makes 10 metaseries.
+The measurement `h2o_quality` has the additional tag key `randtag` with the tag values `1`,`2`, and `3` - that makes 14 metaseries.
 
-Return series for a specific measurement:
+Return metaseries for a specific measurement:
 ```sql
 > SHOW SERIES FROM "h2o_quality"
 ```
@@ -126,7 +126,7 @@ h2o_quality,location=santa_monica,randtag=2
 h2o_quality,location=santa_monica,randtag=3
 ```
 
-Return series for a specific measurement and tag set:
+Return metaseries for a specific measurement and tag set:
 ```sql
 > SHOW SERIES FROM "h2o_quality" WHERE "location" = 'coyote_creek'
 ```

--- a/content/influxdb/v1.0/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v1.0/troubleshooting/frequently_encountered_issues.md
@@ -23,6 +23,7 @@ Where applicable, it links to outstanding issues on GitHub.
 * [Identifying write precision from returned timestamps](#identifying-write-precision-from-returned-timestamps)  
 * [Single quoting and double quoting in queries](#single-quoting-and-double-quoting-in-queries)  
 * [Missing data after creating a new `DEFAULT` retention policy](#missing-data-after-creating-a-new-default-retention-policy)
+* [Querying for metaseries cardinality](#querying-for-metaseries-cardinality)
 * [Using `OR` with absolute time in the `WHERE` clause](#using-or-with-absolute-time-in-the-where-clause)
 
 **Writing data**  
@@ -280,6 +281,26 @@ time			               count
 1970-01-01T00:00:00Z	 8
 ```
 
+## Querying for metaseries cardinality
+
+The following queries return
+[metaseries](/influxdb/v1.0/concepts/glossary/#metaseries) cardinality:
+
+#### Metaseries cardinality per database:
+
+```
+SELECT numSeries FROM "_internal".."database" GROUP BY "database" ORDER BY desc LIMIT 1
+```
+
+#### Metaseries cardinality across all databases:
+
+```
+SELECT sum(numSeries) AS “total_series" FROM “_internal".."database" WHERE time > now() - 10s
+```
+
+> **Note:** Changes to the [`[monitor]`](/influxdb/v1.0/administration/config/#monitor) section in the configuration file may affect query results.
+
+
 ## Using `OR` with absolute time in the `WHERE` clause
 
 Currently, InfluxQL does not support using `OR` with
@@ -358,7 +379,7 @@ To store both points:
     New point: `cpu_load,hostname=server02,az=us_west val_1=89 1234567890000001`
 
     After writing the new point to InfluxDB:
-    
+
     ```
     > SELECT * FROM "cpu_load" WHERE time >= 1234567890000000 and time <= 1234567890000001
     name: cpu_load

--- a/content/influxdb/v1.0/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v1.0/troubleshooting/frequently_encountered_issues.md
@@ -23,7 +23,6 @@ Where applicable, it links to outstanding issues on GitHub.
 * [Identifying write precision from returned timestamps](#identifying-write-precision-from-returned-timestamps)  
 * [Single quoting and double quoting in queries](#single-quoting-and-double-quoting-in-queries)  
 * [Missing data after creating a new `DEFAULT` retention policy](#missing-data-after-creating-a-new-default-retention-policy)
-* [Querying for series cardinality](#querying-for-series-cardinality)
 * [Using `OR` with absolute time in the `WHERE` clause](#using-or-with-absolute-time-in-the-where-clause)
 
 **Writing data**  
@@ -281,22 +280,6 @@ time			               count
 1970-01-01T00:00:00Z	 8
 ```
 
-## Querying for series cardinality
-
-The following queries return [series cardinality](/influxdb/v1.0/concepts/glossary/#series-cardinality):
-
-#### Series cardinality per database:
-```
-SELECT numSeries FROM "_internal".."database" GROUP BY "database" ORDER BY desc LIMIT 1
-```
-#### Series cardinality across all database:
-```
-SELECT sum(numSeries) AS “total_series" FROM “_internal".."database" WHERE time > now() - 10s
-```
-
-> **Note:** Changes to the [`[monitor]`](/influxdb/v1.0/administration/config/#monitor)
-section in the configuration file may affect query results.
-
 ## Using `OR` with absolute time in the `WHERE` clause
 
 Currently, InfluxQL does not support using `OR` with
@@ -323,56 +306,66 @@ Writes an integer: `value=100i`
 Writes a float: `value=100`
 
 ## Writing duplicate points
-A point is uniquely identified by the measurement name, [tag set](/influxdb/v1.0/concepts/glossary/#tag-set), and timestamp.
-If you submit a new point with the same measurement, tag set, and timestamp as an existing point, the field set becomes the union of the old field set and the new field set, where any ties go to the new field set.
+A point is uniquely identified by the measurement name, [tag set](/influxdb/v1.0/concepts/glossary/#tag-set), [field key](/influxdb/v1.0/concepts/glossary/#field-key), and timestamp.
+If you submit a new point with the same measurement, tag set, field key, and timestamp as an existing point, InfluxDB overwrites the existing point with the new point.
 This is the intended behavior.
 
 For example:
 
-Old point: `cpu_load,hostname=server02,az=us_west val_1=24.5,val_2=7 1234567890000000`
+Old point: `cpu_load,hostname=server02,az=us_west val_1=51 1234567890000000`
 
-New point: `cpu_load,hostname=server02,az=us_west val_1=5.24 1234567890000000`
+New point: `cpu_load,hostname=server02,az=us_west val_1=89 1234567890000000`
 
-After you submit the new point, InfluxDB overwrites `val_1` with the new field value and leaves the field `val_2` alone:
+After you submit the new point, InfluxDB overwrites `val_1` with the new field value:
 ```
 > SELECT * FROM "cpu_load" WHERE time = 1234567890000000
 name: cpu_load
 --------------
-time			                  az	      hostname	 val_1	 val_2
-1970-01-15T06:56:07.89Z	 us_west	 server02	 5.24	  7
+time               az        hostname   val_1
+1234567890000000   us_west   server02   51
+
+> INSERT cpu_load,hostname=server02,az=us_west val_1=89 1234567890000000
+
+> SELECT * FROM "cpu_load" WHERE time = 1234567890000000
+name: cpu_load
+--------------
+time               az        hostname   val_1
+1234567890000000   us_west   server02   89
 ```
 
 To store both points:
 
 * Introduce an arbitrary new tag to enforce uniqueness.
 
-    Old point: `cpu_load,hostname=server02,az=us_west,uniq=1 val_1=24.5,val_2=7 1234567890000000`
+    Old point: `cpu_load,hostname=server02,az=us_west,uniq=1 val_1=51 1234567890000000`
 
-    New point: `cpu_load,hostname=server02,az=us_west,uniq=2 val_1=5.24 1234567890000000`
+    New point: `cpu_load,hostname=server02,az=us_west,uniq=2 val_1=89 1234567890000000`
 
     After writing the new point to InfluxDB:
+
     ```
-  > SELECT * FROM "cpu_load" WHERE time = 1234567890000000
-  name: cpu_load
-  --------------
-  time			            az	     hostname	uniq	val_1	val_2
-  1970-01-15T06:56:07.89Z	us_west	 server02	1	    24.5	7
-  1970-01-15T06:56:07.89Z	us_west	 server02	2	    5.24
+    > SELECT * FROM "cpu_load" WHERE time = 1234567890000000
+    name: cpu_load
+    --------------
+    time               az        hostname   uniq   val_1
+    1234567890000000   us_west   server02   1      51
+    1234567890000000   us_west   server02   2      89
     ```
 * Increment the timestamp by a nanosecond.
 
-    Old point: `cpu_load,hostname=server02,az=us_west val_1=24.5,val_2=7 1234567890000000`
+    Old point: `cpu_load,hostname=server02,az=us_west val_1=51 1234567890000000`
 
-    New point: `cpu_load,hostname=server02,az=us_west val_1=5.24 1234567890000001`
+    New point: `cpu_load,hostname=server02,az=us_west val_1=89 1234567890000001`
 
     After writing the new point to InfluxDB:
+    
     ```
     > SELECT * FROM "cpu_load" WHERE time >= 1234567890000000 and time <= 1234567890000001
     name: cpu_load
     --------------
-    time				             az	      hostname	 val_1	val_2
-    1970-01-15T06:56:07.89Z		     us_west  server02	 24.5	 7
-    1970-01-15T06:56:07.890000001Z	 us_west  server02	 5.24
+    time               az        hostname   val_1
+    1234567890000000   us_west   server02   51
+    1234567890000001   us_west   server02   89
     ```
 
 ## Getting an unexpected error when sending data over the HTTP API
@@ -431,9 +424,9 @@ See the [Line Protocol Syntax](/influxdb/v1.0/write_protocols/write_syntax/) pag
 
 # Administration
 ## Process consuming too much memory
-InfluxDB maintains an in-memory index of every [series](/influxdb/v1.0/concepts/glossary/#series) in the system. As the number of unique series grows, so does the RAM usage. High [series cardinality](/influxdb/v1.0/concepts/glossary/#series-cardinality) can lead to the operating system killing the InfluxDB process with an out of memory (OOM) exception. See [Querying for series cardinality](/influxdb/v1.0/troubleshooting/frequently_encountered_issues/#querying-for-series-cardinality) to learn how to query for series cardinality.
+InfluxDB maintains an in-memory index of every [series](/influxdb/v1.0/concepts/glossary/#series) in the system. As the number of unique series grows, so does the RAM usage. High [series cardinality](/influxdb/v1.0/concepts/glossary/#series-cardinality) can lead to the operating system killing the InfluxDB process with an out of memory (OOM) exception.
 
-To reduce series cardinality, series must be dropped from the index. [`DROP DATABASE`], [`DROP MEASUREMENT`], and [`DROP SERIES`] will all remove series from the index and reduce the overall series cardinality. 
+To reduce series cardinality, series must be dropped from the index. [`DROP DATABASE`], [`DROP MEASUREMENT`], and [`DROP SERIES`] will all remove series from the index and reduce the overall series cardinality.
 
 > **Note:** `DROP` commands are usually CPU-intensive, as they frequently trigger a TSM compaction. Issuing `DROP` queries at a high frequency may significantly impact write and other query throughput.
 

--- a/content/influxdb/v1.0/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.0/write_protocols/line_protocol_reference.md
@@ -229,10 +229,9 @@ write Line Protocol to the database.
 
 ### Duplicate points
 
-A point is uniquely identified by the measurement name, tag set, and timestamp.
-If you submit Line Protocol with the same measurement, tag set, and timestamp,
-but with a different field set, the field set becomes the union of the old
-field set and the new field set, where any conflicts favor the new field set.
+A point is uniquely identified by the measurement name, tag set, field key, and timestamp.
+If you submit Line Protocol with the same measurement, tag set, field key, and timestamp
+InfluxDB will overwrite the existing point with the new point.
 
 See
 [Frequently Encountered Issues](/influxdb/v1.0/troubleshooting/frequently_encountered_issues/#writing-duplicate-points)

--- a/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
@@ -413,10 +413,9 @@ on the [HTTP API](/influxdb/v1.0/tools/api/#write), the
 
 ### Duplicate points
 
-A point is uniquely identified by the measurement name, tag set, and timestamp.
-If you submit Line Protocol with the same measurement, tag set, and timestamp,
-but with a different field set, the field set becomes the union of the old
-field set and the new field set, where any conflicts favor the new field set.
+A point is uniquely identified by the measurement name, tag set, field key, and timestamp.
+If you submit Line Protocol with the same measurement, tag set, field key, and timestamp,
+InfluxDB will overwrite the existing point with the new point.
 
 See
 [Frequently Encountered Issues](/influxdb/v1.0/troubleshooting/frequently_encountered_issues/#writing-duplicate-points)


### PR DESCRIPTION
### Concepts/definitions

This PR updates the definitions for:
- series (it now includes field key)
- points
- points per second
- values per second 

(I believe points per second and values per second are essentially the same now)

The PR also introduces the concept of metaseries - the measurement-tag-set combination that we previously called series.
### Query description updates

`DROP SERIES` drops metaseries instead of series and `SHOW SERIES` shows metaseries instead of series.

`SLIMIT` limits metaseries, not series.
### Issues
- The PR removes the queries for series cardinality from the Frequently Encountered Issues page. If anyone knows how to query `_internal` to get the actual series cardinality let me know. The `database` measurement that we were using initially only has data on `numMeasurements` and `numSeries` (where `numSeries` does not include field keys) and I'm not sure how to get the number of field keys in there.
- There's no transition documentation that lets users know about the series definition change. Any ideas about how/where to put this are appreciated.

Fixes https://github.com/influxdata/docs.influxdata.com/issues/668
