### PR TITLE
Redirect blank home pages to latest version

### DIFF
--- a/content/chronograf/index.md
+++ b/content/chronograf/index.md
@@ -1,5 +1,4 @@
 ---
-title: "Chronograf"
+type: chronograf
+layout: list
 ---
-
-The Chronograf documentation is currently under construction.

--- a/content/enterprise/index.md
+++ b/content/enterprise/index.md
@@ -1,3 +1,4 @@
 ---
-title: Enterprise Documentation
+type: enterprise
+layout: list
 ---

--- a/content/influxdb/index.md
+++ b/content/influxdb/index.md
@@ -1,3 +1,4 @@
 ---
-title: InfluxDB Documentation
+type: influxdb
+layout: list
 ---

--- a/content/kapacitor/index.md
+++ b/content/kapacitor/index.md
@@ -1,4 +1,4 @@
-+++
-title = "Kapacitor"
-
-+++
+---
+type: kapacitor
+layout: list
+---

--- a/content/telegraf/index.md
+++ b/content/telegraf/index.md
@@ -1,5 +1,4 @@
 ---
-title: Telegraf Documentation
+type: telegraf
+layout: list
 ---
-
-The Telegraf documentation is currently under construction.

--- a/layouts/chronograf/list.html
+++ b/layouts/chronograf/list.html
@@ -1,0 +1,3 @@
+<head>
+<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/chronograf/latest/" />
+</head>

--- a/layouts/enterprise/list.html
+++ b/layouts/enterprise/list.html
@@ -1,0 +1,3 @@
+<head>
+<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/enterprise/latest/" />
+</head>

--- a/layouts/influxdb/list.html
+++ b/layouts/influxdb/list.html
@@ -1,0 +1,3 @@
+<head>
+<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/influxdb/latest/" />
+</head>

--- a/layouts/kapacitor/list.html
+++ b/layouts/kapacitor/list.html
@@ -1,0 +1,3 @@
+<head>
+<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/kapacitor/latest/" />
+</head>

--- a/layouts/telegraf/list.html
+++ b/layouts/telegraf/list.html
@@ -1,0 +1,3 @@
+<head>
+<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/telegraf/latest/" />
+</head>


### PR DESCRIPTION
Instead of the blank homepages (like `/influxdb/`):
![image](https://cloud.githubusercontent.com/assets/8750814/18492539/a6236752-79c0-11e6-957f-600ea432b46f.png)

This redirects those homepages to the lastest version (that is, `/influxdb/v1.0/`)

Fixes #676