### PR TITLE
Quick formatting fixes

### DIFF
--- a/content/influxdb/v1.0/troubleshooting/query_management.md
+++ b/content/influxdb/v1.0/troubleshooting/query_management.md
@@ -7,16 +7,16 @@ menu:
     parent: troubleshooting
 ---
 
-With InfluxDB's query management features, users are able to:
+With InfluxDB's query management features, users are able to
+identify currently-running queries,
+kill queries that are overloading their system,
+and prevent and halt the execution of inefficient queries with several configuration settings.
 
-1. Identify currently-running queries.
-2. Kill queries that are overloading their system.
-3. Prevent and halt the execution of inefficient queries with several configuration settings.
-
+This document covers how to:
 
 * [List currently-running queries with `SHOW QUERIES`](/influxdb/v1.0/troubleshooting/query_management/#list-currently-running-queries-with-show-queries)
 * [Stop currently-running queries with `KILL QUERY`](/influxdb/v1.0/troubleshooting/query_management/#stop-currently-running-queries-with-kill-query)
-* [Configuration settings for query management](/influxdb/v1.0/troubleshooting/query_management/#configuration-settings-for-query-management)
+* [Configure query management](/influxdb/v1.0/troubleshooting/query_management/#configuration-settings-for-query-management)
     * [Limit the number of running queries with `max-concurrent-queries`](/influxdb/v1.0/troubleshooting/query_management/#max-concurrent-queries)
     * [Set a query timeout with `query-timeout`](/influxdb/v1.0/troubleshooting/query_management/#query-timeout)
     * [Log queries if they run longer than specified time with `log-queries-after`](/influxdb/v1.0/troubleshooting/query_management/#log-queries-after)

--- a/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
@@ -171,6 +171,7 @@ Field values can be floats, integers, strings, or booleans:
 * Floats - by default, InfluxDB assumes all numerical field values are floats.
 
     Store the field value `82` as a float:
+
     ```
 weather,location=us-midwest temperature=82 1465839830100400200
     ```
@@ -179,6 +180,7 @@ weather,location=us-midwest temperature=82 1465839830100400200
 number as an integer.
 
     Store the field value `82` as an integer:
+
     ```
 weather,location=us-midwest temperature=82i 1465839830100400200
     ```
@@ -187,6 +189,7 @@ weather,location=us-midwest temperature=82i 1465839830100400200
 [below](#quoting)).
 
     Store the field value `too warm` as a string:
+
     ```
 weather,location=us-midwest temperature="too warm" 1465839830100400200
     ```
@@ -195,6 +198,7 @@ weather,location=us-midwest temperature="too warm" 1465839830100400200
 FALSE with `f`, `F`, `false`, `False`, or `FALSE`.
 
     Store the field value `true` as a boolean:
+    
     ```
 weather,location=us-midwest too_hot=true 1465839830100400200
     ```
@@ -237,6 +241,7 @@ Moving from never quote to please do quote:
 It's not valid Line Protocol.
 
     Example:
+
     ```
 > INSERT weather,location=us-midwest temperature=82 "1465839830100400200"
 ERR: {"error":"unable to parse 'weather,location=us-midwest temperature=82 \"1465839830100400200\"': bad timestamp"}
@@ -246,6 +251,7 @@ ERR: {"error":"unable to parse 'weather,location=us-midwest temperature=82 \"146
 It's also not valid Line Protocol.
 
     Example:
+
     ```
 > INSERT weather,location=us-midwest temperature='too warm'
 ERR: {"error":"unable to parse 'weather,location=us-midwest temperature='too warm'': invalid boolean"}
@@ -257,6 +263,7 @@ It is valid Line Protocol but InfluxDB assumes that the quotes are part of the
 name.
 
     Example:
+
     ```
 > INSERT weather,location=us-midwest temperature=82 1465839830100400200
 > INSERT "weather",location=us-midwest temperature=87 1465839830100400200
@@ -270,6 +277,7 @@ weather
 
     To query data in `"weather"` you need to double quote the measurement name and
 escape the measurement's double quotes:
+
     ```
 > SELECT * FROM "\"weather\""
 name: "weather"
@@ -282,6 +290,7 @@ time				            location	 temperature
 InfluxDB will assume that those values are strings.
 
     Example:
+
     ```
 > INSERT weather,location=us-midwest temperature="82"
 > SELECT * FROM weather WHERE temperature >= 70
@@ -291,6 +300,7 @@ InfluxDB will assume that those values are strings.
 * Do double quote field values that are strings.
 
     Example:
+
     ```
 > INSERT weather,location=us-midwest temperature="too warm"
 > SELECT * FROM weather


### PR DESCRIPTION
Fixes code blocks in the line_protocol_tutorial and turns the first list in query_management into a paragraph. 

The second changes this:
![image](https://cloud.githubusercontent.com/assets/8750814/18532969/7c208d84-7a94-11e6-9e3f-77610b15a0a3.png)

to this:
![image](https://cloud.githubusercontent.com/assets/8750814/18532980/8c3c9e42-7a94-11e6-997a-aacce9bccfb7.png)
