### PR TITLE
Clean up Kapacitor and Chronograf installation pages

### DIFF
--- a/content/chronograf/v1.0/introduction/installation.md
+++ b/content/chronograf/v1.0/introduction/installation.md
@@ -30,28 +30,13 @@ Follow the instructions in the Chronograf Downloads section on the [Downloads pa
 To run Chronograf manually, you can specify the configuration file on the
 command line:
 ```
-chronograf -config=/usr/local/etc/chronograf.toml
-```
-
-To have launchd start homebrew/binary/chronograf at login:
-```
-ln -sfv /usr/local/opt/chronograf/*.plist ~/Library/LaunchAgents
-```
-Then to load homebrew/binary/chronograf now:
-```
-launchctl load ~/Library/LaunchAgents/homebrew.mxcl.chronograf.plist
+chronograf -sample-config > chronograf.toml
+chronograf -config=chronograf.toml
 ```
 
 #### Linux DEB or RPM package:
 ```
 sudo service chronograf start
-```
-
-#### Standalone OS X binary
-Assuming you’re working with Chronograf version 0.13, from the
-`chronograf-0.13/`` directory:
-```
-./chronograf-0.13-darwin_amd64
 ```
 
 ## Configuration

--- a/content/kapacitor/v1.0/introduction/installation.md
+++ b/content/kapacitor/v1.0/introduction/installation.md
@@ -11,8 +11,7 @@ This page provides directions for installing, starting, and configuring Kapacito
 
 ## Requirements
 
-For packaged installations, root or sudo access may be required to
-complete the installation.
+Installation of the InfluxDB package may require `root` or administrator privileges in order to complete successfully.
 
 ### Networking
 
@@ -29,14 +28,8 @@ Kapacitor has two binaries:
 * kapacitor -- a CLI program for calling the Kapacitor API.
 * kapacitord -- the Kapacitor server daemon.
 
-You can either download the binaries directly from the
-[downloads](https://influxdata.com/downloads/#kapacitor) page or by
-using the Go command `go get`:
-
-```bash
-go get github.com/influxdb/kapacitor/cmd/kapacitor
-go get github.com/influxdb/kapacitor/cmd/kapacitord
-```
+You can download the binaries directly from the
+[downloads](https://influxdata.com/downloads/#kapacitor) page.
 
 ### Start the Kapacitor Service
 


### PR DESCRIPTION
Chronograf: Removes some of the homebrew features that are no longer available now that it is a cask formula.

Kapacitor: Removes the recommendation to install Kapacitor via `go get`.