### PR TITLE
AuthN and AuthZ links broken due to administration / query_language cross indexing

### DIFF
--- a/content/influxdb/v1.0/administration/config.md
+++ b/content/influxdb/v1.0/administration/config.md
@@ -511,7 +511,7 @@ Controls how long an http request for the subscriber service will run before it 
 This section controls how InfluxDB configures the HTTP endpoints.
 These are the primary mechanisms for getting data into and out of InfluxDB.
 Edit the options in this section to enable HTTPS and authentication.
-See [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/).
+See [Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/).
 
 ### enabled = true
 

--- a/content/influxdb/v1.0/administration/index.md
+++ b/content/influxdb/v1.0/administration/index.md
@@ -3,7 +3,7 @@ title: Database Administration
 ---
 The administration documentation contains all the information needed to administer a working InfluxDB installation.
 
-## [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/)
+## [Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/)
 
 This section covers setting up and managing authentication and authorization in InfluxDB.
 

--- a/content/influxdb/v1.0/concepts/glossary.md
+++ b/content/influxdb/v1.0/concepts/glossary.md
@@ -289,7 +289,7 @@ There are two kinds of users in InfluxDB:
 * *Non-admin users* have `READ`, `WRITE`, or `ALL` (both `READ` and `WRITE`) access per database.
 
 When authentication is enabled, InfluxDB only executes HTTP requests that are sent with a valid username and password.
-See [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/).
+See [Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/).
 
 ## values per second
 The preferred measurement of the rate at which data are persisted to InfluxDB. Write speeds are generally quoted in values per second.

--- a/content/influxdb/v1.0/concepts/key_concepts.md
+++ b/content/influxdb/v1.0/concepts/key_concepts.md
@@ -185,7 +185,7 @@ The timestamp for the point is `2015-08-18T00:00:00Z`.
 
 All of the stuff we've just covered is stored in a database - the sample data are in the database `my_database`.
 An InfluxDB <a name=database></a>*database* is similar to traditional relational databases and serves as a logical container for users, retention policies, continuous queries, and, of course, your time series data.
-See [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/) and [Continuous Queries](/influxdb/v1.0/query_language/continuous_queries/) for more on those topics.
+See [Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/) and [Continuous Queries](/influxdb/v1.0/query_language/continuous_queries/) for more on those topics.
 
 Databases can have several users, continuous queries, retention policies, and measurements.
 InfluxDB is a schemaless database which means it's easy to add new measurements, tags, and fields at any time.

--- a/content/influxdb/v1.0/guides/querying_data.md
+++ b/content/influxdb/v1.0/guides/querying_data.md
@@ -132,7 +132,7 @@ curl -G 'http://localhost:8086/query' --data-urlencode "db=mydb" --data-urlencod
 
 #### Authentication
 Authentication in InfluxDB is disabled by default.
-See [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/) for how to enable and set up authentication.
+See [Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/) for how to enable and set up authentication.
 
 #### Maximum Row Limit
 InfluxDB will limit the maximum number of returned results to prevent itself from running out of memory while it aggregates the results. This is set to 10,000 by default and can be configured by modifying `max-row-limit` in the `http` section of the configuration file.

--- a/content/influxdb/v1.0/query_language/authentication_and_authorization.md
+++ b/content/influxdb/v1.0/query_language/authentication_and_authorization.md
@@ -8,35 +8,35 @@ menu:
 
 This document covers setting up and managing authentication and authorization in InfluxDB.
 
-[Authentication](/influxdb/v1.0/administration/authentication_and_authorization/#authentication)
+[Authentication](/influxdb/v1.0/query_language/authentication_and_authorization/#authentication)
 
-* [Set up authentication](/influxdb/v1.0/administration/authentication_and_authorization/#set-up-authentication)
-* [Authenticating requests](/influxdb/v1.0/administration/authentication_and_authorization/#authenticating-requests)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Authenticate using the HTTP API](/influxdb/v1.0/administration/authentication_and_authorization/#authenticate-using-the-http-api)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Authenticate using the CLI](/influxdb/v1.0/administration/authentication_and_authorization/#authenticate-using-the-cli)  
+* [Set up authentication](/influxdb/v1.0/query_language/authentication_and_authorization/#set-up-authentication)
+* [Authenticating requests](/influxdb/v1.0/query_language/authentication_and_authorization/#authenticating-requests)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Authenticate using the HTTP API](/influxdb/v1.0/query_language/authentication_and_authorization/#authenticate-using-the-http-api)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Authenticate using the CLI](/influxdb/v1.0/query_language/authentication_and_authorization/#authenticate-using-the-cli)  
 
-[Authorization](/influxdb/v1.0/administration/authentication_and_authorization/#authorization)
+[Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/#authorization)
 
-* [User types and their privileges](/influxdb/v1.0/administration/authentication_and_authorization/#user-types-and-their-privileges)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Admin users](/influxdb/v1.0/administration/authentication_and_authorization/#admin-users)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Non-admin users](/influxdb/v1.0/administration/authentication_and_authorization/#non-admin-users)  
-* [User management commands](/influxdb/v1.0/administration/authentication_and_authorization/#user-management-commands)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Admin user management](/influxdb/v1.0/administration/authentication_and_authorization/#admin-user-management)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`CREATE` a new admin user](/influxdb/v1.0/administration/authentication_and_authorization/#create-a-new-admin-user)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`GRANT` administrative privileges to an existing user](/influxdb/v1.0/administration/authentication_and_authorization/#grant-administrative-privileges-to-an-existing-user)   
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`REVOKE` administrative privileges from an admin user](/influxdb/v1.0/administration/authentication_and_authorization/#revoke-administrative-privileges-from-an-admin-user)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`SHOW` all existing users and their admin status](/influxdb/v1.0/administration/authentication_and_authorization/#show-all-existing-users-and-their-admin-status)    
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Non-admin user management](/influxdb/v1.0/administration/authentication_and_authorization/#non-admin-user-management)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`CREATE` a new non-admin user](/influxdb/v1.0/administration/authentication_and_authorization/#create-a-new-non-admin-user)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`GRANT` `READ`,`WRITE`, or `ALL` database privileges to an existing user](/influxdb/v1.0/administration/authentication_and_authorization/#grant-read-write-or-all-database-privileges-to-an-existing-user)   
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`REVOKE` `READ`,`WRITE`, or `ALL` database privileges from an existing user](/influxdb/v1.0/administration/authentication_and_authorization/#revoke-read-write-or-all-database-privileges-from-an-existing-user)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`SHOW` a user's database privileges](/influxdb/v1.0/administration/authentication_and_authorization/#show-a-user-s-database-privileges)  
-&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[General admin and non-admin user management](/influxdb/v1.0/administration/authentication_and_authorization/#show-a-user-s-database-privileges)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Re`SET` a user's password](/influxdb/v1.0/administration/authentication_and_authorization/#re-set-a-user-s-password)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`DROP` a user](/influxdb/v1.0/administration/authentication_and_authorization/#drop-a-user)  
+* [User types and their privileges](/influxdb/v1.0/query_language/authentication_and_authorization/#user-types-and-their-privileges)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Admin users](/influxdb/v1.0/query_language/authentication_and_authorization/#admin-users)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Non-admin users](/influxdb/v1.0/query_language/authentication_and_authorization/#non-admin-users)  
+* [User management commands](/influxdb/v1.0/query_language/authentication_and_authorization/#user-management-commands)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Admin user management](/influxdb/v1.0/query_language/authentication_and_authorization/#admin-user-management)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`CREATE` a new admin user](/influxdb/v1.0/query_language/authentication_and_authorization/#create-a-new-admin-user)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`GRANT` administrative privileges to an existing user](/influxdb/v1.0/query_language/authentication_and_authorization/#grant-administrative-privileges-to-an-existing-user)   
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`REVOKE` administrative privileges from an admin user](/influxdb/v1.0/query_language/authentication_and_authorization/#revoke-administrative-privileges-from-an-admin-user)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`SHOW` all existing users and their admin status](/influxdb/v1.0/query_language/authentication_and_authorization/#show-all-existing-users-and-their-admin-status)    
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Non-admin user management](/influxdb/v1.0/query_language/authentication_and_authorization/#non-admin-user-management)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`CREATE` a new non-admin user](/influxdb/v1.0/query_language/authentication_and_authorization/#create-a-new-non-admin-user)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`GRANT` `READ`,`WRITE`, or `ALL` database privileges to an existing user](/influxdb/v1.0/query_language/authentication_and_authorization/#grant-read-write-or-all-database-privileges-to-an-existing-user)   
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`REVOKE` `READ`,`WRITE`, or `ALL` database privileges from an existing user](/influxdb/v1.0/query_language/authentication_and_authorization/#revoke-read-write-or-all-database-privileges-from-an-existing-user)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`SHOW` a user's database privileges](/influxdb/v1.0/query_language/authentication_and_authorization/#show-a-user-s-database-privileges)  
+&nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[General admin and non-admin user management](/influxdb/v1.0/query_language/authentication_and_authorization/#show-a-user-s-database-privileges)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Re`SET` a user's password](/influxdb/v1.0/query_language/authentication_and_authorization/#re-set-a-user-s-password)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;□&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`DROP` a user](/influxdb/v1.0/query_language/authentication_and_authorization/#drop-a-user)  
 
 
-[Authentication and authorization HTTP errors](/influxdb/v1.0/administration/authentication_and_authorization/#authentication-and-authorization-http-errors)
+[Authentication and authorization HTTP errors](/influxdb/v1.0/query_language/authentication_and_authorization/#authentication-and-authorization-http-errors)
 
 > **Note:** Authentication and authorization should not be relied upon to prevent access and protect data from malicious actors.
 If additional security or compliance features are desired, InfluxDB should be run behind a third-party service.
@@ -52,10 +52,10 @@ Plugins do not currently have the ability to authenticate requests and service e
 
 ### Set up authentication
 ---
-1. Create at least one [admin user](/influxdb/v1.0/administration/authentication_and_authorization/#admin-users).
-See the [authorization section](/influxdb/v1.0/administration/authentication_and_authorization/#authorization) for how to create an admin user.
+1. Create at least one [admin user](/influxdb/v1.0/query_language/authentication_and_authorization/#admin-users).
+See the [authorization section](/influxdb/v1.0/query_language/authentication_and_authorization/#authorization) for how to create an admin user.
 
-    > **Note:** If you enable authentication and have no users, InfluxDB will **not** enforce authentication and will only accept the [query](/influxdb/v1.0/administration/authentication_and_authorization/#create-a-new-admin-user) that creates a new admin user.
+    > **Note:** If you enable authentication and have no users, InfluxDB will **not** enforce authentication and will only accept the [query](/influxdb/v1.0/query_language/authentication_and_authorization/#create-a-new-admin-user) that creates a new admin user.
     InfluxDB will enforce authentication once there is an admin user.
 
 2. By default, authentication is disabled in the configuration file.
@@ -101,8 +101,8 @@ Example:
 curl -G http://localhost:8086/query --data-urlencode "u=todd" --data-urlencode "p=influxdb4ever" --data-urlencode "q=SHOW DATABASES"
 ```
 
-The queries in both examples assume that the user is an [admin user](/influxdb/v1.0/administration/authentication_and_authorization/#admin-users).
-See the section on [authorization](/influxdb/v1.0/administration/authentication_and_authorization/#authorization) for the different user types, their privileges, and more on user management.
+The queries in both examples assume that the user is an [admin user](/influxdb/v1.0/query_language/authentication_and_authorization/#admin-users).
+See the section on [authorization](/influxdb/v1.0/query_language/authentication_and_authorization/#authorization) for the different user types, their privileges, and more on user management.
 
 If you authenticate with both Basic Authentication **and** the URL query parameters, the user credentials specified in the query parameters take precedence.
 
@@ -132,7 +132,7 @@ influx -username todd -password influxdb4ever
     ```
 
 ## Authorization
-Authorization is only enforced once you've [enabled authentication](/influxdb/v1.0/administration/authentication_and_authorization/#set-up-authentication).
+Authorization is only enforced once you've [enabled authentication](/influxdb/v1.0/query_language/authentication_and_authorization/#set-up-authentication).
 By default, authentication is disabled, all credentials are silently ignored, and all users have all privileges.
 
 ### User types and their privileges
@@ -150,13 +150,13 @@ See the [database management](/influxdb/v1.0/query_language/database_management/
 
 User management:  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Admin user management:  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`CREATE USER`](/influxdb/v1.0/administration/authentication_and_authorization/#create-a-new-admin-user), [`GRANT ALL PRIVILEGES`](/influxdb/v1.0/administration/authentication_and_authorization/#grant-administrative-privileges-to-an-existing-user), [`REVOKE ALL PRIVILEGES`](/influxdb/v1.0/administration/authentication_and_authorization/#revoke-administrative-privileges-from-an-admin-user), and [`SHOW USERS`](/influxdb/v1.0/administration/authentication_and_authorization/#show-all-existing-users-and-their-admin-status)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`CREATE USER`](/influxdb/v1.0/query_language/authentication_and_authorization/#create-a-new-admin-user), [`GRANT ALL PRIVILEGES`](/influxdb/v1.0/query_language/authentication_and_authorization/#grant-administrative-privileges-to-an-existing-user), [`REVOKE ALL PRIVILEGES`](/influxdb/v1.0/query_language/authentication_and_authorization/#revoke-administrative-privileges-from-an-admin-user), and [`SHOW USERS`](/influxdb/v1.0/query_language/authentication_and_authorization/#show-all-existing-users-and-their-admin-status)  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Non-admin user management:  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`CREATE USER`](/influxdb/v1.0/administration/authentication_and_authorization/#create-a-new-non-admin-user), [`GRANT [READ,WRITE,ALL]`](/influxdb/v1.0/administration/authentication_and_authorization/#grant-read-write-or-all-database-privileges-to-an-existing-user), [`REVOKE [READ,WRITE,ALL]`](/influxdb/v1.0/administration/authentication_and_authorization/#revoke-read-write-or-all-database-privileges-from-an-existing-user), and [`SHOW GRANTS`](/influxdb/v1.0/administration/authentication_and_authorization/#show-a-user-s-database-privileges)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`CREATE USER`](/influxdb/v1.0/query_language/authentication_and_authorization/#create-a-new-non-admin-user), [`GRANT [READ,WRITE,ALL]`](/influxdb/v1.0/query_language/authentication_and_authorization/#grant-read-write-or-all-database-privileges-to-an-existing-user), [`REVOKE [READ,WRITE,ALL]`](/influxdb/v1.0/query_language/authentication_and_authorization/#revoke-read-write-or-all-database-privileges-from-an-existing-user), and [`SHOW GRANTS`](/influxdb/v1.0/query_language/authentication_and_authorization/#show-a-user-s-database-privileges)  
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;General user management:  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`SET PASSWORD`](/influxdb/v1.0/administration/authentication_and_authorization/#re-set-a-user-s-password) and [`DROP USER`](/influxdb/v1.0/administration/authentication_and_authorization/#drop-a-user)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[`SET PASSWORD`](/influxdb/v1.0/query_language/authentication_and_authorization/#re-set-a-user-s-password) and [`DROP USER`](/influxdb/v1.0/query_language/authentication_and_authorization/#drop-a-user)  
 
-See [below](/influxdb/v1.0/administration/authentication_and_authorization/#user-management-commands) for a complete discussion of the user management commands.
+See [below](/influxdb/v1.0/query_language/authentication_and_authorization/#user-management-commands) for a complete discussion of the user management commands.
 
 #### Non-admin users
 Non-admin users can have one of the following three privileges per database:  
@@ -165,7 +165,7 @@ Non-admin users can have one of the following three privileges per database:
 &nbsp;&nbsp;&nbsp;◦&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`ALL` (both `READ` and `WRITE` access)
 
 `READ`, `WRITE`, and `ALL` privileges are controlled per user per database.
-A new non-admin user has no access to any database until they are specifically [granted privileges to a database](/influxdb/v1.0/administration/authentication_and_authorization/#grant-read-write-or-all-database-privileges-to-an-existing-user) by an admin user.
+A new non-admin user has no access to any database until they are specifically [granted privileges to a database](/influxdb/v1.0/query_language/authentication_and_authorization/#grant-read-write-or-all-database-privileges-to-an-existing-user) by an admin user.
 
 ### User management commands
 ---

--- a/content/influxdb/v1.0/query_language/continuous_queries.md
+++ b/content/influxdb/v1.0/query_language/continuous_queries.md
@@ -27,7 +27,7 @@ The time ranges of the CQ results have natural time boundaries that are set inte
 Users can use an [offset interval](/influxdb/v1.0/query_language/data_exploration/#configured-group-by-time-boundaries)
 to alter the start or end times of the intervals.
 
-Only admin users are allowed to work with continuous queries. For more on user privileges, see [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/#user-types-and-their-privileges).
+Only admin users are allowed to work with continuous queries. For more on user privileges, see [Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/#user-types-and-their-privileges).
 
 > **Note:** CQs only execute on data received after the CQ's creation. If you'd like to downsample data written to InfluxDB before the CQ was created, see the examples in [Data Exploration](/influxdb/v1.0/query_language/data_exploration/#downsample-data).
 

--- a/content/influxdb/v1.0/query_language/database_management.md
+++ b/content/influxdb/v1.0/query_language/database_management.md
@@ -29,7 +29,7 @@ You can also execute the commands using the HTTP API; simply  send a `GET` reque
 See the [Querying Data](/influxdb/v1.0/guides/querying_data/) guide for more on using the HTTP API.
 
 > **Note:** When authentication is enabled, only admin users can execute most of the commands listed on this page.
-See the documentation on [authentication and authorization](/influxdb/v1.0/administration/authentication_and_authorization/) for more information.
+See the documentation on [authentication and authorization](/influxdb/v1.0/query_language/authentication_and_authorization/) for more information.
 
 ## Data Management
 

--- a/content/influxdb/v1.0/query_language/index.md
+++ b/content/influxdb/v1.0/query_language/index.md
@@ -59,12 +59,12 @@ Covers the use of mathematical operators in InfluxQL.
 #### [Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/)
 
 Covers how to
-[set up authentication](/influxdb/v1.0/administration/authentication_and_authorization/#set-up-authentication)
+[set up authentication](/influxdb/v1.0/query_language/authentication_and_authorization/#set-up-authentication)
 and how to
-[authenticate requests](/influxdb/v1.0/administration/authentication_and_authorization/#authenticating-requests) in InfluxDB.
+[authenticate requests](/influxdb/v1.0/query_language/authentication_and_authorization/#authenticating-requests) in InfluxDB.
 This page also describes the different
-[user types](/influxdb/v1.0/administration/authentication_and_authorization/#user-types-and-their-privileges) and the InfluxQL for
-[managing database users](/influxdb/v1.0/administration/authentication_and_authorization/#user-management-commands).
+[user types](/influxdb/v1.0/query_language/authentication_and_authorization/#user-types-and-their-privileges) and the InfluxQL for
+[managing database users](/influxdb/v1.0/query_language/authentication_and_authorization/#user-management-commands).
 
 ## [InfluxQL Reference](/influxdb/v1.0/query_language/spec/)
 

--- a/content/influxdb/v1.0/query_language/spec.md
+++ b/content/influxdb/v1.0/query_language/spec.md
@@ -9,7 +9,7 @@ menu:
 ## Introduction
 
 This is a reference for the Influx Query Language ("InfluxQL").
-If you're looking for less formal documentation see [Data Exploration](/influxdb/v1.0/query_language/data_exploration/), [Schema Exploration](/influxdb/v1.0/query_language/schema_exploration/), [Database Management](/influxdb/v1.0/query_language/database_management/), and [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/).
+If you're looking for less formal documentation see [Data Exploration](/influxdb/v1.0/query_language/data_exploration/), [Schema Exploration](/influxdb/v1.0/query_language/schema_exploration/), [Database Management](/influxdb/v1.0/query_language/database_management/), and [Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/).
 
 InfluxQL is a SQL-like query language for interacting with InfluxDB.
 It has been lovingly crafted to feel familiar to those coming from other SQL or SQL-like environments while providing features specific to storing and analyzing time series data.

--- a/content/influxdb/v1.0/tools/shell.md
+++ b/content/influxdb/v1.0/tools/shell.md
@@ -326,4 +326,4 @@ Restarting the CLI will revert to using the `DEFAULT` retention policy.
 
 ### Queries
 Execute all InfluxQL queries in `influx`.
-See [Data Exploration](/influxdb/v1.0/query_language/data_exploration/), [Schema Exploration](/influxdb/v1.0/query_language/schema_exploration/), [Database Management](/influxdb/v1.0/query_language/database_management/), [Authentication and Authorization](/influxdb/v1.0/administration/authentication_and_authorization/) for InfluxQL documentation.
+See [Data Exploration](/influxdb/v1.0/query_language/data_exploration/), [Schema Exploration](/influxdb/v1.0/query_language/schema_exploration/), [Database Management](/influxdb/v1.0/query_language/database_management/), [Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/) for InfluxQL documentation.


### PR DESCRIPTION
It seems all of the authentication and authorization links are broken as the content actually lives within query_language but links reference administration.  Assuming this content is meant to live within query_language, I've updated links to point there to get this working.