### PR TITLE
Typo InfluxDB- v1.0- concepts- storage engine- compactions

### DIFF
--- a/content/influxdb/v1.0/concepts/storage_engine.md
+++ b/content/influxdb/v1.0/concepts/storage_engine.md
@@ -230,7 +230,7 @@ Lower level compactions use strategies that avoid CPU-intensive activities like 
 Higher level (and thus less frequent) compactions will re-combine blocks to fully compact them and increase the compression ratio.
 * Index Optimization - When many level 4 TSM files accumulate, the internal indexes become larger and more costly to access.
 An index optimization compaction splits the series and indices across a new set of TSM files, sorting all points for a given series into one TSM file.
-Before an index iptimization, each TSM file contained points for most or all series, and thus each contains the same series index.
+Before an index optimization, each TSM file contained points for most or all series, and thus each contains the same series index.
 After an index optimzation, each TSM file contains points from a minimum of series and there is little series overlap between files.
 Each TSM file thus has a smaller unique series index, instead of a duplicate of the full series list. 
 In addition, all points from a particular series are contiguous in a TSM file rather than spread across multiple TSM files.


### PR DESCRIPTION
Typo in [influxdb v1.0 storage engine's concept compactions](https://docs.influxdata.com/influxdb/v1.0/concepts/storage_engine/#compactions)
sub-section - Index Optimization (Line Number 3)
Before an index ~~iptimization~~, changed to, Before an index optimization