### PR TITLE
alphabetize queries in spec

### DIFF
--- a/content/influxdb/v1.0/query_language/spec.md
+++ b/content/influxdb/v1.0/query_language/spec.md
@@ -595,36 +595,6 @@ SELECT mean("value") FROM "cpu" WHERE "region" = 'uswest' GROUP BY time(10m) fil
 SELECT mean("value") INTO "cpu_1h".:MEASUREMENT FROM /cpu.*/
 ```
 
-## Clauses
-
-```
-from_clause     = "FROM" measurements .
-
-group_by_clause = "GROUP BY" dimensions fill(fill_option).
-
-into_clause     = "INTO" ( measurement | back_ref ).
-
-limit_clause    = "LIMIT" int_lit .
-
-offset_clause   = "OFFSET" int_lit .
-
-slimit_clause   = "SLIMIT" int_lit .
-
-soffset_clause  = "SOFFSET" int_lit .
-
-on_clause       = "ON" db_name .
-
-order_by_clause = "ORDER BY" sort_fields .
-
-to_clause       = "TO" user_name .
-
-where_clause    = "WHERE" expr .
-
-with_measurement_clause = "WITH MEASUREMENT" ( "=" measurement | "=~" regex_lit ) .
-
-with_tag_clause = "WITH KEY" ( "=" tag_key | "!=" tag_key | "=~" regex_lit | "IN (" tag_keys ")"  ) .
-```
-
 ### SHOW CONTINUOUS QUERIES
 
 ```
@@ -830,6 +800,36 @@ show_users_stmt = "SHOW USERS" .
 ```sql
 -- show all users
 SHOW USERS
+```
+
+## Clauses
+
+```
+from_clause     = "FROM" measurements .
+
+group_by_clause = "GROUP BY" dimensions fill(fill_option).
+
+into_clause     = "INTO" ( measurement | back_ref ).
+
+limit_clause    = "LIMIT" int_lit .
+
+offset_clause   = "OFFSET" int_lit .
+
+slimit_clause   = "SLIMIT" int_lit .
+
+soffset_clause  = "SOFFSET" int_lit .
+
+on_clause       = "ON" db_name .
+
+order_by_clause = "ORDER BY" sort_fields .
+
+to_clause       = "TO" user_name .
+
+where_clause    = "WHERE" expr .
+
+with_measurement_clause = "WITH MEASUREMENT" ( "=" measurement | "=~" regex_lit ) .
+
+with_tag_clause = "WITH KEY" ( "=" tag_key | "!=" tag_key | "=~" regex_lit | "IN (" tag_keys ")"  ) .
 ```
 
 ## Expressions

--- a/content/influxdb/v1.0/query_language/spec.md
+++ b/content/influxdb/v1.0/query_language/spec.md
@@ -231,7 +231,7 @@ statement           = alter_retention_policy_stmt |
                       grant_stmt |
                       kill_query_statement |
                       revoke_stmt |
-                      select_stmt .
+                      select_stmt |
                       show_continuous_queries_stmt |
                       show_databases_stmt |
                       show_field_keys_stmt |

--- a/content/influxdb/v1.0/query_language/spec.md
+++ b/content/influxdb/v1.0/query_language/spec.md
@@ -230,6 +230,8 @@ statement           = alter_retention_policy_stmt |
                       drop_user_stmt |
                       grant_stmt |
                       kill_query_statement |
+                      revoke_stmt |
+                      select_stmt .
                       show_continuous_queries_stmt |
                       show_databases_stmt |
                       show_field_keys_stmt |
@@ -243,9 +245,7 @@ statement           = alter_retention_policy_stmt |
                       show_subscriptions_stmt|
                       show_tag_keys_stmt |
                       show_tag_values_stmt |
-                      show_users_stmt |
-                      revoke_stmt |
-                      select_stmt .
+                      show_users_stmt .
 ```
 
 ## Statements
@@ -561,6 +561,70 @@ KILL QUERY 36
 
 > **NOTE:** Identify the `query_id` from the [`SHOW QUERIES`](/influxdb/v1.0/query_language/spec/#show-queries) output.
 
+### REVOKE
+
+```
+revoke_stmt = "REVOKE" privilege [ on_clause ] "FROM" user_name .
+```
+
+#### Examples:
+
+```sql
+-- revoke admin privileges from jdoe
+REVOKE ALL PRIVILEGES FROM "jdoe"
+
+-- revoke read privileges from jdoe on mydb
+REVOKE READ ON "mydb" FROM "jdoe"
+```
+
+### SELECT
+
+```
+select_stmt = "SELECT" fields from_clause [ into_clause ] [ where_clause ]
+              [ group_by_clause ] [ order_by_clause ] [ limit_clause ]
+              [ offset_clause ] [ slimit_clause ] [ soffset_clause ] .
+```
+
+#### Examples:
+
+```sql
+-- select mean value from the cpu measurement where region = 'uswest' grouped by 10 minute intervals
+SELECT mean("value") FROM "cpu" WHERE "region" = 'uswest' GROUP BY time(10m) fill(0)
+
+-- select from all measurements beginning with cpu into the same measurement name in the cpu_1h retention policy
+SELECT mean("value") INTO "cpu_1h".:MEASUREMENT FROM /cpu.*/
+```
+
+## Clauses
+
+```
+from_clause     = "FROM" measurements .
+
+group_by_clause = "GROUP BY" dimensions fill(fill_option).
+
+into_clause     = "INTO" ( measurement | back_ref ).
+
+limit_clause    = "LIMIT" int_lit .
+
+offset_clause   = "OFFSET" int_lit .
+
+slimit_clause   = "SLIMIT" int_lit .
+
+soffset_clause  = "SOFFSET" int_lit .
+
+on_clause       = "ON" db_name .
+
+order_by_clause = "ORDER BY" sort_fields .
+
+to_clause       = "TO" user_name .
+
+where_clause    = "WHERE" expr .
+
+with_measurement_clause = "WITH MEASUREMENT" ( "=" measurement | "=~" regex_lit ) .
+
+with_tag_clause = "WITH KEY" ( "=" tag_key | "!=" tag_key | "=~" regex_lit | "IN (" tag_keys ")"  ) .
+```
+
 ### SHOW CONTINUOUS QUERIES
 
 ```
@@ -766,70 +830,6 @@ show_users_stmt = "SHOW USERS" .
 ```sql
 -- show all users
 SHOW USERS
-```
-
-### REVOKE
-
-```
-revoke_stmt = "REVOKE" privilege [ on_clause ] "FROM" user_name .
-```
-
-#### Examples:
-
-```sql
--- revoke admin privileges from jdoe
-REVOKE ALL PRIVILEGES FROM "jdoe"
-
--- revoke read privileges from jdoe on mydb
-REVOKE READ ON "mydb" FROM "jdoe"
-```
-
-### SELECT
-
-```
-select_stmt = "SELECT" fields from_clause [ into_clause ] [ where_clause ]
-              [ group_by_clause ] [ order_by_clause ] [ limit_clause ]
-              [ offset_clause ] [ slimit_clause ] [ soffset_clause ] .
-```
-
-#### Examples:
-
-```sql
--- select mean value from the cpu measurement where region = 'uswest' grouped by 10 minute intervals
-SELECT mean("value") FROM "cpu" WHERE "region" = 'uswest' GROUP BY time(10m) fill(0)
-
--- select from all measurements beginning with cpu into the same measurement name in the cpu_1h retention policy
-SELECT mean("value") INTO "cpu_1h".:MEASUREMENT FROM /cpu.*/
-```
-
-## Clauses
-
-```
-from_clause     = "FROM" measurements .
-
-group_by_clause = "GROUP BY" dimensions fill(fill_option).
-
-into_clause     = "INTO" ( measurement | back_ref ).
-
-limit_clause    = "LIMIT" int_lit .
-
-offset_clause   = "OFFSET" int_lit .
-
-slimit_clause   = "SLIMIT" int_lit .
-
-soffset_clause  = "SOFFSET" int_lit .
-
-on_clause       = "ON" db_name .
-
-order_by_clause = "ORDER BY" sort_fields .
-
-to_clause       = "TO" user_name .
-
-where_clause    = "WHERE" expr .
-
-with_measurement_clause = "WITH MEASUREMENT" ( "=" measurement | "=~" regex_lit ) .
-
-with_tag_clause = "WITH KEY" ( "=" tag_key | "!=" tag_key | "=~" regex_lit | "IN (" tag_keys ")"  ) .
 ```
 
 ## Expressions


### PR DESCRIPTION
@rkuchan noticed today that the statements were no longer in alphabetical order. Thought I'd fix that. 