### PR TITLE
Docs issues

### DIFF
--- a/content/influxdb/v1.0/query_language/authentication_and_authorization.md
+++ b/content/influxdb/v1.0/query_language/authentication_and_authorization.md
@@ -341,4 +341,7 @@ DROP USER <username>
     ```
 
 ## Authentication and authorization HTTP errors
-Requests with invalid credentials and requests by unauthorized users yield the `HTTP 401 Unauthorized` response.
+
+Requests with no authentication credentials or incorrect credentials yield the `HTTP 401 Unauthorized` response.
+
+Requests by unauthorized users yield the `HTTP 403 Forbidden` response.

--- a/content/influxdb/v1.0/query_language/data_exploration.md
+++ b/content/influxdb/v1.0/query_language/data_exploration.md
@@ -480,6 +480,9 @@ Use `fill()` to change the value reported for intervals that have no data.
 * `previous` - copies the value from the previous interval for intervals with no data
 * `none` - skips intervals with no data to report
 
+> **Note:**
+`fill()` must go at the end of the `GROUP BY` clause if you're `GROUP(ing) BY` several things (for example, both tags and a time interval).
+
 Follow the ✨ in the examples below to see what `fill()` can do.
 
 **GROUP BY without fill()**
@@ -528,9 +531,13 @@ time			                 mean
 ✨
 ```
 
-> **Notes:**
->
-* `fill()` must go at the end of the `GROUP BY` clause if you're `GROUP(ing) BY` several things (for example, both tags and a time interval).
+#### Common issues with `fill()`
+
+* Currently, queries ignore `fill()` if no data fall within the query's time range.
+This is the expected behavior. An open
+[feature request](https://github.com/influxdata/influxdb/issues/6967) on GitHub
+proposes that `fill()` should force a return of values even if the query's time
+range covers no data.
 * `fill(previous)` doesn’t fill the result for a time bucket if the previous value is outside the query’s time range. See [Frequently Asked Questions](/influxdb/v1.0/troubleshooting/frequently-asked-questions/#why-does-fill-previous-return-empty-results) for more information.
 
 ## The INTO clause

--- a/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
@@ -127,24 +127,16 @@ Check your retention policy's shard group duration with the
 statement.
 
 ## Why aren't data dropped after I've altered a retention policy?
-Several factors explain why data may not be immediately dropped after a
-retention policy (RP) change.
 
-First, by default, InfluxDB checks to enforce a RP every 30 minutes.
+By default, InfluxDB checks to enforce a RP every 30 minutes.
 You may need to wait for the next RP check for InfluxDB to drop data that are
 outside the RP's new `DURATION` setting.
 The 30 minute interval is
 [configurable](/influxdb/v1.0/administration/config/#check-interval-30m0s).
 
-Second,
-changing an RP's `DURATION` [may cause](#what-is-the-relationship-between-shard-group-durations-and-retention-policies)
-the [shard group's](/influxdb/v1.0/concepts/glossary/#shard-group) duration to shrink.
-InfluxDB cannot divide the old, longer shard groups.
-If any data in an old, longer shard group fall within the
-RP's new `DURATION` setting, InfluxDB will need to keep **all** of the data in
-that shard group.
-InfluxDB will drop that shard group once all data in that shard group are outside
-the RP's new `DURATION` setting.
+> **Note:** In versions prior to 1.0.2 altering an RP automatically reset
+the `SHARD GROUP DURATION`.
+In some cases, that behavior resulted in unexpected data retention.
 
 ## How do I make InfluxDB’s CLI return human readable timestamps?
 

--- a/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
@@ -676,7 +676,6 @@ time                   max
 
 While this is the expected behavior of `fill(previous)`, an [open feature request](https://github.com/influxdata/influxdb/issues/6878) on GitHub proposes that `fill(previous)` should fill results even when previous values fall outside the query’s time range.
 
-
 ## Why are my INTO queries missing data?
 
 By default, `INTO` queries convert any tags in the initial data to fields in

--- a/content/kapacitor/v1.0/examples/anomaly_detection.md
+++ b/content/kapacitor/v1.0/examples/anomaly_detection.md
@@ -537,7 +537,7 @@ Save this script as `/tmp/kapacitor_udf/print_temps.tick` and define
 the Kapacitor task:
 
 ```bash
-kapacitor define print_temps -type stream -dbrp printer.default -tick print_temps.tick
+kapacitor define print_temps -type stream -dbrp printer.autogen -tick print_temps.tick
 ```
 
 ### Generating Test Data
@@ -568,7 +568,7 @@ bed_t = 90
 air_t = 70
 
 # Connection info
-write_url = 'http://localhost:9092/write?db=printer&rp=default&precision=s'
+write_url = 'http://localhost:9092/write?db=printer&rp=autogen&precision=s'
 measurement = 'temperatures'
 
 def temp(target, sigma):
@@ -737,5 +737,3 @@ There are a few things that we have left as exercises to the reader:
    and change the `TTestHandler` to maintain historical data and
    batches for each field instead of just the one.  That way only one
    ttest.py process needs to be running.
-
-

--- a/content/kapacitor/v1.0/examples/continuous_queries.md
+++ b/content/kapacitor/v1.0/examples/continuous_queries.md
@@ -38,7 +38,7 @@ stream
         .as('usage_idle')
     |influxDBOut()
         .database('telegraf')
-        .retentionPolicy('default')
+        .retentionPolicy('autogen')
         .measurement('mean_cpu_idle')
         .precision('s')
 ```
@@ -47,13 +47,13 @@ The same thing can also be done as a batch task in Kapacitor.
 
 ```javascript
 batch
-    |query('SELECT mean(usage_idle) as usage_idle FROM "telegraf"."default".cpu')
+    |query('SELECT mean(usage_idle) as usage_idle FROM "telegraf"."autogen".cpu')
         .period(5m)
         .every(5m)
         .groupBy(*)
     |influxDBOut()
         .database('telegraf')
-        .retentionPolicy('default')
+        .retentionPolicy('autogen')
         .measurement('mean_cpu_idle')
         .precision('s')
 ```
@@ -101,7 +101,7 @@ If you are using a batch task it is still possible for a point to arrive late an
 Create a continuous query to down sample across retention policies.
 
 ```
-CREATE CONTINUOUS QUERY cpu_idle_median ON telegraf BEGIN SELECT median("usage_idle") as usage_idle INTO "telegraf"."sampled_5m"."median_cpu_idle" FROM "telegraf"."default"."cpu" GROUP BY time(5m),* END
+CREATE CONTINUOUS QUERY cpu_idle_median ON telegraf BEGIN SELECT median("usage_idle") as usage_idle INTO "telegraf"."sampled_5m"."median_cpu_idle" FROM "telegraf"."autogen"."cpu" GROUP BY time(5m),* END
 ```
 
 The stream TICKscript:
@@ -110,7 +110,7 @@ The stream TICKscript:
 stream
     |from()
         .database('telegraf')
-        .retentionPolicy('default')
+        .retentionPolicy('autogen')
         .measurement('cpu')
         .groupBy(*)
     |window()
@@ -130,7 +130,7 @@ And the batch TICKscript:
 
 ```javascript
 batch
-    |query('SELECT median(usage_idle) as usage_idle FROM "telegraf"."default"."cpu"')
+    |query('SELECT median(usage_idle) as usage_idle FROM "telegraf"."autogen"."cpu"')
         .period(5m)
         .every(5m)
         .groupBy(*)
@@ -148,6 +148,3 @@ Kapacitor is a powerful tool, if you need more power use it.
 If not keep using CQs until you do.
 For more information and help writing TICKscripts from InfluxQL queries take a looks at these [docs](https://docs.influxdata.com/kapacitor/latest/nodes/influx_q_l_node/) on the InfluxQL node in Kapacitor.
 Every function available in the InfluxDB query language is available in Kapacitor, so you can convert any query into a Kapacitor TICKscript.
-
-
-

--- a/content/kapacitor/v1.0/examples/join_backfill.md
+++ b/content/kapacitor/v1.0/examples/join_backfill.md
@@ -17,7 +17,7 @@ Let's say we have two measurements:
 * `errors` -- the number of page views that had an error.
 * `views` -- the number of page views that had no errror.
 
-Both measurements exist in a database called `pages` and in the retention policy `default`.
+Both measurements exist in a database called `pages` and in the retention policy `autogen`.
 
 We want to know the percent of page views that resulted in an error.
 The process is to select both existing measurements join them and calculate the percentage.
@@ -29,7 +29,7 @@ We need to query the two measurements, `errors` and `views`.
 ```javascript
 // Get errors batch data
 var errors = batch
-    |query('SELECT sum(value) FROM "pages"."default".errors')
+    |query('SELECT sum(value) FROM "pages"."autogen".errors')
         .period(1h)
         .every(1h)
         .groupBy(time(1m), *)
@@ -37,7 +37,7 @@ var errors = batch
 
 // Get views batch data
 var views = batch
-    |query('SELECT sum(value) FROM "pages"."default".views')
+    |query('SELECT sum(value) FROM "pages"."autogen".views')
         .period(1h)
         .every(1h)
         .groupBy(time(1m), *)
@@ -91,7 +91,7 @@ Here is the complete TICKscript for the batch task:
 ```javascript
 // Get errors batch data
 var errors = batch
-    |query('SELECT sum(value) FROM "pages"."default".errors')
+    |query('SELECT sum(value) FROM "pages"."autogen".errors')
         .period(1h)
         .every(1h)
         .groupBy(time(1m), *)
@@ -99,7 +99,7 @@ var errors = batch
 
 // Get views batch data
 var views = batch
-    |query('SELECT sum(value) FROM "pages"."default".views')
+    |query('SELECT sum(value) FROM "pages"."autogen".views')
         .period(1h)
         .every(1h)
         .groupBy(time(1m), *)
@@ -129,7 +129,7 @@ Then create a recording for the past time frame we want.
 kapacitor define error_percent \
     -type batch \
     -tick error_percent.tick \
-    -dbrp pages.default
+    -dbrp pages.autogen
 kapacitor record batch -task error_percent -past 1d
 ```
 
@@ -184,4 +184,3 @@ errors
         .database('pages')
         .measurement('error_percent')
 ```
-

--- a/content/kapacitor/v1.0/examples/live_leaderboard.md
+++ b/content/kapacitor/v1.0/examples/live_leaderboard.md
@@ -37,11 +37,11 @@ Add this configuration section to the end of your Kapacitor configuration.
     enabled = true
     bind-address = ":9100"
     database = "game"
-    retention-policy = "default"
+    retention-policy = "autogen"
 ```
 
 This configuration tells Kapacitor to listen on port `9100` for UDP packets in the line protocol format.
-It will scope in incoming data to be in the `game.default` database and retention policy.
+It will scope in incoming data to be in the `game.autogen` database and retention policy.
 Start Kapacitor running with that added to the configuration.
 
 Here is a simple bash script to generate random score data so we can test it without
@@ -261,7 +261,7 @@ max
 Define and enable our task to see it in action:
 
 ```bash
-kapacitor define top_scores -tick top_scores.tick -type stream -dbrp game.default
+kapacitor define top_scores -tick top_scores.tick -type stream -dbrp game.autogen
 kapacitor enable top_scores
 ```
 
@@ -289,4 +289,3 @@ curl \
 Great!
 The hard work is done.
 All that is left is to configure the game server to send score updates to Kapacitor and update the spectator dashboard to pull scores from Kapacitor.
-

--- a/content/kapacitor/v1.0/examples/socket_udf.md
+++ b/content/kapacitor/v1.0/examples/socket_udf.md
@@ -182,7 +182,7 @@ func main() {
 }
 ```
 
-Now let's add in each of the methods needed to initialize the UDF. 
+Now let's add in each of the methods needed to initialize the UDF.
 These next methods implement the behavior described in Step 3 of the UDF Lifecycle above,
 where Kapacitor connects to the socket in order to query basic information about the UDF.
 
@@ -238,7 +238,7 @@ func (h *mirrorHandler) Point(p *udf.Point) error {
 Notice that the `agent` has a channel for responses, this is because your UDF can send data to Kapacitor
 at any time, so it does not need to be in a response to receive a point.
 
-As a result, we need to close the channel to let the `agent` know 
+As a result, we need to close the channel to let the `agent` know
 that we will not be sending any more data, which can be done via the `Stop` method.
 Once the `agent` calls `Stop` on the `handler`, no other methods will be called and the `agent` won't stop until
 the channel is closed.
@@ -291,7 +291,7 @@ type Accepter interface {
 }
 ```
 
-Here is a simple `accepter` that creates a new `agent` and `mirrorHandler` 
+Here is a simple `accepter` that creates a new `agent` and `mirrorHandler`
 for each new connection. Add this to the `main.go` file:
 
 ```go
@@ -490,8 +490,8 @@ func main() {
 }
 ```
 
-Run `go run main.go` to start the UDF. 
-If you get an error about the socket being in use, 
+Run `go run main.go` to start the UDF.
+If you get an error about the socket being in use,
 just delete the socket file and try running the UDF again.
 
 ## Configure Kapacitor to Talk to the UDF
@@ -530,7 +530,7 @@ stream
 Define the above alert from your terminal like so:
 
 ```sh
-kapacitor define mirror_udf_example -type stream -dbrp telegraf.default -tick path/to/above/script.tick
+kapacitor define mirror_udf_example -type stream -dbrp telegraf.autogen -tick path/to/above/script.tick
 ```
 
 Start the task:
@@ -649,5 +649,3 @@ If you want to learn more, here are a few places to start:
 * Change the mirror UDF to work on batches instead of streams.
 	This requires changing the edge type in the `Info` method as well as implementing the `BeginBatch` and `EndBatch` methods.
 * Take a look at the other [examples](https://github.com/influxdata/kapacitor/tree/master/udf/agent/examples) and modify one to do something similar to one of your existing requirements.
-
-

--- a/content/kapacitor/v1.0/examples/template_tasks.md
+++ b/content/kapacitor/v1.0/examples/template_tasks.md
@@ -102,7 +102,7 @@ Create a file `cpu_vars.json` with these contents.
 Now define the task using the vars for the task.
 
 ```
-kapacitor define cpu_alert -template generic_mean_alert -vars cpu_vars.json -dbrp telegraf.default
+kapacitor define cpu_alert -template generic_mean_alert -vars cpu_vars.json -dbrp telegraf.autogen
 ```
 
 The `show` command will display the `vars` associated with this task.
@@ -143,7 +143,7 @@ Create a `mem_vars.json` and use this snippet.
 ```
 
 ```
-kapacitor define mem_alert -template generic_mean_alert -vars mem_vars.json -dbrp telegraf.default
+kapacitor define mem_alert -template generic_mean_alert -vars mem_vars.json -dbrp telegraf.autogen
 ```
 
 Running `show` will display the `vars` associated with this task which are unique to our `mem_alert` task.

--- a/content/kapacitor/v1.0/introduction/getting_started.md
+++ b/content/kapacitor/v1.0/introduction/getting_started.md
@@ -156,7 +156,7 @@ Now use the CLI tool to define the `task` and the databases and retention polici
 kapacitor define cpu_alert \
     -type stream \
     -tick cpu_alert.tick \
-    -dbrp kapacitor_example.default
+    -dbrp kapacitor_example.autogen
 ```
 
 That's it, Kapacitor now knows how to trigger our alert.
@@ -255,7 +255,7 @@ Executing: true
 Created: 04 May 16 21:01 MDT
 Modified: 04 May 16 21:04 MDT
 LastEnabled: 04 May 16 21:03 MDT
-Databases Retention Policies: ["kapacitor_example"."default"]
+Databases Retention Policies: ["kapacitor_example"."autogen"]
 TICKscript:
 stream
     // Select just the cpu measurement from our example database.
@@ -309,7 +309,7 @@ Note the following example:
 var data = stream
     |from()
         .database('telegraf')
-        .retentionPolicy('default')
+        .retentionPolicy('autogen')
         .measurement('cpu')
         // NOTE: Double quotes on server1
         .where(lambda: "host" == "server1")
@@ -324,7 +324,7 @@ We were probably searching for series where tag "host" has value "server1", so w
 var data = stream
     |from()
         .database('telegraf')
-        .retentionPolicy('default')
+        .retentionPolicy('autogen')
         .measurement('cpu')
         // NOTE: Single quotes on server1
         .where(lambda: "host" == 'server1')
@@ -449,7 +449,7 @@ This TICKscript does the same thing as the earlier stream task, but as a batch t
 batch
     |query('''
         SELECT mean(usage_idle)
-        FROM "kapacitor_example"."default"."cpu"
+        FROM "kapacitor_example"."autogen"."cpu"
     ''')
         .period(5m)
         .every(5m)
@@ -462,7 +462,7 @@ batch
 To define this task do:
 
 ```bash
-kapacitor define batch_cpu_alert -type batch -tick batch_cpu_alert.tick -dbrp kapacitor_example.default
+kapacitor define batch_cpu_alert -type batch -tick batch_cpu_alert.tick -dbrp kapacitor_example.autogen
 ```
 
 You can record the result of the query in the task like so (again, your ID will differ):


### PR DESCRIPTION
Fixes issues:

* #762: Update the `Why aren't data dropped after I've altered a retention policy?` FAQ for 1.0.2 behavior.
* #522: Add documentation for `fill()` behavior with no data.
* #476: Add FAQ on mixing aggregates and non-aggregates.
* #772: Remove mentions of the `default` RP and replace with `autogen` in the 1.0 Kapacitor docs.
* #680: Update description of auth errors to include `403`.