### PR TITLE
Fix docs issues and create a new error page

### DIFF
--- a/content/influxdb/v1.0/concepts/glossary.md
+++ b/content/influxdb/v1.0/concepts/glossary.md
@@ -77,10 +77,18 @@ See [InfluxQL Functions](/influxdb/v1.0/query_language/functions/) for a complet
 Related entries: [aggregation](/influxdb/v1.0/concepts/glossary/#aggregation), [selector](/influxdb/v1.0/concepts/glossary/#selector), [transformation](/influxdb/v1.0/concepts/glossary/#transformation)  
 
 ## identifier
-Tokens which refer to database names, retention policy names, continuous query names, user names, measurement names, tag keys, and field keys.
+Tokens that refer to continuous query names, database names, field keys,
+measurement names, retention policy names, subscription names, tag keys, and
+user names.
 See [Query Language Specification](/influxdb/v1.0/query_language/spec/#identifiers).
 
-Related entries: [database](/influxdb/v1.0/concepts/glossary/#database), [field key](/influxdb/v1.0/concepts/glossary/#field-key), [measurement](/influxdb/v1.0/concepts/glossary/#measurement), [retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp), [tag key](/influxdb/v1.0/concepts/glossary/#tag-key), [user](/influxdb/v1.0/concepts/glossary/#user)
+Related entries:
+[database](/influxdb/v1.0/concepts/glossary/#database),
+[field key](/influxdb/v1.0/concepts/glossary/#field-key),
+[measurement](/influxdb/v1.0/concepts/glossary/#measurement),
+[retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp),
+[tag key](/influxdb/v1.0/concepts/glossary/#tag-key),
+[user](/influxdb/v1.0/concepts/glossary/#user)
 
 ## line protocol
 The text based format for writing points to InfluxDB. See [Line Protocol](/influxdb/v1.0/write_protocols/).

--- a/content/influxdb/v1.0/concepts/glossary.md
+++ b/content/influxdb/v1.0/concepts/glossary.md
@@ -77,7 +77,7 @@ See [InfluxQL Functions](/influxdb/v1.0/query_language/functions/) for a complet
 Related entries: [aggregation](/influxdb/v1.0/concepts/glossary/#aggregation), [selector](/influxdb/v1.0/concepts/glossary/#selector), [transformation](/influxdb/v1.0/concepts/glossary/#transformation)  
 
 ## identifier
-Tokens which refer to database names, retention policy names, user names, measurement names, tag keys, and field keys.
+Tokens which refer to database names, retention policy names, continuous query names, user names, measurement names, tag keys, and field keys.
 See [Query Language Specification](/influxdb/v1.0/query_language/spec/#identifiers).
 
 Related entries: [database](/influxdb/v1.0/concepts/glossary/#database), [field key](/influxdb/v1.0/concepts/glossary/#field-key), [measurement](/influxdb/v1.0/concepts/glossary/#measurement), [retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp), [tag key](/influxdb/v1.0/concepts/glossary/#tag-key), [user](/influxdb/v1.0/concepts/glossary/#user)

--- a/content/influxdb/v1.0/troubleshooting/errors.md
+++ b/content/influxdb/v1.0/troubleshooting/errors.md
@@ -10,8 +10,7 @@ This page documents parsing errors, their descriptions, and, where applicable,
 common resolutions.
 
 <dt>
-**Disclaimer:** This document is under development and does not contain a
-comprehensive list of all InfluxDB errors.
+**Disclaimer:** This document does not contain an exhaustive list of all possible InfluxDB errors.
 </dt>
 
 ## error parsing query: found < >, expected identifier at line < >, char < >
@@ -19,8 +18,9 @@ comprehensive list of all InfluxDB errors.
 ### InfluxQL Syntax
 The `expected identifier` error occurs when InfluxDB anticipates an identifier
 in a query but doesn't find it.
-Identifiers are tokens that refer to database names, retention policy names,
-continuous query names, user names, measurement names, tag keys, and field keys.
+Identifiers are tokens that refer to continuous query names, database names,
+field keys, measurement names, retention policy names, subscription names,
+tag keys, and user names.
 The error is often a gentle reminder to double-check your query's syntax.
 
 **Examples**
@@ -44,7 +44,7 @@ Query 2 is missing a measurement name between `FROM` and `WHERE`.
 In some cases the `expected identifier` error occurs when one of the
 [identifiers](/influxdb/v1.0/concepts/glossary/#identifier) in the query is an
 [InfluxQL Keyword](/influxdb/v1.0/query_language/spec/#keywords).
-To successfully query an identifier that's also a keyword enclose that
+To successfully query an identifier that's also a keyword, enclose that
 identifier in double quotes.
 
 **Examples**

--- a/content/influxdb/v1.0/troubleshooting/errors.md
+++ b/content/influxdb/v1.0/troubleshooting/errors.md
@@ -1,0 +1,220 @@
+---
+title: Error Messages
+menu:
+  influxdb_1_0:
+    weight: 30
+    parent: troubleshooting
+---
+
+This page documents parsing errors, their descriptions, and, where applicable,
+common resolutions.
+
+<dt>
+**Disclaimer:** This document is under development and does not contain a
+comprehensive list of all InfluxDB errors.
+</dt>
+
+## error parsing query: found < >, expected identifier at line < >, char < >
+
+### InfluxQL Syntax
+The `expected identifier` error occurs when InfluxDB anticipates an identifier
+in a query but doesn't find it.
+Identifiers are tokens that refer to database names, retention policy names,
+continuous query names, user names, measurement names, tag keys, and field keys.
+The error is often a gentle reminder to double-check your query's syntax.
+
+**Examples**
+
+*Query 1:*
+```
+> CREATE CONTINUOUS QUERY ON "telegraf" BEGIN SELECT mean("usage_idle") INTO "average_cpu" FROM "cpu" GROUP BY time(1h),"cpu" END
+ERR: error parsing query: found ON, expected identifier at line 1, char 25
+```
+Query 1 is missing a continuous query name between `CREATE CONTINUOUS QUERY` and
+`ON`.
+
+*Query 2:*
+```
+> SELECT * FROM WHERE "blue" = true
+ERR: error parsing query: found WHERE, expected identifier at line 1, char 15
+```
+Query 2 is missing a measurement name between `FROM` and `WHERE`.
+
+### InfluxQL Keywords
+In some cases the `expected identifier` error occurs when one of the
+[identifiers](/influxdb/v1.0/concepts/glossary/#identifier) in the query is an
+[InfluxQL Keyword](/influxdb/v1.0/query_language/spec/#keywords).
+To successfully query an identifier that's also a keyword enclose that
+identifier in double quotes.
+
+**Examples**
+
+*Query 1:*
+```
+> SELECT duration FROM runs
+ERR: error parsing query: found DURATION, expected identifier, string, number, bool at line 1, char 8
+```
+In Query 1, the field key `duration` is an InfluxQL Keyword.
+Double quote `duration` to avoid the error:
+```
+> SELECT "duration" FROM runs
+```
+
+*Query 2:*
+```
+> CREATE RETENTION POLICY limit ON telegraf DURATION 1d REPLICATION 1
+ERR: error parsing query: found LIMIT, expected identifier at line 1, char 25
+```
+In Query 2, the retention policy name `limit` is an InfluxQL Keyword.
+Double quote `limit` to avoid the error:
+```
+> CREATE RETENTION POLICY "limit" ON telegraf DURATION 1d REPLICATION 1
+```
+
+While using double quotes is an acceptable workaround, we recommend that you avoid using InfluxQL keywords as identifiers for simplicity's sake.
+
+**Resources:**
+[InfluxQL Keywords](/influxdb/v1.0/query_language/spec/#keywords),
+[Query Language Documentation](/influxdb/v1.0/query_language/)
+
+## error parsing query: found < >, expected string at line < >, char < >
+
+The `expected string` error occurs when InfluxDB anticipates a string
+but doesn't find it.
+In most cases, the error is a result of forgetting to quote the password
+string in the `CREATE USER` statement.
+
+**Example**
+
+```
+> CREATE USER penelope WITH PASSWORD timeseries4dayz
+ERR: error parsing query: found timeseries4dayz, expected string at line 1, char 36
+```
+
+The `CREATE USER` statement requires single quotation marks around the password
+string:
+
+```
+> CREATE USER penelope WITH PASSWORD 'timeseries4dayz'
+```
+
+Note that you should not include the single quotes when authenticating requests.
+
+**Resources:**
+[Authentication and Authorization](/influxdb/v1.0/query_language/authentication_and_authorization/)
+
+## error parsing query: mixing aggregate and non-aggregate queries is not supported
+
+The `mixing aggregate and non-aggregate` error occurs when a `SELECT` statement
+includes both an [aggregate function](/influxdb/v1.0/query_language/functions/)
+and a standalone [field key](/influxdb/v1.0/concepts/glossary/#field-key) or
+[tag key](/influxdb/v1.0/concepts/glossary/#tag-key).
+
+Aggregate functions return a single calculated value and there is no obvious
+single value to return for any unaggregated fields or tags.
+
+**Example**
+
+*Raw data:*
+
+The `peg` measurement has two fields (`square` and `round`) and one tag
+(`force`):
+```
+name: peg
+---------
+time                   square   round   force
+2016-10-07T18:50:00Z   2        8       1
+2016-10-07T18:50:10Z   4        12      2
+2016-10-07T18:50:20Z   6        14      4
+2016-10-07T18:50:30Z   7        15      3
+```
+
+*Query 1:*
+
+```
+> SELECT mean("square"),"round" FROM "peg"
+ERR: error parsing query: mixing aggregate and non-aggregate queries is not supported
+```
+Query 1 includes an aggregate function and a standalone field.
+
+`mean("square")` returns a single aggregated value calculated from the four values
+of `square` in the `peg` measurement, and there is no obvious single field value
+to return from the four unaggregated values of the `round` field.
+
+*Query 2:*
+
+```
+> SELECT mean("square"),"force" FROM "peg"
+ERR: error parsing query: mixing aggregate and non-aggregate queries is not supported
+```
+Query 2 includes an aggregate function and a standalone tag.
+
+`mean("square")` returns a single aggregated value calculated from the four values
+of `square` in the `peg` measurement, and there is no obvious single tag value
+to return from the four unaggregated values of the `force` tag.
+
+**Resources:**
+[Functions](/influxdb/v1.0/query_language/functions/)
+
+## unable to parse < >: bad timestamp
+
+### Timestamp Syntax
+The `bad timestamp` error occurs when the
+[line protocol](/influxdb/v1.0/concepts/glossary/#line-protocol) includes a
+timestamp in a format other than a UNIX timestamp.
+
+**Example**
+
+```
+> INSERT pineapple value=1 '2015-08-18T23:00:00Z'
+ERR: {"error":"unable to parse 'pineapple value=1 '2015-08-18T23:00:00Z'': bad timestamp"}
+```
+
+The line protocol above uses an [RFC3339](https://www.ietf.org/rfc/rfc3339.txt)
+timestamp.
+Replace the timestamp with a UNIX timestamp to avoid the error and successfully
+write the point to InfluxDB:
+
+```
+> INSERT pineapple,fresh=true value=1 1439938800000000000
+```
+
+### Line Protocol Syntax
+In some cases, the `bad timestamp` error occurs with more general syntax errors
+in the line protocol.
+Line protocol is whitespace sensitive; misplaced spaces can cause InfluxDB
+to assume that a field or tag is an invalid timestamp.
+
+**Example**
+
+*Write 1*
+```
+> INSERT hens location=2 value=9
+ERR: {"error":"unable to parse 'hens location=2 value=9': bad timestamp"}
+```
+The line protocol in Write 1 separates the `hen` measurement from the `location=2`
+tag with a space instead of a comma.
+InfluxDB assumes that the `value=9` field is the timestamp and returns an error.
+
+Use a comma instead of a space between the measurement and tag to avoid the error:
+```
+> INSERT hens,location=2 value=9
+```
+
+*Write 2*
+```
+> INSERT cows,name=daisy milk_prod=3 happy=3
+ERR: {"error":"unable to parse 'cows,name=daisy milk_prod=3 happy=3': bad timestamp"}
+```
+The line protocol in Write 2 separates the `milk_prod=3` field and the
+`happy=3` field with a space instead of a comma.
+InfluxDB assumes that the `happy=3` field is the timestamp and returns an error.
+
+Use a comma instead of a space between the two fields to avoid the error:
+```
+> INSERT cows,name=daisy milk_prod=3,happy=3
+```
+
+**Resources:**
+[Line Protocol Tutorial](/influxdb/v1.0/write_protocols/line_protocol_tutorial/),
+[Line Protocol Reference](/influxdb/v1.0/write_protocols/line_protocol_reference/)

--- a/content/influxdb/v1.0/troubleshooting/errors.md
+++ b/content/influxdb/v1.0/troubleshooting/errors.md
@@ -6,7 +6,7 @@ menu:
     parent: troubleshooting
 ---
 
-This page documents parsing errors, their descriptions, and, where applicable,
+This page documents errors, their descriptions, and, where applicable,
 common resolutions.
 
 <dt>
@@ -218,3 +218,22 @@ Use a comma instead of a space between the two fields to avoid the error:
 **Resources:**
 [Line Protocol Tutorial](/influxdb/v1.0/write_protocols/line_protocol_tutorial/),
 [Line Protocol Reference](/influxdb/v1.0/write_protocols/line_protocol_reference/)
+
+## write failed for shard < >: engine: cache maximum memory size exceeded
+
+The `cache maximum memory size exceeded` error occurs when the cached
+memory size increases beyond the
+[`cache-max-memory-size` setting](/influxdb/v1.0/administration/config/#cache-max-memory-size-524288000)
+in the configuration file.
+
+By default, `cache-max-memory-size` is set to 512mb.
+This value is fine for most workloads, but is too small for larger write volumes
+or for datasets with higher [series cardinality](/influxdb/v1.0/concepts/glossary/#series-cardinality).
+If you have lots of RAM you could set it to `0` to disable the cached memory
+limit and never get this error.
+You can also examine the `memBytes` field in the`cache` measurement in the
+[`_internal` database](/influxdb/v1.0/troubleshooting/statistics/#internal-monitoring)
+to get a sense of how big the caches are in memory.
+
+**Resources:**
+[Database Configuration](/influxdb/v1.0/administration/config/)

--- a/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
@@ -846,7 +846,7 @@ InfluxDB does not support an
 [tag key](/influxdb/v1.0/concepts/glossary/#tag-key) in the same `SELECT`
 statement.
 Aggregate functions return a single calculated value and there is no obvious
-single value to return for any unaggregated fields or keys.
+single value to return for any unaggregated fields or tags.
 
 #### Example
 

--- a/content/influxdb/v1.0/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.0/write_protocols/line_protocol_reference.md
@@ -222,7 +222,7 @@ Line Protocol accepts
 as [identifier](/influxdb/v1.0/concepts/glossary/#identifier) names.
 In general, we recommend avoiding using InfluxQL keywords in your schema as
 it can cause
-[confusion](/influxdb/v1.0/troubleshooting/frequently-asked-questions/#why-am-i-getting-an-expected-identifier-error) when querying the data.
+[confusion](/influxdb/v1.0/troubleshooting/errors/#error-parsing-query-found-expected-identifier-at-line-char) when querying the data.
 
 ## Line Protocol in Practice
 

--- a/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
@@ -377,7 +377,7 @@ Line Protocol accepts
 as [identifier](/influxdb/v1.0/concepts/glossary/#identifier) names.
 In general, we recommend avoiding using InfluxQL keywords in your schema as
 it can cause
-[confusion](/influxdb/v1.0/troubleshooting/frequently-asked-questions/#why-am-i-getting-an-expected-identifier-error) when querying the data.
+[confusion](/influxdb/v1.0/troubleshooting/errors/#error-parsing-query-found-expected-identifier-at-line-char) when querying the data.
 
 ## Writing data to InfluxDB
 

--- a/content/kapacitor/v0.13/nodes/alert_node.md
+++ b/content/kapacitor/v0.13/nodes/alert_node.md
@@ -10,50 +10,50 @@ menu:
     parent: nodes
 ---
 
-An [AlertNode](/kapacitor/v0.13/nodes/alert_node/) can trigger an event of varying severity levels, 
-and pass the event to alert handlers. The criteria for triggering 
-an alert is specified via a [lambda expression](/kapacitor/latest/tick/expr/). 
-See [AlertNode.Info,](/kapacitor/v0.13/nodes/alert_node/#info) [AlertNode.Warn,](/kapacitor/v0.13/nodes/alert_node/#warn) and [AlertNode.Crit](/kapacitor/v0.13/nodes/alert_node/#crit) below. 
+An [AlertNode](/kapacitor/v0.13/nodes/alert_node/) can trigger an event of varying severity levels,
+and pass the event to alert handlers. The criteria for triggering
+an alert is specified via a [lambda expression](/kapacitor/latest/tick/expr/).
+See [AlertNode.Info,](/kapacitor/v0.13/nodes/alert_node/#info) [AlertNode.Warn,](/kapacitor/v0.13/nodes/alert_node/#warn) and [AlertNode.Crit](/kapacitor/v0.13/nodes/alert_node/#crit) below.
 
-Different event handlers can be configured for each [AlertNode.](/kapacitor/v0.13/nodes/alert_node/) 
-Some handlers like Email, HipChat, Sensu, Slack, OpsGenie, VictorOps, PagerDuty and Talk have a configuration 
-option &#39;global&#39; that indicates that all alerts implicitly use the handler. 
+Different event handlers can be configured for each [AlertNode.](/kapacitor/v0.13/nodes/alert_node/)
+Some handlers like Email, HipChat, Sensu, Slack, OpsGenie, VictorOps, PagerDuty and Talk have a configuration
+option &#39;global&#39; that indicates that all alerts implicitly use the handler.
 
-Available event handlers: 
+Available event handlers:
 
-* log -- log alert data to file. 
-* post -- HTTP POST data to a specified URL. 
-* email -- Send and email with alert data. 
-* exec -- Execute a command passing alert data over STDIN. 
-* HipChat -- Post alert message to HipChat room. 
-* Alerta -- Post alert message to Alerta. 
-* Sensu -- Post alert message to Sensu client. 
-* Slack -- Post alert message to Slack channel. 
-* OpsGenie -- Send alert to OpsGenie. 
-* VictorOps -- Send alert to VictorOps. 
-* PagerDuty -- Send alert to PagerDuty. 
-* Talk -- Post alert message to Talk client. 
+* log -- log alert data to file.
+* post -- HTTP POST data to a specified URL.
+* email -- Send and email with alert data.
+* exec -- Execute a command passing alert data over STDIN.
+* HipChat -- Post alert message to HipChat room.
+* Alerta -- Post alert message to Alerta.
+* Sensu -- Post alert message to Sensu client.
+* Slack -- Post alert message to Slack channel.
+* OpsGenie -- Send alert to OpsGenie.
+* VictorOps -- Send alert to VictorOps.
+* PagerDuty -- Send alert to PagerDuty.
+* Talk -- Post alert message to Talk client.
 
-See below for more details on configuring each handler. 
+See below for more details on configuring each handler.
 
-Each event that gets sent to a handler contains the following alert data: 
+Each event that gets sent to a handler contains the following alert data:
 
-* ID -- the ID of the alert, user defined. 
-* Message -- the alert message, user defined. 
-* Details -- the alert details, user defined HTML content. 
-* Time -- the time the alert occurred. 
-* Duration -- the duration of the alert in nanoseconds. 
-* Level -- one of OK, INFO, WARNING or CRITICAL. 
-* Data -- influxql.Result containing the data that triggered the alert. 
+* ID -- the ID of the alert, user defined.
+* Message -- the alert message, user defined.
+* Details -- the alert details, user defined HTML content.
+* Time -- the time the alert occurred.
+* Duration -- the duration of the alert in nanoseconds.
+* Level -- one of OK, INFO, WARNING or CRITICAL.
+* Data -- influxql.Result containing the data that triggered the alert.
 
-Events are sent to handlers if the alert is in a state other than &#39;OK&#39; 
-or the alert just changed to the &#39;OK&#39; state from a non &#39;OK&#39; state (a.k.a. the alert recovered). 
-Using the [AlertNode.StateChangesOnly](/kapacitor/v0.13/nodes/alert_node/#statechangesonly) property events will only be sent to handlers 
-if the alert changed state. 
+Events are sent to handlers if the alert is in a state other than &#39;OK&#39;
+or the alert just changed to the &#39;OK&#39; state from a non &#39;OK&#39; state (a.k.a. the alert recovered).
+Using the [AlertNode.StateChangesOnly](/kapacitor/v0.13/nodes/alert_node/#statechangesonly) property events will only be sent to handlers
+if the alert changed state.
 
-It is valid to configure multiple alert handlers, even with the same type. 
+It is valid to configure multiple alert handlers, even with the same type.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -71,21 +71,21 @@ Example:
 ```
 
 
-It is assumed that each successive level filters a subset 
-of the previous level. As a result, the filter will only be applied if 
-a data point passed the previous level. 
-In the above example, if value = 15 then the INFO and 
-WARNING expressions would be evaluated, but not the 
-CRITICAL expression. 
-Each expression maintains its own state. 
+It is assumed that each successive level filters a subset
+of the previous level. As a result, the filter will only be applied if
+a data point passed the previous level.
+In the above example, if value = 15 then the INFO and
+WARNING expressions would be evaluated, but not the
+CRITICAL expression.
+Each expression maintains its own state.
 
-Available Statistics: 
+Available Statistics:
 
-* alerts_triggered -- Total number of alerts triggered 
-* oks_triggered -- Number of OK alerts triggered 
-* infos_triggered -- Number of Info alerts triggered 
-* warns_triggered -- Number of Warn alerts triggered 
-* crits_triggered -- Number of Crit alerts triggered 
+* alerts_triggered -- Total number of alerts triggered
+* oks_triggered -- Number of OK alerts triggered
+* infos_triggered -- Number of Info alerts triggered
+* warns_triggered -- Number of Warn alerts triggered
+* crits_triggered -- Number of Crit alerts triggered
 
 
 
@@ -165,9 +165,9 @@ Property methods are marked using the `.` operator.
 
 ### Alerta
 
-Send the alert to Alerta. 
+Send the alert to Alerta.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -179,13 +179,13 @@ Example:
       origin = "Kapacitor"
 ```
 
-In order to not post a message every alert interval 
-use [AlertNode.StateChangesOnly](/kapacitor/v0.13/nodes/alert_node/#statechangesonly) so that only events 
-where the alert changed state are sent to Alerta. 
+In order to not post a message every alert interval
+use [AlertNode.StateChangesOnly](/kapacitor/v0.13/nodes/alert_node/#statechangesonly) so that only events
+where the alert changed state are sent to Alerta.
 
-Send alerts to Alerta. The resource and event properties are required. 
+Send alerts to Alerta. The resource and event properties are required.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -196,9 +196,9 @@ Example:
                  .event('Something went wrong')
 ```
 
-Alerta also accepts optional alert information. 
+Alerta also accepts optional alert information.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -211,7 +211,7 @@ Example:
                  .group('Dev. Servers')
 ```
 
-NOTE: Alerta cannot be configured globally because of its required properties. 
+NOTE: Alerta cannot be configured globally because of its required properties.
 
 
 ```javascript
@@ -220,9 +220,9 @@ node.alerta()
 
 #### Alerta Environment
 
-Alerta environment. 
-Can be a template and has access to the same data as the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property. 
-Defaut is set from the configuration. 
+Alerta environment.
+Can be a template and has access to the same data as the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property.
+Defaut is set from the configuration.
 
 
 ```javascript
@@ -233,9 +233,9 @@ node.alerta()
 
 #### Alerta Event
 
-Alerta event. 
-Can be a template and has access to the same data as the idInfo property. 
-Default: {{ .ID }} 
+Alerta event.
+Can be a template and has access to the same data as the idInfo property.
+Default: {{ .ID }}
 
 
 ```javascript
@@ -246,9 +246,9 @@ node.alerta()
 
 #### Alerta Group
 
-Alerta group. 
-Can be a template and has access to the same data as the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property. 
-Default: {{ .Group }} 
+Alerta group.
+Can be a template and has access to the same data as the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property.
+Default: {{ .Group }}
 
 
 ```javascript
@@ -259,8 +259,8 @@ node.alerta()
 
 #### Alerta Origin
 
-Alerta origin. 
-If empty uses the origin from the configuration. 
+Alerta origin.
+If empty uses the origin from the configuration.
 
 
 ```javascript
@@ -271,9 +271,9 @@ node.alerta()
 
 #### Alerta Resource
 
-Alerta resource. 
-Can be a template and has access to the same data as the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property. 
-Default: {{ .Name }} 
+Alerta resource.
+Can be a template and has access to the same data as the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property.
+Default: {{ .Name }}
 
 
 ```javascript
@@ -284,8 +284,8 @@ node.alerta()
 
 #### Alerta Token
 
-Alerta authentication token. 
-If empty uses the token from the configuration. 
+Alerta authentication token.
+If empty uses the token from the configuration.
 
 
 ```javascript
@@ -296,9 +296,9 @@ node.alerta()
 
 #### Alerta Value
 
-Alerta value. 
-Can be a template and has access to the same data as the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property. 
-Default is an empty string. 
+Alerta value.
+Can be a template and has access to the same data as the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property.
+Default is an empty string.
 
 
 ```javascript
@@ -310,8 +310,8 @@ node.alerta()
 
 ### All
 
-Indicates an alert should trigger only if all points in a batch match the criteria 
-Does not apply to stream alerts. 
+Indicates an alert should trigger only if all points in a batch match the criteria
+Does not apply to stream alerts.
 
 
 ```javascript
@@ -321,8 +321,8 @@ node.all()
 
 ### Crit
 
-Filter expression for the CRITICAL alert level. 
-An empty value indicates the level is invalid and is skipped. 
+Filter expression for the CRITICAL alert level.
+An empty value indicates the level is invalid and is skipped.
 
 
 ```javascript
@@ -332,21 +332,21 @@ node.crit(value tick.Node)
 
 ### Details
 
-Template for constructing a detailed HTML message for the alert. 
-The same template data is available as the [AlertNode.Message](/kapacitor/v0.13/nodes/alert_node/#message) property, 
-in addition to a Message field that contains the rendered Message value. 
+Template for constructing a detailed HTML message for the alert.
+The same template data is available as the [AlertNode.Message](/kapacitor/v0.13/nodes/alert_node/#message) property,
+in addition to a Message field that contains the rendered Message value.
 
-The intent is that the Message property be a single line summary while the 
-Details property is a more detailed message possibly spanning multiple lines, 
-and containing HTML formatting. 
+The intent is that the Message property be a single line summary while the
+Details property is a more detailed message possibly spanning multiple lines,
+and containing HTML formatting.
 
-This template is rendered using the html/template package in Go so that 
-safe and valid HTML can be generated. 
+This template is rendered using the html/template package in Go so that
+safe and valid HTML can be generated.
 
-The `json` method is available within the template to convert any variable to a valid 
-JSON string. 
+The `json` method is available within the template to convert any variable to a valid
+JSON string.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -360,7 +360,7 @@ Value: {{ index .Fields "value" }}
        .email()
 ```
 
-Default: {{ json . }} 
+Default: {{ json . }}
 
 
 ```javascript
@@ -370,8 +370,8 @@ node.details(value string)
 
 ### DurationField
 
-Optional field key to add the alert duration to the data. 
-The duration is always in units of nanoseconds. 
+Optional field key to add the alert duration to the data.
+The duration is always in units of nanoseconds.
 
 
 ```javascript
@@ -381,18 +381,18 @@ node.durationField(value string)
 
 ### Email
 
-Email the alert data. 
+Email the alert data.
 
-If the To list is empty, the To addresses from the configuration are used. 
-The email subject is the [AlertNode.Message](/kapacitor/v0.13/nodes/alert_node/#message) property. 
-The email body is the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property. 
-The emails are sent as HTML emails and so the body can contain html markup. 
+If the To list is empty, the To addresses from the configuration are used.
+The email subject is the [AlertNode.Message](/kapacitor/v0.13/nodes/alert_node/#message) property.
+The email body is the [AlertNode.Details](/kapacitor/v0.13/nodes/alert_node/#details) property.
+The emails are sent as HTML emails and so the body can contain html markup.
 
-If the &#39;smtp&#39; section in the configuration has the option: global = true 
-then all alerts are sent via email without the need to explicitly state it 
-in the TICKscript. 
+If the &#39;smtp&#39; section in the configuration has the option: global = true
+then all alerts are sent via email without the need to explicitly state it
+in the TICKscript.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -409,9 +409,9 @@ Value: {{ index .Fields "value" }}
        .email()
 ```
 
-Send an email with custom subject and body. 
+Send an email with custom subject and body.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -428,7 +428,7 @@ Example:
        state-changes-only =  true
 ```
 
-Example: 
+Example:
 
 
 ```javascript
@@ -436,7 +436,7 @@ Example:
          |alert()
 ```
 
-Send email to &#39;oncall@example.com&#39; from &#39;kapacitor@example.com&#39; 
+Send email to &#39;oncall@example.com&#39; from &#39;kapacitor@example.com&#39;
 
 
 
@@ -447,7 +447,7 @@ node.email(to ...string)
 
 ### Exec
 
-Execute a command whenever an alert is triggered and pass the alert data over STDIN in JSON format. 
+Execute a command whenever an alert is triggered and pass the alert data over STDIN in JSON format.
 
 
 ```javascript
@@ -457,18 +457,18 @@ node.exec(executable string, args ...string)
 
 ### Flapping
 
-Perform flap detection on the alerts. 
-The method used is similar method to Nagios: 
-https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/flapping.html 
+Perform flap detection on the alerts.
+The method used is similar method to Nagios:
+https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/flapping.html
 
-Each different alerting level is considered a different state. 
-The low and high thresholds are inverted thresholds of a percentage of state changes. 
-Meaning that if the percentage of state changes goes above the `high` 
-threshold, the alert enters a flapping state. The alert remains in the flapping state 
-until the percentage of state changes goes below the `low` threshold. 
-Typical values are low: 0.25 and high: 0.5. The percentage values represent the number state changes 
-over the total possible number of state changes. A percentage change of 0.5 means that the alert changed 
-state in half of the recorded history, and remained the same in the other half of the history. 
+Each different alerting level is considered a different state.
+The low and high thresholds are inverted thresholds of a percentage of state changes.
+Meaning that if the percentage of state changes goes above the `high`
+threshold, the alert enters a flapping state. The alert remains in the flapping state
+until the percentage of state changes goes below the `low` threshold.
+Typical values are low: 0.25 and high: 0.5. The percentage values represent the number state changes
+over the total possible number of state changes. A percentage change of 0.5 means that the alert changed
+state in half of the recorded history, and remained the same in the other half of the history.
 
 
 ```javascript
@@ -479,11 +479,11 @@ node.flapping(low float64, high float64)
 ### HipChat
 
 
-If the &#39;hipchat&#39; section in the configuration has the option: global = true 
-then all alerts are sent to HipChat without the need to explicitly state it 
-in the TICKscript. 
+If the &#39;hipchat&#39; section in the configuration has the option: global = true
+then all alerts are sent to HipChat without the need to explicitly state it
+in the TICKscript.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -496,7 +496,7 @@ Example:
       state-changes-only = true
 ```
 
-Example: 
+Example:
 
 
 ```javascript
@@ -504,7 +504,7 @@ Example:
          |alert()
 ```
 
-Send alert to HipChat using default room &#39;Test Room&#39;. 
+Send alert to HipChat using default room &#39;Test Room&#39;.
 
 
 ```javascript
@@ -513,8 +513,8 @@ node.hipChat()
 
 #### HipChat Room
 
-HipChat room in which to post messages. 
-If empty uses the channel from the configuration. 
+HipChat room in which to post messages.
+If empty uses the channel from the configuration.
 
 
 ```javascript
@@ -525,8 +525,8 @@ node.hipChat()
 
 #### HipChat Token
 
-HipChat authentication token. 
-If empty uses the token from the configuration. 
+HipChat authentication token.
+If empty uses the token from the configuration.
 
 
 ```javascript
@@ -538,11 +538,11 @@ node.hipChat()
 
 ### History
 
-Number of previous states to remember when computing flapping levels and 
-checking for state changes. 
-Minimum value is 2 in order to keep track of current and previous states. 
+Number of previous states to remember when computing flapping levels and
+checking for state changes.
+Minimum value is 2 in order to keep track of current and previous states.
 
-Default: 21 
+Default: 21
 
 
 ```javascript
@@ -552,17 +552,17 @@ node.history(value int64)
 
 ### Id
 
-Template for constructing a unique ID for a given alert. 
+Template for constructing a unique ID for a given alert.
 
-Available template data: 
+Available template data:
 
-* Name -- Measurement name. 
-* TaskName -- The name of the task 
-* Group -- Concatenation of all group-by tags of the form [key=value,]+. 
-If no groupBy is performed equal to literal &#39;nil&#39;. 
-* Tags -- Map of tags. Use &#39;{{ index .Tags &#34;key&#34; }}&#39; to get a specific tag value. 
+* Name -- Measurement name.
+* TaskName -- The name of the task
+* Group -- Concatenation of all group-by tags of the form [key=value,]+.
+If no groupBy is performed equal to literal &#39;nil&#39;.
+* Tags -- Map of tags. Use &#39;{{ index .Tags &#34;key&#34; }}&#39; to get a specific tag value.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -574,9 +574,9 @@ Example:
            .id('kapacitor/{{ .Name }}/{{ .Group }}')
 ```
 
-ID: kapacitor/cpu/cpu=cpu0, 
+ID: kapacitor/cpu/cpu=cpu0,
 
-Example: 
+Example:
 
 
 ```javascript
@@ -588,9 +588,9 @@ Example:
            .id('kapacitor/{{ index .Tags "service" }}')
 ```
 
-ID: kapacitor/authentication 
+ID: kapacitor/authentication
 
-Example: 
+Example:
 
 
 ```javascript
@@ -602,9 +602,9 @@ Example:
            .id('kapacitor/{{ index .Tags "service" }}/{{ index .Tags "host" }}')
 ```
 
-ID: kapacitor/authentication/auth001.example.com 
+ID: kapacitor/authentication/auth001.example.com
 
-Default: {{ .Name }}:{{ .Group }} 
+Default: {{ .Name }}:{{ .Group }}
 
 
 ```javascript
@@ -614,7 +614,7 @@ node.id(value string)
 
 ### IdField
 
-Optional field key to add to the data, containing the alert ID as a string. 
+Optional field key to add to the data, containing the alert ID as a string.
 
 
 ```javascript
@@ -624,7 +624,7 @@ node.idField(value string)
 
 ### IdTag
 
-Optional tag key to use when tagging the data with the alert ID. 
+Optional tag key to use when tagging the data with the alert ID.
 
 
 ```javascript
@@ -634,8 +634,8 @@ node.idTag(value string)
 
 ### Info
 
-Filter expression for the INFO alert level. 
-An empty value indicates the level is invalid and is skipped. 
+Filter expression for the INFO alert level.
+An empty value indicates the level is invalid and is skipped.
 
 
 ```javascript
@@ -645,7 +645,7 @@ node.info(value tick.Node)
 
 ### LevelField
 
-Optional field key to add to the data, containing the alert level as a string. 
+Optional field key to add to the data, containing the alert level as a string.
 
 
 ```javascript
@@ -655,7 +655,7 @@ node.levelField(value string)
 
 ### LevelTag
 
-Optional tag key to use when tagging the data with the alert level. 
+Optional tag key to use when tagging the data with the alert level.
 
 
 ```javascript
@@ -665,10 +665,10 @@ node.levelTag(value string)
 
 ### Log
 
-Log JSON alert data to file. One event per line. 
-Must specify the absolute path to the log file. 
-It will be created if it does not exist. 
-Example: 
+Log JSON alert data to file. One event per line.
+Must specify the absolute path to the log file.
+It will be created if it does not exist.
+Example:
 
 
 ```javascript
@@ -677,7 +677,7 @@ Example:
              .log('/tmp/alert')
 ```
 
-Example: 
+Example:
 
 
 ```javascript
@@ -695,7 +695,7 @@ node.log(filepath string)
 
 #### Log Mode
 
-File&#39;s mode and permissions, default is 0600 
+File&#39;s mode and permissions, default is 0600
 
 
 ```javascript
@@ -707,21 +707,21 @@ node.log(filepath string)
 
 ### Message
 
-Template for constructing a meaningful message for the alert. 
+Template for constructing a meaningful message for the alert.
 
-Available template data: 
+Available template data:
 
-* ID -- The ID of the alert. 
-* Name -- Measurement name. 
-* TaskName -- The name of the task 
-* Group -- Concatenation of all group-by tags of the form [key=value,]+. 
-If no groupBy is performed equal to literal &#39;nil&#39;. 
-* Tags -- Map of tags. Use &#39;{{ index .Tags &#34;key&#34; }}&#39; to get a specific tag value. 
-* Level -- Alert Level, one of: INFO, WARNING, CRITICAL. 
-* Fields -- Map of fields. Use &#39;{{ index .Fields &#34;key&#34; }}&#39; to get a specific field value. 
-* Time -- The time of the point that triggered the event. 
+* ID -- The ID of the alert.
+* Name -- Measurement name.
+* TaskName -- The name of the task
+* Group -- Concatenation of all group-by tags of the form [key=value,]+.
+If no groupBy is performed equal to literal &#39;nil&#39;.
+* Tags -- Map of tags. Use &#39;{{ index .Tags &#34;key&#34; }}&#39; to get a specific tag value.
+* Level -- Alert Level, one of: INFO, WARNING, CRITICAL.
+* Fields -- Map of fields. Use &#39;{{ index .Fields &#34;key&#34; }}&#39; to get a specific field value.
+* Time -- The time of the point that triggered the event.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -734,9 +734,9 @@ Example:
            .message('{{ .ID }} is {{ .Level}} value: {{ index .Fields "value" }}')
 ```
 
-Message: authentication/auth001.example.com is CRITICAL value:42 
+Message: authentication/auth001.example.com is CRITICAL value:42
 
-Default: {{ .ID }} is {{ .Level }} 
+Default: {{ .ID }} is {{ .Level }}
 
 
 ```javascript
@@ -746,12 +746,12 @@ node.message(value string)
 
 ### OpsGenie
 
-Send alert to OpsGenie. 
-To use OpsGenie alerting you must first enable the &#39;Alert Ingestion API&#39; 
-in the &#39;Integrations&#39; section of OpsGenie. 
-Then place the API key from the URL into the &#39;opsgenie&#39; section of the Kapacitor configuration. 
+Send alert to OpsGenie.
+To use OpsGenie alerting you must first enable the &#39;Alert Ingestion API&#39;
+in the &#39;Integrations&#39; section of OpsGenie.
+Then place the API key from the URL into the &#39;opsgenie&#39; section of the Kapacitor configuration.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -762,9 +762,9 @@ Example:
       recipients = ["jim", "bob"]
 ```
 
-With the correct configuration you can now use OpsGenie in TICKscripts. 
+With the correct configuration you can now use OpsGenie in TICKscripts.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -773,9 +773,9 @@ Example:
              .opsGenie()
 ```
 
-Send alerts to OpsGenie using the teams and recipients in the configuration file. 
+Send alerts to OpsGenie using the teams and recipients in the configuration file.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -785,13 +785,13 @@ Example:
              .teams('team_rocket','team_test')
 ```
 
-Send alerts to OpsGenie with team set to &#39;team_rocket&#39; and &#39;team_test&#39; 
+Send alerts to OpsGenie with team set to &#39;team_rocket&#39; and &#39;team_test&#39;
 
-If the &#39;opsgenie&#39; section in the configuration has the option: global = true 
-then all alerts are sent to OpsGenie without the need to explicitly state it 
-in the TICKscript. 
+If the &#39;opsgenie&#39; section in the configuration has the option: global = true
+then all alerts are sent to OpsGenie without the need to explicitly state it
+in the TICKscript.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -802,7 +802,7 @@ Example:
       global = true
 ```
 
-Example: 
+Example:
 
 
 ```javascript
@@ -810,7 +810,7 @@ Example:
          |alert()
 ```
 
-Send alert to OpsGenie using the default recipients, found in the configuration. 
+Send alert to OpsGenie using the default recipients, found in the configuration.
 
 
 ```javascript
@@ -819,7 +819,7 @@ node.opsGenie()
 
 #### OpsGenie Recipients
 
-The list of recipients to be alerted. If empty defaults to the recipients from the configuration. 
+The list of recipients to be alerted. If empty defaults to the recipients from the configuration.
 
 
 ```javascript
@@ -830,7 +830,7 @@ node.opsGenie()
 
 #### OpsGenie Teams
 
-The list of teams to be alerted. If empty defaults to the teams from the configuration. 
+The list of teams to be alerted. If empty defaults to the teams from the configuration.
 
 
 ```javascript
@@ -842,19 +842,19 @@ node.opsGenie()
 
 ### PagerDuty
 
-Send the alert to PagerDuty. 
-To use PagerDuty alerting you must first follow the steps to enable a new &#39;Generic API&#39; service. 
+Send the alert to PagerDuty.
+To use PagerDuty alerting you must first follow the steps to enable a new &#39;Generic API&#39; service.
 
-From https://developer.pagerduty.com/documentation/integration/events 
+From https://developer.pagerduty.com/documentation/integration/events
 
-1. In your account, under the Services tab, click &#34;Add New Service&#34;. 
-2. Enter a name for the service and select an escalation policy. Then, select &#34;Generic API&#34; for the Service Type. 
-3. Click the &#34;Add Service&#34; button. 
-4. Once the service is created, you&#39;ll be taken to the service page. On this page, you&#39;ll see the &#34;Service key&#34;, which is needed to access the API 
+1. In your account, under the Services tab, click &#34;Add New Service&#34;.
+2. Enter a name for the service and select an escalation policy. Then, select &#34;Generic API&#34; for the Service Type.
+3. Click the &#34;Add Service&#34; button.
+4. Once the service is created, you&#39;ll be taken to the service page. On this page, you&#39;ll see the &#34;Service key&#34;, which is needed to access the API
 
-Place the &#39;service key&#39; into the &#39;pagerduty&#39; section of the Kapacitor configuration as the option &#39;service-key&#39;. 
+Place the &#39;service key&#39; into the &#39;pagerduty&#39; section of the Kapacitor configuration as the option &#39;service-key&#39;.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -863,9 +863,9 @@ Example:
       service-key = "xxxxxxxxx"
 ```
 
-With the correct configuration you can now use PagerDuty in TICKscripts. 
+With the correct configuration you can now use PagerDuty in TICKscripts.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -874,11 +874,11 @@ Example:
              .pagerDuty()
 ```
 
-If the &#39;pagerduty&#39; section in the configuration has the option: global = true 
-then all alerts are sent to PagerDuty without the need to explicitly state it 
-in the TICKscript. 
+If the &#39;pagerduty&#39; section in the configuration has the option: global = true
+then all alerts are sent to PagerDuty without the need to explicitly state it
+in the TICKscript.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -888,7 +888,7 @@ Example:
       global = true
 ```
 
-Example: 
+Example:
 
 
 ```javascript
@@ -896,7 +896,7 @@ Example:
          |alert()
 ```
 
-Send alert to PagerDuty. 
+Send alert to PagerDuty.
 
 
 ```javascript
@@ -906,7 +906,7 @@ node.pagerDuty()
 
 ### Post
 
-HTTP POST JSON alert data to a specified URL. 
+HTTP POST JSON alert data to a specified URL.
 
 
 ```javascript
@@ -916,9 +916,9 @@ node.post(url string)
 
 ### Sensu
 
-Send the alert to Sensu. 
+Send the alert to Sensu.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -928,7 +928,7 @@ Example:
       source = "Kapacitor"
 ```
 
-Example: 
+Example:
 
 
 ```javascript
@@ -937,7 +937,7 @@ Example:
              .sensu()
 ```
 
-Send alerts to Sensu client. 
+Send alerts to Sensu client.
 
 
 
@@ -948,13 +948,13 @@ node.sensu()
 
 ### Slack
 
-Send the alert to Slack. 
-To allow Kapacitor to post to Slack, 
-go to the URL https://slack.com/services/new/incoming-webhook 
-and create a new incoming webhook and place the generated URL 
-in the &#39;slack&#39; configuration section. 
+Send the alert to Slack.
+To allow Kapacitor to post to Slack,
+go to the URL https://slack.com/services/new/incoming-webhook
+and create a new incoming webhook and place the generated URL
+in the &#39;slack&#39; configuration section.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -964,11 +964,11 @@ Example:
       channel = "#general"
 ```
 
-In order to not post a message every alert interval 
-use [AlertNode.StateChangesOnly](/kapacitor/v0.13/nodes/alert_node/#statechangesonly) so that only events 
-where the alert changed state are posted to the channel. 
+In order to not post a message every alert interval
+use [AlertNode.StateChangesOnly](/kapacitor/v0.13/nodes/alert_node/#statechangesonly) so that only events
+where the alert changed state are posted to the channel.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -977,9 +977,9 @@ Example:
              .slack()
 ```
 
-Send alerts to Slack channel in the configuration file. 
+Send alerts to Slack channel in the configuration file.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -989,9 +989,9 @@ Example:
              .channel('#alerts')
 ```
 
-Send alerts to Slack channel &#39;#alerts&#39; 
+Send alerts to Slack channel &#39;#alerts&#39;
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1001,13 +1001,13 @@ Example:
              .channel('@jsmith')
 ```
 
-Send alert to user &#39;@jsmith&#39; 
+Send alert to user &#39;@jsmith&#39;
 
-If the &#39;slack&#39; section in the configuration has the option: global = true 
-then all alerts are sent to Slack without the need to explicitly state it 
-in the TICKscript. 
+If the &#39;slack&#39; section in the configuration has the option: global = true
+then all alerts are sent to Slack without the need to explicitly state it
+in the TICKscript.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1019,7 +1019,7 @@ Example:
       state-changes-only = true
 ```
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1027,7 +1027,7 @@ Example:
          |alert()
 ```
 
-Send alert to Slack using default channel &#39;#general&#39;. 
+Send alert to Slack using default channel &#39;#general&#39;.
 
 
 ```javascript
@@ -1036,8 +1036,8 @@ node.slack()
 
 #### Slack Channel
 
-Slack channel in which to post messages. 
-If empty uses the channel from the configuration. 
+Slack channel in which to post messages.
+If empty uses the channel from the configuration.
 
 
 ```javascript
@@ -1049,11 +1049,11 @@ node.slack()
 
 ### StateChangesOnly
 
-Only sends events where the state changed. 
-Each different alert level OK, INFO, WARNING, and CRITICAL 
-are considered different states. 
+Only sends events where the state changed.
+Each different alert level OK, INFO, WARNING, and CRITICAL
+are considered different states.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1069,18 +1069,18 @@ Example:
            .slack()
 ```
 
-If the &#34;value&#34; is greater than 10 for a total of 60s, then 
-only two events will be sent. First, when the value crosses 
-the threshold, and second, when it falls back into an OK state. 
-Without stateChangesOnly, the alert would have triggered 7 times: 
-6 times for each 10s period where the condition was met and once more 
-for the recovery. 
+If the &#34;value&#34; is greater than 10 for a total of 60s, then
+only two events will be sent. First, when the value crosses
+the threshold, and second, when it falls back into an OK state.
+Without stateChangesOnly, the alert would have triggered 7 times:
+6 times for each 10s period where the condition was met and once more
+for the recovery.
 
-An optional maximum interval duration can be provided. 
-An event will not be ignore (aka trigger an alert) if more than the maximum interval has elapsed 
-since the last alert. 
+An optional maximum interval duration can be provided.
+An event will not be ignore (aka trigger an alert) if more than the maximum interval has elapsed
+since the last alert.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1096,7 +1096,7 @@ Example:
            .slack()
 ```
 
-The abvove usage will only trigger alerts to slack on state changes or at least every 10 minutes. 
+The above usage will only trigger alerts to slack on state changes or at least every 10 minutes. 
 
 
 
@@ -1107,18 +1107,18 @@ node.stateChangesOnly(maxInterval ...time.Duration)
 
 ### Talk
 
-Send the alert to Talk. 
-To use Talk alerting you must first follow the steps to create a new incoming webhook. 
+Send the alert to Talk.
+To use Talk alerting you must first follow the steps to create a new incoming webhook.
 
-1. Go to the URL https:/account.jianliao.com/signin. 
-2. Sign in with you account. under the Team tab, click &#34;Integrations&#34;. 
-3. Select &#34;Customize service&#34;, click incoming Webhook &#34;Add&#34; button. 
-4. After choose the topic to connect with &#34;xxx&#34;, click &#34;Confirm Add&#34; button. 
-5. Once the service is created, you&#39;ll see the &#34;Generate Webhook url&#34;. 
+1. Go to the URL https:/account.jianliao.com/signin.
+2. Sign in with you account. under the Team tab, click &#34;Integrations&#34;.
+3. Select &#34;Customize service&#34;, click incoming Webhook &#34;Add&#34; button.
+4. After choose the topic to connect with &#34;xxx&#34;, click &#34;Confirm Add&#34; button.
+5. Once the service is created, you&#39;ll see the &#34;Generate Webhook url&#34;.
 
-Place the &#39;Generate Webhook url&#39; into the &#39;Talk&#39; section of the Kapacitor configuration as the option &#39;url&#39;. 
+Place the &#39;Generate Webhook url&#39; into the &#39;Talk&#39; section of the Kapacitor configuration as the option &#39;url&#39;.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1128,7 +1128,7 @@ Example:
       author_name = "Kapacitor"
 ```
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1137,7 +1137,7 @@ Example:
              .talk()
 ```
 
-Send alerts to Talk client. 
+Send alerts to Talk client.
 
 
 
@@ -1148,12 +1148,12 @@ node.talk()
 
 ### VictorOps
 
-Send alert to VictorOps. 
-To use VictorOps alerting you must first enable the &#39;Alert Ingestion API&#39; 
-in the &#39;Integrations&#39; section of VictorOps. 
-Then place the API key from the URL into the &#39;victorops&#39; section of the Kapacitor configuration. 
+Send alert to VictorOps.
+To use VictorOps alerting you must first enable the &#39;Alert Ingestion API&#39;
+in the &#39;Integrations&#39; section of VictorOps.
+Then place the API key from the URL into the &#39;victorops&#39; section of the Kapacitor configuration.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1163,9 +1163,9 @@ Example:
       routing-key = "everyone"
 ```
 
-With the correct configuration you can now use VictorOps in TICKscripts. 
+With the correct configuration you can now use VictorOps in TICKscripts.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1174,9 +1174,9 @@ Example:
              .victorOps()
 ```
 
-Send alerts to VictorOps using the routing key in the configuration file. 
+Send alerts to VictorOps using the routing key in the configuration file.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1186,13 +1186,13 @@ Example:
              .routingKey('team_rocket')
 ```
 
-Send alerts to VictorOps with routing key &#39;team_rocket&#39; 
+Send alerts to VictorOps with routing key &#39;team_rocket&#39;
 
-If the &#39;victorops&#39; section in the configuration has the option: global = true 
-then all alerts are sent to VictorOps without the need to explicitly state it 
-in the TICKscript. 
+If the &#39;victorops&#39; section in the configuration has the option: global = true
+then all alerts are sent to VictorOps without the need to explicitly state it
+in the TICKscript.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1203,7 +1203,7 @@ Example:
       global = true
 ```
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1211,7 +1211,7 @@ Example:
          |alert()
 ```
 
-Send alert to VictorOps using the default routing key, found in the configuration. 
+Send alert to VictorOps using the default routing key, found in the configuration.
 
 
 ```javascript
@@ -1220,8 +1220,8 @@ node.victorOps()
 
 #### VictorOps RoutingKey
 
-The routing key to use for the alert. 
-Defaults to the value in the configuration if empty. 
+The routing key to use for the alert.
+Defaults to the value in the configuration if empty.
 
 
 ```javascript
@@ -1233,8 +1233,8 @@ node.victorOps()
 
 ### Warn
 
-Filter expression for the WARNING alert level. 
-An empty value indicates the level is invalid and is skipped. 
+Filter expression for the WARNING alert level.
+An empty value indicates the level is invalid and is skipped.
 
 
 ```javascript
@@ -1252,7 +1252,7 @@ Chaining methods are marked using the `|` operator.
 
 ### Alert
 
-Create an alert node, which can trigger alerts. 
+Create an alert node, which can trigger alerts.
 
 
 ```javascript
@@ -1264,7 +1264,7 @@ Returns: [AlertNode](/kapacitor/v0.13/nodes/alert_node/)
 
 ### Bottom
 
-Select the bottom `num` points for `field` and sort by any extra tags or fields. 
+Select the bottom `num` points for `field` and sort by any extra tags or fields.
 
 
 ```javascript
@@ -1276,7 +1276,7 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Count
 
-Count the number of points. 
+Count the number of points.
 
 
 ```javascript
@@ -1288,13 +1288,13 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Deadman
 
-Helper function for creating an alert on low throughput, aka deadman&#39;s switch. 
+Helper function for creating an alert on low throughput, aka deadman&#39;s switch.
 
-- Threshold -- trigger alert if throughput drops below threshold in points/interval. 
-- Interval -- how often to check the throughput. 
-- Expressions -- optional list of expressions to also evaluate. Useful for time of day alerting. 
+- Threshold -- trigger alert if throughput drops below threshold in points/interval.
+- Interval -- how often to check the throughput.
+- Expressions -- optional list of expressions to also evaluate. Useful for time of day alerting.
 
-Example: 
+Example:
 
 
 ```javascript
@@ -1307,8 +1307,8 @@ Example:
     data...
 ```
 
-The above is equivalent to this 
-Example: 
+The above is equivalent to this
+Example:
 
 
 ```javascript
@@ -1328,10 +1328,10 @@ Example:
     data...
 ```
 
-The `id` and `message` alert properties can be configured globally via the &#39;deadman&#39; configuration section. 
+The `id` and `message` alert properties can be configured globally via the &#39;deadman&#39; configuration section.
 
-Since the [AlertNode](/kapacitor/v0.13/nodes/alert_node/) is the last piece it can be further modified as normal. 
-Example: 
+Since the [AlertNode](/kapacitor/v0.13/nodes/alert_node/) is the last piece it can be further modified as normal.
+Example:
 
 
 ```javascript
@@ -1346,8 +1346,8 @@ Example:
     data...
 ```
 
-You can specify additional lambda expressions to further constrain when the deadman&#39;s switch is triggered. 
-Example: 
+You can specify additional lambda expressions to further constrain when the deadman&#39;s switch is triggered.
+Example:
 
 
 ```javascript
@@ -1372,7 +1372,7 @@ Returns: [AlertNode](/kapacitor/v0.13/nodes/alert_node/)
 
 ### Default
 
-Create a node that can set defaults for missing tags or fields. 
+Create a node that can set defaults for missing tags or fields.
 
 
 ```javascript
@@ -1384,7 +1384,7 @@ Returns: [DefaultNode](/kapacitor/v0.13/nodes/default_node/)
 
 ### Derivative
 
-Create a new node that computes the derivative of adjacent points. 
+Create a new node that computes the derivative of adjacent points.
 
 
 ```javascript
@@ -1396,7 +1396,7 @@ Returns: [DerivativeNode](/kapacitor/v0.13/nodes/derivative_node/)
 
 ### Distinct
 
-Produce batch of only the distinct points. 
+Produce batch of only the distinct points.
 
 
 ```javascript
@@ -1408,7 +1408,7 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Elapsed
 
-Compute the elapsed time between points 
+Compute the elapsed time between points
 
 
 ```javascript
@@ -1420,9 +1420,9 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Eval
 
-Create an eval node that will evaluate the given transformation function to each data point. 
-A list of expressions may be provided and will be evaluated in the order they are given 
-and results of previous expressions are made available to later expressions. 
+Create an eval node that will evaluate the given transformation function to each data point.
+A list of expressions may be provided and will be evaluated in the order they are given
+and results of previous expressions are made available to later expressions.
 
 
 ```javascript
@@ -1434,7 +1434,7 @@ Returns: [EvalNode](/kapacitor/v0.13/nodes/eval_node/)
 
 ### First
 
-Select the first point. 
+Select the first point.
 
 
 ```javascript
@@ -1446,10 +1446,10 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### GroupBy
 
-Group the data by a set of tags. 
+Group the data by a set of tags.
 
-Can pass literal * to group by all dimensions. 
-Example: 
+Can pass literal * to group by all dimensions.
+Example:
 
 
 ```javascript
@@ -1467,11 +1467,11 @@ Returns: [GroupByNode](/kapacitor/v0.13/nodes/group_by_node/)
 
 ### HttpOut
 
-Create an http output node that caches the most recent data it has received. 
-The cached data is available at the given endpoint. 
-The endpoint is the relative path from the API endpoint of the running task. 
-For example if the task endpoint is at &#34;/api/v1/task/&lt;task_name&gt;&#34; and endpoint is 
-&#34;top10&#34;, then the data can be requested from &#34;/api/v1/task/&lt;task_name&gt;/top10&#34;. 
+Create an http output node that caches the most recent data it has received.
+The cached data is available at the given endpoint.
+The endpoint is the relative path from the API endpoint of the running task.
+For example if the task endpoint is at &#34;/api/v1/task/&lt;task_name&gt;&#34; and endpoint is
+&#34;top10&#34;, then the data can be requested from &#34;/api/v1/task/&lt;task_name&gt;/top10&#34;.
 
 
 ```javascript
@@ -1483,7 +1483,7 @@ Returns: [HTTPOutNode](/kapacitor/v0.13/nodes/http_out_node/)
 
 ### InfluxDBOut
 
-Create an influxdb output node that will store the incoming data into InfluxDB. 
+Create an influxdb output node that will store the incoming data into InfluxDB.
 
 
 ```javascript
@@ -1495,7 +1495,7 @@ Returns: [InfluxDBOutNode](/kapacitor/v0.13/nodes/influx_d_b_out_node/)
 
 ### Join
 
-Join this node with other nodes. The data is joined on timestamp. 
+Join this node with other nodes. The data is joined on timestamp.
 
 
 ```javascript
@@ -1507,7 +1507,7 @@ Returns: [JoinNode](/kapacitor/v0.13/nodes/join_node/)
 
 ### Last
 
-Select the last point. 
+Select the last point.
 
 
 ```javascript
@@ -1519,7 +1519,7 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Max
 
-Select the maximum point. 
+Select the maximum point.
 
 
 ```javascript
@@ -1531,7 +1531,7 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Mean
 
-Compute the mean of the data. 
+Compute the mean of the data.
 
 
 ```javascript
@@ -1543,8 +1543,8 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Median
 
-Compute the median of the data. Note, this method is not a selector, 
-if you want the median point use .percentile(field, 50.0). 
+Compute the median of the data. Note, this method is not a selector,
+if you want the median point use .percentile(field, 50.0).
 
 
 ```javascript
@@ -1556,7 +1556,7 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Min
 
-Select the minimum point. 
+Select the minimum point.
 
 
 ```javascript
@@ -1568,7 +1568,7 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Percentile
 
-Select a point at the given percentile. This is a selector function, no interpolation between points is performed. 
+Select a point at the given percentile. This is a selector function, no interpolation between points is performed.
 
 
 ```javascript
@@ -1580,9 +1580,9 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Sample
 
-Create a new node that samples the incoming points or batches. 
+Create a new node that samples the incoming points or batches.
 
-One point will be emitted every count or duration specified. 
+One point will be emitted every count or duration specified.
 
 
 ```javascript
@@ -1594,7 +1594,7 @@ Returns: [SampleNode](/kapacitor/v0.13/nodes/sample_node/)
 
 ### Shift
 
-Create a new node that shifts the incoming points or batches in time. 
+Create a new node that shifts the incoming points or batches in time.
 
 
 ```javascript
@@ -1606,7 +1606,7 @@ Returns: [ShiftNode](/kapacitor/v0.13/nodes/shift_node/)
 
 ### Spread
 
-Compute the difference between min and max points. 
+Compute the difference between min and max points.
 
 
 ```javascript
@@ -1618,9 +1618,9 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Stats
 
-Create a new stream of data that contains the internal statistics of the node. 
-The interval represents how often to emit the statistics based on real time. 
-This means the interval time is independent of the times of the data points the source node is receiving. 
+Create a new stream of data that contains the internal statistics of the node.
+The interval represents how often to emit the statistics based on real time.
+This means the interval time is independent of the times of the data points the source node is receiving.
 
 
 ```javascript
@@ -1632,7 +1632,7 @@ Returns: [StatsNode](/kapacitor/v0.13/nodes/stats_node/)
 
 ### Stddev
 
-Compute the standard deviation. 
+Compute the standard deviation.
 
 
 ```javascript
@@ -1644,7 +1644,7 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Sum
 
-Compute the sum of all values. 
+Compute the sum of all values.
 
 
 ```javascript
@@ -1656,7 +1656,7 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Top
 
-Select the top `num` points for `field` and sort by any extra tags or fields. 
+Select the top `num` points for `field` and sort by any extra tags or fields.
 
 
 ```javascript
@@ -1668,7 +1668,7 @@ Returns: [InfluxQLNode](/kapacitor/v0.13/nodes/influx_q_l_node/)
 
 ### Union
 
-Perform the union of this node and all other given nodes. 
+Perform the union of this node and all other given nodes.
 
 
 ```javascript
@@ -1680,7 +1680,7 @@ Returns: [UnionNode](/kapacitor/v0.13/nodes/union_node/)
 
 ### Where
 
-Create a new node that filters the data stream by a given expression. 
+Create a new node that filters the data stream by a given expression.
 
 
 ```javascript
@@ -1692,9 +1692,9 @@ Returns: [WhereNode](/kapacitor/v0.13/nodes/where_node/)
 
 ### Window
 
-Create a new node that windows the stream by time. 
+Create a new node that windows the stream by time.
 
-NOTE: Window can only be applied to stream edges. 
+NOTE: Window can only be applied to stream edges.
 
 
 ```javascript
@@ -1702,4 +1702,3 @@ node|window()
 ```
 
 Returns: [WindowNode](/kapacitor/v0.13/nodes/window_node/)
-

--- a/content/kapacitor/v1.0/nodes/alert_node.md
+++ b/content/kapacitor/v1.0/nodes/alert_node.md
@@ -1225,7 +1225,7 @@ Example:
            .slack()
 ```
 
-The abvove usage will only trigger alerts to slack on state changes or at least every 10 minutes.
+The above usage will only trigger alerts to slack on state changes or at least every 10 minutes.
 
 
 


### PR DESCRIPTION
Small changes:

* Fixes the typo in `alert_node`, #782 
* Adds `continuous query name` and `subscription name` to the list of identifiers in the glossary

Larger changes:

* Creates a new `Error Messages` page and moves error-related FAQs to it
* Adds a description of the `bad timestamp` error to the `Error Messages` page, #793
* Adds a description of the `cache maximum memory size exceeded` error to the `Error Messages` page, #773




