### PR TITLE
Rename node-influx to `influx` on the clients page

### DIFF
--- a/content/influxdb/v1.0/tools/api_client_libraries.md
+++ b/content/influxdb/v1.0/tools/api_client_libraries.md
@@ -24,7 +24,7 @@ Functionality will vary, and there are, as yet, no standard features that all li
 - [InfluxDB Java](https://github.com/influxdb/influxdb-java) by [majst01](https://github.com/majst01)
 
 ## JavaScript/Node.js
-- [node-influx](https://github.com/node-influx/node-influx) by [node-influx](https://github.com/node-influx)
+- [influx](https://github.com/node-influx/node-influx) by [node-influx](https://github.com/node-influx)
 
 ## Lisp
 - [cl-influxdb](https://github.com/mmaul/cl-influxdb) by [mmaul](https://github.com/mmaul)


### PR DESCRIPTION
The repo is named [node-influx](https://github.com/node-influx/node-influx), primarily for Google-ability and historical reasons I believe (I just joined / took over maintenance this year), but the package itself is published in the JavaScript ecosystem as simply [`influx`](https://www.npmjs.com/package/influx). The package actually called `node-influx` [appears to be](https://www.npmjs.com/package/node-influx) a virtual currency.