### PR TITLE
Add shard group duration section to schema page

### DIFF
--- a/content/influxdb/v1.0/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.0/concepts/schema_and_data_layout.md
@@ -9,11 +9,22 @@ menu:
 Every InfluxDB use case is special and your [schema](/influxdb/v1.0/concepts/glossary/#schema) will reflect that uniqueness.
 There are, however, general guidelines to follow and pitfalls to avoid when designing your schema.
 
-## Encouraged Schema Design
+<table style="width:100%">
+  <tr>
+    <td><a href="#general-recommendations">General Recommendations</a></td>
+    <td><a href="#encouraged-schema-design">Encouraged Schema Design</a></td>
+    <td><a href="#discouraged-schema-design">Discouraged Schema Design</a></td>
+    <td><a href="#shard-group-duration-management">Shard Group Duration Management</a></td>
+  </tr>
+</table>
+
+## General Recommendations
+
+### Encouraged Schema Design
 
 In no particular order, we recommend that you:
 
-### *Encode meta data in tags*
+#### *Encode meta data in tags*
 
 [Tags](/influxdb/v1.0/concepts/glossary/#tag) are indexed and [fields](/influxdb/v1.0/concepts/glossary/#field) are not indexed.
 This means that queries on tags are more performant than those on fields.
@@ -25,7 +36,7 @@ In general, your queries should guide what gets stored as a tag and what gets st
 * Store data in fields if you plan to use them with an [InfluxQL function](/influxdb/v1.0/query_language/functions/)
 * Store data in fields if you *need* them to be something other than a string - [tag values](/influxdb/v1.0/concepts/glossary/#tag-value) are always interpreted as strings
 
-### *Avoid using InfluxQL Keywords as identifier names*
+#### *Avoid using InfluxQL Keywords as identifier names*
 
 This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
 Identifiers are database names, [retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v1.0/concepts/glossary/#user) names, [measurement](/influxdb/v1.0/concepts/glossary/#measurement) names, [tag keys](/influxdb/v1.0/concepts/glossary/#tag-key), and [field keys](/influxdb/v1.0/concepts/glossary/#field-key).
@@ -33,18 +44,18 @@ See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influ
 
 Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 
-## Discouraged Schema Design
+### Discouraged Schema Design
 
 In no particular order, we recommend that you:
 
-### *Don't have too many series*
+#### *Don't have too many series*
 
 [Tags](/influxdb/v1.0/concepts/glossary/#tag) containing highly variable information like UUIDs, hashes, and random strings will lead to a large number of series in the database, known colloquially as high series cardinality.
 High series cardinality is a primary driver of high memory usage for many database workloads.
 
 See [Hardware Sizing Guidelines](/influxdb/v1.0/guides/hardware_sizing/#general-hardware-guidelines-for-a-single-node) for [series cardinality](/influxdb/v1.0/concepts/glossary/#series-cardinality) recommendations based on your hardware. If the system has memory constraints, consider storing high-cardinality data as a field rather than a tag.
 
-### *Don't encode data in measurement names*
+#### *Don't encode data in measurement names*
 
 In general, taking this step will simplify your queries.
 InfluxDB queries merge data that fall within the same [measurement](/influxdb/v1.0/concepts/glossary/#measurement); it's better to differentiate data with [tags](/influxdb/v1.0/concepts/glossary/#tag) than with detailed measurement names.
@@ -84,7 +95,7 @@ While both queries are relatively simple, use of the regular expression make cer
 > SELECT mean("temp") FROM "weather_sensor" WHERE "region" = 'north'
 ```
 
-### *Don't put more than one piece of information in one tag*
+#### *Don't put more than one piece of information in one tag*
 
 Similar to the point above, splitting a single tag with multiple pieces into separate tags will simplify your queries and reduce the need for regular expressions.
 
@@ -119,3 +130,39 @@ While both queries are similar, the use of multiple tags in Schema 2 avoids the 
 # Schema 2 - Query for data encoded in multiple tags
 > SELECT mean("temp") FROM "weather_sensor" WHERE region = 'north'
 ```
+
+## Shard Group Duration Management
+
+### Shard Group Duration Overview
+
+InfluxDB stores data in shard groups.
+Shard groups are organized by [retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp) (RP) and store data with timestamps that fall within a specific time interval.
+The length of that time interval is called the [shard group duration](/influxdb/v1.0/concepts/glossary/#shard-duration).
+
+By default, the shard group duration is determined by the RP's [duration](/influxdb/v1.0/concepts/glossary/#duration):
+
+| RP Duration  | Shard Group Duration  |
+|---|---|
+| < 2 days  | 1 hour  |
+| >= 2 days and <= 6 months  | 1 day  |
+| > 6 months  | 7 days  |
+
+The shard group duration is also configurable per RP.
+See [Retention Policy Management](/influxdb/v1.0/query_language/database_management/#retention-policy-management) for how to configure the
+shard group duration.
+
+### Shard Group Duration Recommendations
+
+In general, shorter shard group durations allow the system to efficiently drop data.
+When InfluxDB enforces an RP it drops entire shard groups, not individual data points.
+For example, if your RP has a duration of one day, it makes sense to have a shard group duration of one hour; InfluxDB will drop an hour worth of data every hour.
+
+If your RP's duration is greater than six months, there's no need to have a short shard group duration.
+In fact, increasing the shard group duration beyond the default seven day value can improve compression, improve write speed, and decrease the fixed iterator overhead per shard group.
+Shard group durations of 50 years and over, for example, are acceptable configurations.
+
+We recommend configuring the shard group duration such that:
+
+* it is two times your longest typical query's time range
+* each shard group has at least 100,000 [points](/influxdb/v1.0/concepts/glossary/#point) per shard group
+* each shard group had at least 1,000 points per [series](/influxdb/v1.0/concepts/glossary/#series)

--- a/content/influxdb/v1.0/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.0/concepts/schema_and_data_layout.md
@@ -18,13 +18,13 @@ There are, however, general guidelines to follow and pitfalls to avoid when desi
   </tr>
 </table>
 
-## General Recommendations
+# General Recommendations
 
-### Encouraged Schema Design
+## Encouraged Schema Design
 
 In no particular order, we recommend that you:
 
-#### *Encode meta data in tags*
+### *Encode meta data in tags*
 
 [Tags](/influxdb/v1.0/concepts/glossary/#tag) are indexed and [fields](/influxdb/v1.0/concepts/glossary/#field) are not indexed.
 This means that queries on tags are more performant than those on fields.
@@ -36,7 +36,7 @@ In general, your queries should guide what gets stored as a tag and what gets st
 * Store data in fields if you plan to use them with an [InfluxQL function](/influxdb/v1.0/query_language/functions/)
 * Store data in fields if you *need* them to be something other than a string - [tag values](/influxdb/v1.0/concepts/glossary/#tag-value) are always interpreted as strings
 
-#### *Avoid using InfluxQL Keywords as identifier names*
+### *Avoid using InfluxQL Keywords as identifier names*
 
 This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
 Identifiers are database names, [retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v1.0/concepts/glossary/#user) names, [measurement](/influxdb/v1.0/concepts/glossary/#measurement) names, [tag keys](/influxdb/v1.0/concepts/glossary/#tag-key), and [field keys](/influxdb/v1.0/concepts/glossary/#field-key).
@@ -44,18 +44,18 @@ See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influ
 
 Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 
-### Discouraged Schema Design
+## Discouraged Schema Design
 
 In no particular order, we recommend that you:
 
-#### *Don't have too many series*
+### *Don't have too many series*
 
 [Tags](/influxdb/v1.0/concepts/glossary/#tag) containing highly variable information like UUIDs, hashes, and random strings will lead to a large number of series in the database, known colloquially as high series cardinality.
 High series cardinality is a primary driver of high memory usage for many database workloads.
 
 See [Hardware Sizing Guidelines](/influxdb/v1.0/guides/hardware_sizing/#general-hardware-guidelines-for-a-single-node) for [series cardinality](/influxdb/v1.0/concepts/glossary/#series-cardinality) recommendations based on your hardware. If the system has memory constraints, consider storing high-cardinality data as a field rather than a tag.
 
-#### *Don't encode data in measurement names*
+### *Don't encode data in measurement names*
 
 In general, taking this step will simplify your queries.
 InfluxDB queries merge data that fall within the same [measurement](/influxdb/v1.0/concepts/glossary/#measurement); it's better to differentiate data with [tags](/influxdb/v1.0/concepts/glossary/#tag) than with detailed measurement names.
@@ -95,7 +95,7 @@ While both queries are relatively simple, use of the regular expression make cer
 > SELECT mean("temp") FROM "weather_sensor" WHERE "region" = 'north'
 ```
 
-#### *Don't put more than one piece of information in one tag*
+### *Don't put more than one piece of information in one tag*
 
 Similar to the point above, splitting a single tag with multiple pieces into separate tags will simplify your queries and reduce the need for regular expressions.
 
@@ -131,9 +131,9 @@ While both queries are similar, the use of multiple tags in Schema 2 avoids the 
 > SELECT mean("temp") FROM "weather_sensor" WHERE region = 'north'
 ```
 
-## Shard Group Duration Management
+# Shard Group Duration Management
 
-### Shard Group Duration Overview
+## Shard Group Duration Overview
 
 InfluxDB stores data in shard groups.
 Shard groups are organized by [retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp) (RP) and store data with timestamps that fall within a specific time interval.
@@ -151,7 +151,7 @@ The shard group duration is also configurable per RP.
 See [Retention Policy Management](/influxdb/v1.0/query_language/database_management/#retention-policy-management) for how to configure the
 shard group duration.
 
-### Shard Group Duration Recommendations
+## Shard Group Duration Recommendations
 
 In general, shorter shard group durations allow the system to efficiently drop data.
 When InfluxDB enforces an RP it drops entire shard groups, not individual data points.


### PR DESCRIPTION
Adds a separate shard group duration management section to the schema design page.
It outlines the information provided in #800.