### PR TITLE
Fix two small issues

### DIFF
--- a/content/influxdb/v1.0/troubleshooting/errors.md
+++ b/content/influxdb/v1.0/troubleshooting/errors.md
@@ -13,6 +13,23 @@ common resolutions.
 **Disclaimer:** This document does not contain an exhaustive list of all possible InfluxDB errors.
 </dt>
 
+## error: max series per database exceeded: < >
+The `max series per database exceeded` error occurs when a write causes the
+number of [series](/influxdb/v1.0/concepts/glossary/#series) in a database to
+exceed the maximum allowable series per database.
+The maximum allowable series per database is controlled by the
+`max-series-per-database` setting in the `[data]` section of the configuration
+file.
+
+The information in the `< >` shows the measurement and the tag set of the series
+that exceeded `max-series-per-database`.
+
+By default `max-series-per-database` is set to one million.
+Changing the setting to `0` allows an unlimited number of series per database.
+
+**Resources:**
+[Database Configuration](/influxdb/v1.0/administration/config/#max-series-per-database-1000000)
+
 ## error parsing query: found < >, expected identifier at line < >, char < >
 
 ### InfluxQL Syntax

--- a/content/influxdb/v1.0/troubleshooting/errors.md
+++ b/content/influxdb/v1.0/troubleshooting/errors.md
@@ -219,6 +219,19 @@ Use a comma instead of a space between the two fields to avoid the error:
 [Line Protocol Tutorial](/influxdb/v1.0/write_protocols/line_protocol_tutorial/),
 [Line Protocol Reference](/influxdb/v1.0/write_protocols/line_protocol_reference/)
 
+## unable to parse < >: time outside range
+
+The `time outside range` error occurs when the timestamp in the
+[line protocol](/influxdb/v1.0/concepts/glossary/#line-protocol)
+falls outside the valid time range for InfluxDB.
+
+The minimum valid timestamp is `-9223372036854775806` or `1677-09-21T00:12:43.145224194Z`.
+The maximum valid timestamp is `9223372036854775806` or `2262-04-11T23:47:16.854775806Z`.
+
+**Resources:**
+[Line Protocol Tutorial](/influxdb/v1.0/write_protocols/line_protocol_tutorial/#data-types),
+[Line Protocol Reference](/influxdb/v1.0/write_protocols/line_protocol_reference/#data-types)
+
 ## write failed for shard < >: engine: cache maximum memory size exceeded
 
 The `cache maximum memory size exceeded` error occurs when the cached

--- a/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
@@ -30,6 +30,7 @@ Where applicable, it links to outstanding issues on GitHub.
 * [Why can't I query boolean field values?](#why-can-t-i-query-boolean-field-values)  
 * [How does InfluxDB handle field type discrepancies across shards?](#how-does-influxdb-handle-field-type-discrepancies-across-shards)  
 * [What are the minimum and maximum integers that InfluxDB can store?](#what-are-the-minimum-and-maximum-integers-that-influxdb-can-store)  
+* [What are the minimum and maximum timestamps that InfluxDB can store?](#what-are-the-minimum-and-maximum-timestamps-that-influxdb-can-store)
 * [How can I tell what type of data are stored in a field?](#how-can-i-tell-what-type-of-data-are-stored-in-a-field)
 * [Can I change a field's data type?](#can-i-change-a-field-s-data-type)
 
@@ -310,6 +311,11 @@ See [Go builtins](http://golang.org/pkg/builtin/#int64) for more information.
 
 Values close to but within those limits may lead to unexpected results; some functions and operators convert the int64 data type to float64 during calculation which can cause overflow issues.
 
+## What are the minimum and maximum timestamps that InfluxDB can store?
+The minimum timestamp is `-9223372036854775806` or `1677-09-21T00:12:43.145224194Z`.
+The maximum timestamp is `9223372036854775806` or `2262-04-11T23:47:16.854775806Z`.
+
+Timestamps outside that range return a [parsing error](/influxdb/v1.0/troubleshooting/errors/#unable-to-parse-time-outside-range).
 
 ## How can I tell what type of data are stored in a field?
 

--- a/content/influxdb/v1.0/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.0/write_protocols/line_protocol_reference.md
@@ -50,6 +50,7 @@ This can result in significant improvements in compression.
 | Integer | Field values | Signed 64-bit integers (-9223372036854775808 to 9223372036854775807). Specify an integer with a trailing `i` on the number. |
 | String | Measurements, tag keys, tag values, field keys, field values | Length limit 64KB. |
 | Boolean | Field values | Stores TRUE or FALSE values.<br><br>TRUE write syntax:`[t, T, true, True, TRUE]`.<br><br>FALSE write syntax:`[f, F, false, False, FALSE]` |
+| Timestamp | Timestamps | Unix nanosecond timestamp. Specify alternative precisions with the [HTTP API](/influxdb/v1.0/tools/api/#write). The minimum valid timestamp is `-9223372036854775806` or `1677-09-21T00:12:43.145224194Z`. The maximum valid timestamp is `9223372036854775806` or `2262-04-11T23:47:16.854775806Z`. |
 
 ### More on field value types
 

--- a/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.0/write_protocols/line_protocol_tutorial.md
@@ -163,6 +163,8 @@ It's a good idea to take into account that information when designing your
 [schema](/influxdb/v1.0/concepts/glossary/#schema).
 
 Timestamps are UNIX timestamps.
+The minimum valid timestamp is `-9223372036854775806` or `1677-09-21T00:12:43.145224194Z`.
+The maximum valid timestamp is `9223372036854775806` or `2262-04-11T23:47:16.854775806Z`.
 As mentioned above, by default, InfluxDB assumes that timestamps have
 nanosecond precision.
 See the [API Reference](/influxdb/v1.0/tools/api/#write) for how to specify


### PR DESCRIPTION
Adds a question to the FAQ about the min and max allowable timestamps in the database. Also adds this information to the line protocol pages and documents the error that occurs when those timestamps are exceeded. Fixes #467.

Adds the `max series per database exceeded` error to the errors page. Fixes #819.

@beckettsean, I didn't see the  `write failed for shard XX` text in the `max series per database exceeded` error. I tested it out on OSS 1.0.2. 
