### PR TITLE
Update requirements on Influx due to HTTP subscriptions

### DIFF
--- a/content/kapacitor/v1.0/introduction/getting_started.md
+++ b/content/kapacitor/v1.0/introduction/getting_started.md
@@ -18,7 +18,7 @@ What you will need
 Don't worry about installing anything yet, instructions are found below.
 
 * [InfluxDB](/docs/v0.9/introduction/installation.html)  - While Kapacitor does not require InfluxDB it is the easiest to setup and so we will use it in this guide.
-You will need InfluxDB >= 0.13
+You will need InfluxDB >= 1.0.0
 * [Telegraf](https://github.com/influxdb/telegraf#installation) - We will use a specific Telegraf config to send data to InfluxDB so that the examples Kapacitor tasks have context.
 You will need Telegraf >= 0.13
 * [Kapacitor](https://github.com/influxdb/kapacitor) - You can get the latest Kapacitor binaries for your OS at the [downloads](https://influxdata.com/downloads/#kapacitor) page.


### PR DESCRIPTION
Subscriptions with HTTP were added to Influx for v1.0.0. The Kapacitor config by default creates HTTP subscriptions. Therefore, the version for Influx must be >= 1.0.0.

I went round in circles for a while as Influx SHOW SUBSCRIPTIONS showed HTTP subscriptions yet nothing worked. Upgrading Influx to 1.0.0 made everything work.
