### PR TITLE
enforce 3 meta nodes

### DIFF
--- a/content/enterprise/v1.0/introduction/meta_node_installation.md
+++ b/content/enterprise/v1.0/introduction/meta_node_installation.md
@@ -21,9 +21,10 @@ The steps below set up three
 [meta nodes](/enterprise/v1.0/concepts/glossary/#meta-node) with each meta node
 on its own server.
 
-Please note that there is no requirement to use that number of servers.
-The meta process can run on the same or different servers.
-For high availability and redundancy your cluster should have at least three
+You **must** add 3 meta nodes at minimum while setting up the cluster.
+
+There is no requirement to use exactly that number of servers, but
+for high availability and redundancy your cluster should have at least three
 meta nodes and an odd number of meta nodes.
 See the
 [Clustering Guide](/enterprise/v1.0/concepts/clustering#optimal-server-counts)

--- a/content/enterprise/v1.0/introduction/meta_node_installation.md
+++ b/content/enterprise/v1.0/introduction/meta_node_installation.md
@@ -25,7 +25,8 @@ You **must** add 3 meta nodes at minimum while setting up the cluster.
 
 There is no requirement to use exactly that number of servers, but
 for high availability and redundancy your cluster should have at least three
-meta nodes and an odd number of meta nodes.
+meta nodes and an odd number of meta nodes. 
+More than three meta nodes is not recommended unless the servers are unreliable.
 See the
 [Clustering Guide](/enterprise/v1.0/concepts/clustering#optimal-server-counts)
 for more on cluster architecture.


### PR DESCRIPTION
Users have been trying to initiate clusters with 1 or 2 meta nodes, assuming that the 3rd one is just for redundancy since we state that a cluster can survive the loss of one metanode.

It needs to be made clear in the installation guide that a minimum number of 3 meta nodes is required to set up a healthy cluster.

@rkuchan @beckettsean 