### PR TITLE
Fix inconsistent spacing in auth example

### DIFF
--- a/content/influxdb/v1.1/query_language/authentication_and_authorization.md
+++ b/content/influxdb/v1.1/query_language/authentication_and_authorization.md
@@ -57,7 +57,7 @@ Enable authentication by setting the `auth-enabled` option to `true` in the `[ht
 [http]  
   enabled = true  
   bind-address = ":8086"  
- auth-enabled = true # ✨
+  auth-enabled = true # ✨
   log-enabled = true  
   write-tracing = false  
   pprof-enabled = false  


### PR DESCRIPTION
If the spacing is there to call out the important bits disregard this pr