### PR TITLE
fix incorrect version number on diff link text

### DIFF
--- a/content/influxdb/v1.1/administration/previous_differences.md
+++ b/content/influxdb/v1.1/administration/previous_differences.md
@@ -12,12 +12,12 @@ menu:
     parent: administration
 ---
 
-If you're using version 1.0, please see [Differences Between InfluxDB 1.0 and 1.0](/influxdb/v1.1/administration/differences/).
+If you're using version 1.0, please see [Differences Between InfluxDB 1.1 and 1.0](/influxdb/v1.1/administration/differences/).
 
 Users looking to upgrade to InfluxDB 1.1 from versions prior to 1.0 should view the following pages in our documentation.
 
 ##### 0.13 users:
-[Differences Between InfluxDB 1.0 and 1.1](/influxdb/v1.0/administration/013_vs_1/)
+[Differences Between InfluxDB 1.0 and 1.13](/influxdb/v1.0/administration/013_vs_1/)
 
 ##### 0.12 users:
 [Differences Between InfluxDB 0.13 and 0.12](/influxdb/v0.13/administration/012_vs_013/)

--- a/content/influxdb/v1.1/administration/previous_differences.md
+++ b/content/influxdb/v1.1/administration/previous_differences.md
@@ -17,7 +17,7 @@ If you're using version 1.0, please see [Differences Between InfluxDB 1.1 and 1.
 Users looking to upgrade to InfluxDB 1.1 from versions prior to 1.0 should view the following pages in our documentation.
 
 ##### 0.13 users:
-[Differences Between InfluxDB 1.0 and 1.13](/influxdb/v1.0/administration/013_vs_1/)
+[Differences Between InfluxDB 1.0 and 0.13](/influxdb/v1.0/administration/013_vs_1/)
 
 ##### 0.12 users:
 [Differences Between InfluxDB 0.13 and 0.12](/influxdb/v0.13/administration/012_vs_013/)


### PR DESCRIPTION
This is a typo fix on text of diff links.