### PR TITLE
Fix for build issue

### DIFF
--- a/content/chronograf/deprecated/administration/chronograf-product-faq.md
+++ b/content/chronograf/deprecated/administration/chronograf-product-faq.md
@@ -1,0 +1,10 @@
+---
+title: Chronograf Product FAQ
+
+menu:
+  chronograf_deprecated:
+    name: Chronograf Product FAQ
+    weight: 0
+    parent: Administration
+    url: /chronograf/v1.1/administration/chronograf-product-faq/
+---

--- a/content/chronograf/deprecated/administration/index.md
+++ b/content/chronograf/deprecated/administration/index.md
@@ -1,0 +1,8 @@
+---
+title: Administration
+
+menu:
+  Deprecated:
+    name: Administration
+    weight: 0
+---

--- a/content/chronograf/deprecated/index.md
+++ b/content/chronograf/deprecated/index.md
@@ -4,7 +4,7 @@ title: Notice of Deprecated Chronograf Versions
 menu:
   chronograf:
     name: Deprecated
-    identifier: v0.0
+    identifier: chronograf_deprecated
     weight: 1
 ---
 


### PR DESCRIPTION
Adds an item to the deprecated section's sidebar to get rid of the build error below:
```
ERROR: 2016/11/16 template: partials/chronograf/sidebar.html:26:35: executing "partials/chronograf/sidebar.html" at <.Identifier>: range can't iterate over <*hugolib.Menu Value> in partials/chronograf/sidebar.html
```