### PR TITLE
Fix link to old v0.11 SourceBatchNode

### DIFF
--- a/content/kapacitor/v1.1/tick/index.md
+++ b/content/kapacitor/v1.1/tick/index.md
@@ -22,7 +22,7 @@ These methods come in two flavors.
 The reference documentation lists each node's `Property` and `Chaining` methods along with examples and descriptions.
 
 Every TICKscript will have either a `stream` or `batch` variable defined depending on the type of task you want to run.
-The `stream` and `batch` variables are an instance of a [StreamNode](/kapacitor/v1.1/nodes/stream_node/) or [SourceBatchNode](/kapacitor/v0.11/nodes/source_batch_node/) respectively.
+The `stream` and `batch` variables are an instance of a [StreamNode](/kapacitor/v1.1/nodes/stream_node/) or [BatchNode](/kapacitor/v1.1/nodes/batch_node/) respectively.
 
 Pipelines
 ---------


### PR DESCRIPTION
The old documentation page for SourceBatchNode was linked:
https://docs.influxdata.com/kapacitor/v0.11/nodes/source_batch_node/

But the current version for 1.1 is:
https://docs.influxdata.com/kapacitor/v1.1/nodes/batch_node