### PR TITLE
Remove insert into note

### DIFF
--- a/content/influxdb/v0.13/tools/shell.md
+++ b/content/influxdb/v0.13/tools/shell.md
@@ -317,10 +317,6 @@ Using retention policy oneday
 >
 ```
 
-Note that once you specify a retention policy with `INSERT INTO`, `influx` automatically writes data to that retention policy.
-This occurs even for later `INSERT` entries that do not include an `INTO` clause.
-Restarting the CLI will revert to using the `DEFAULT` retention policy.
-
 ### Queries
 Execute all InfluxQL queries in `influx`.
 See [Data Exploration](/influxdb/v0.13/query_language/data_exploration/), [Schema Exploration](/influxdb/v0.13/query_language/schema_exploration/), [Database Management](/influxdb/v0.13/query_language/database_management/), [Authentication and Authorization](/influxdb/v0.13/administration/authentication_and_authorization/) for InfluxQL documentation.


### PR DESCRIPTION
This note was due to an incorrect behavior in the client.  The bug has been fixed in the client, so the note no longer applies.

//cc @rkuchan 