### PR TITLE
Wrong field name in alternate example

### DIFF
--- a/content/kapacitor/v0.10/introduction/getting_started.md
+++ b/content/kapacitor/v0.10/introduction/getting_started.md
@@ -221,7 +221,7 @@ cat /tmp/alerts.log
 
 Depending on how busy the server was, maybe not.
 Let's modify the task to be really sensitive so that we know the alerts are working.
-Change the `.crit(lambda: "value" < 70)` line in the TICKscript to `.crit(lambda: "value" < 100)`.
+Change the `.crit(lambda: "usage_idle" < 70)` line in the TICKscript to `.crit(lambda: "usage_idle" < 100)`.
 Now every data point that was received during
 the recording will trigger an alert.
 

--- a/content/kapacitor/v0.11/introduction/getting_started.md
+++ b/content/kapacitor/v0.11/introduction/getting_started.md
@@ -221,7 +221,7 @@ cat /tmp/alerts.log
 
 Depending on how busy the server was, maybe not.
 Let's modify the task to be really sensitive so that we know the alerts are working.
-Change the `.crit(lambda: "value" < 70)` line in the TICKscript to `.crit(lambda: "value" < 100)`.
+Change the `.crit(lambda: "usage_idle" < 70)` line in the TICKscript to `.crit(lambda: "usage_idle" < 100)`.
 Now every data point that was received during
 the recording will trigger an alert.
 

--- a/content/kapacitor/v0.12/introduction/getting_started.md
+++ b/content/kapacitor/v0.12/introduction/getting_started.md
@@ -222,7 +222,7 @@ cat /tmp/alerts.log
 
 Depending on how busy the server was, maybe not.
 Let's modify the task to be really sensitive so that we know the alerts are working.
-Change the `.crit(lambda: "value" < 70)` line in the TICKscript to `.crit(lambda: "value" < 100)`.
+Change the `.crit(lambda: "usage_idle" < 70)` line in the TICKscript to `.crit(lambda: "usage_idle" < 100)`.
 Now every data point that was received during
 the recording will trigger an alert.
 

--- a/content/kapacitor/v0.13/introduction/getting_started.md
+++ b/content/kapacitor/v0.13/introduction/getting_started.md
@@ -220,7 +220,7 @@ cat /tmp/alerts.log
 
 Depending on how busy the server was, maybe not.
 Let's modify the task to be really sensitive so that we know the alerts are working.
-Change the `.crit(lambda: "value" < 70)` line in the TICKscript to `.crit(lambda: "value" < 100)`.
+Change the `.crit(lambda: "usage_idle" < 70)` line in the TICKscript to `.crit(lambda: "usage_idle" < 100)`.
 Now every data point that was received during
 the recording will trigger an alert.
 

--- a/content/kapacitor/v1.0/introduction/getting_started.md
+++ b/content/kapacitor/v1.0/introduction/getting_started.md
@@ -220,7 +220,7 @@ cat /tmp/alerts.log
 
 Depending on how busy the server was, maybe not.
 Let's modify the task to be really sensitive so that we know the alerts are working.
-Change the `.crit(lambda: "value" < 70)` line in the TICKscript to `.crit(lambda: "value" < 100)`.
+Change the `.crit(lambda: "usage_idle" < 70)` line in the TICKscript to `.crit(lambda: "usage_idle" < 100)`.
 Now every data point that was received during
 the recording will trigger an alert.
 

--- a/content/kapacitor/v1.1/introduction/getting_started.md
+++ b/content/kapacitor/v1.1/introduction/getting_started.md
@@ -220,7 +220,7 @@ cat /tmp/alerts.log
 
 Depending on how busy the server was, maybe not.
 Let's modify the task to be really sensitive so that we know the alerts are working.
-Change the `.crit(lambda: "value" < 70)` line in the TICKscript to `.crit(lambda: "value" < 100)`.
+Change the `.crit(lambda: "usage_idle" < 70)` line in the TICKscript to `.crit(lambda: "usage_idle" < 100)`.
 Now every data point that was received during
 the recording will trigger an alert.
 


### PR DESCRIPTION
Shouldn't it be "usage_idle" as in the above example.