### PR TITLE
InfluxDB security documentation

### DIFF
--- a/content/influxdb/v1.1/administration/https_setup.md
+++ b/content/influxdb/v1.1/administration/https_setup.md
@@ -23,16 +23,14 @@ and a Transport Layer Security (TLS) certificate (also known as a
 Secured Sockets Layer (SSL) certificate).
 InfluxDB supports three types of TLS/SSL certificates:
 
-* **Single domain certificates signed by a Certificate Authority**
+* **Single domain certificates signed by a [Certificate Authority](https://en.wikipedia.org/wiki/Certificate_authority)**
 
-    Single domain certificates signed by a [Certificate Authority](https://en.wikipedia.org/wiki/Certificate_authority) (CA) are available from CAs.
-    The certificates provide cryptographic security to HTTPS requests and allow clients to verify the identity of the InfluxDB server.
+    These certificates provide cryptographic security to HTTPS requests and allow clients to verify the identity of the InfluxDB server.
     With this certificate option, every InfluxDB instance requires a unique single domain certificate.
 
 * **Wildcard certificates signed by a Certificate Authority**
 
-    Wildcard certificates signed by a CA are available from CAs.
-    The certificates provide cryptographic security to HTTPS requests and allow clients to verify the identity of the InfluxDB server.
+    These certificates provide cryptographic security to HTTPS requests and allow clients to verify the identity of the InfluxDB server.
     Wildcard certificates can be used across multiple InfluxDB instances on different servers.
 
 * **Self-signed certificates**
@@ -40,16 +38,17 @@ InfluxDB supports three types of TLS/SSL certificates:
     Self-signed certificates are not signed by a CA and you can [generate](#step-1-generate-a-self-signed-certificate) them on your own machine.
     Unlike CA-signed certificates, self-signed certificates only provide cryptographic security to HTTPS requests.
     They do not allow clients to verify the identity of the InfluxDB server.
-    While not as secure as CA-signed certificates, we recommend using a self-signed certificate if you are unable to obtain a CA-signed certificate.
+    We recommend using a self-signed certificate if you are unable to obtain a CA-signed certificate.
     With this certificate option, every InfluxDB instance requires a unique self-signed certificate.
 
-Regardless of your certificate's type, InfluxDB supports certificates separated
-into a private key file (`.key`) and a signed certificate file (`.crt`) file, as well as certificates
+Regardless of your certificate's type, InfluxDB supports certificates composed of
+a private key file (`.key`) and a signed certificate file (`.crt`) file pair, as well as certificates
 that combine the private key file and the signed certificate file into a single bundled file (`.pem`).
 
 The following two sections outline how to set up HTTPS with InfluxDB [using a CA-signed
-certificate](#setup-https-with-a-ca-signed-certificate) and [using a self-signed certificate](#setup-https-with-a-self-signed-certificate).
-Please note that this guide assumes you are using InfluxDB on Ubuntu 16.04.
+certificate](#setup-https-with-a-ca-signed-certificate) and [using a self-signed certificate](#setup-https-with-a-self-signed-certificate)
+on Ubuntu 16.04.
+Specific steps may be different for other operating systems.
 
 ## Setup HTTPS with a CA-Signed Certificate
 
@@ -76,8 +75,6 @@ Enable HTTPS in InfluxDB's the `[http]` section of the configuration file (`/etc
 * `https-enabled` to `true`
 * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
 * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-
-Be sure to uncomment the `[http]` section header in addition to uncommenting those three settings.
 
 ```
 [http]
@@ -144,8 +141,6 @@ Enable HTTPS in InfluxDB's the `[http]` section of the configuration file (`/etc
 * `https-enabled` to `true`
 * `http-certificate` to `/etc/ssl/influxdb-selfsigned.crt`
 * `http-private-key` to `/etc/ssl/influxdb-selfsigned.key`
-
-Be sure to uncomment the `[http]` section header in addition to uncommenting those three settings.
 
 ```
 [http]

--- a/content/influxdb/v1.1/administration/https_setup.md
+++ b/content/influxdb/v1.1/administration/https_setup.md
@@ -1,0 +1,105 @@
+---
+title: HTTPS Setup
+menu:
+  influxdb_1_1:
+    weight: 100
+    parent: administration
+---
+
+## How to set up HTTPS on with InfluxDB
+
+This guide explains how to enable HTTPS with InfluxDB. HTTPS has two features,
+it secures the communication between a server and client, and (optionally)
+verifies the authenticity of the owner of the InfluxDB server to clients.
+
+The recommended best practice is to always enable HTTPS when requests to
+InfluxDB will be sent over a network.
+
+This tutorial assumes you are using InfluxDB on Ubuntu 16.04 and plan to use a self-signed certificate.
+
+1. Generate a TLS/SSL certificate.
+
+InfluxDB can use three types of TLS/SSL certificates.
+
+- Single domain certificates signed by a [certificate authority](https://en.wikipedia.org/wiki/Certificate_authority) (commonly refered to as a CA).
+Every instance of InfluxDB would need a unique certificate and private key which match the server's hostname.
+
+- Wildcard certificate signed by a CA.
+A single wildcard certificate and private key can be used for multiple InfluxDB instances on different servers.
+
+- Self-signed certificates.
+Self-signed certificates are not signed by a CA so it's not possible for clients to verify the identity of the server.
+However, self-signed certificates provide the same cryptographic security to HTTPS requests as CA signed certificates.
+If CA signed certificates are unavailable, we highly recommend using self-signed certificates.
+
+The following command will generate a self-signed certificate and private key on an Ubuntu 16.04 server:
+
+```
+sudo openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/ssl/influxdb-selfsigned.key -out /etc/ssl/influxdb-selfsigned.crt -days NUMBER_OF_DAYS
+```
+
+`NUMBER_OF_DAYS` is the number of days the certificate will be valid.
+The command will offer prompts for more information, which can be left blank. 
+
+This will generate both a self-signed certificate and an associated private key.
+These files can be combined into a single bundled certificate file with a `.pem` filename, but it is unnecessary for InfluxDB.
+InfluxDB supports using both separate certificate and key files, as well as a combined `.pem` bundle file.
+
+2. Install the SSL certificate on the instance.
+
+On Ubuntu 16.04, all certificate files (including `.crt`, `.key`, and `.pem`) should be placed in the `/etc/ssl` directory.
+The files owner should be set to `root` and restricted to read-write access by the `root` user.
+
+```
+sudo chown root:root /etc/ssl/influxdb-selfsigned.crt /etc/ssl/influxdb-selfsigned.key
+sudo chmod 644 /etc/ssl/influxdb-selfsigned.crt /etc/ssl/influxdb-selfsigned.key
+```
+
+If a self-signed certificate was generated using the command listed above, the self-signed certificates will already be in the correct path and have the right permissions.
+
+3. Enable HTTPS in the InfluxDB config file.
+
+In the InfluxDB config file, the following options in the `[http]` section should be configured.
+If the certificate is in a combined `.pem` file, the location of the `.pem` file should used as both the `https-certificate` and `https-private-key` files. 
+
+```
+[http]
+  # Determines whether HTTPS is enabled.
+  https-enabled = true
+
+  # The SSL certificate to use when HTTPS is enabled.
+  https-certificate = "/etc/ssl/influxdb-selfsigned.crt"
+
+  # Use a separate private key location.
+  https-private-key = "/etc/ssl/influxdb-selfsigned.key"
+```
+
+Note, the OpenTSDB plugin for InfluxDB is the only plugin that supports TLS/SSL aside from the HTTP endpoint. 
+
+4. Restart InfluxDB to enable HTTPS.
+
+```
+sudo systemctl restart influxdb
+```
+
+Check the logs to verify InfluxDB started correctly.
+
+5. Verify clients can connect to InfluxDB with HTTPS enabled.
+
+Once HTTPS is enabled, verify HTTPS is working by connecting to InfluxDB using the `influx` CLI tool using the `-ssl` option.
+
+```
+influx -ssl -host security-demo.s.influxdb.com
+```
+
+For self-signed certificates, the `influx` CLI will need to also specify the `-unsafeSsl` option.
+
+```
+influx -ssl -unsafeSsl -host security-demo.s.influxdb.com
+```
+
+6. Connect Telegraf and other clients to InfluxDB with HTTPS enabled.
+
+Blah blah
+
+Telegraf https:// (for self-signed do `insecure_skip_verify = true`)

--- a/content/influxdb/v1.1/administration/security_best_practices.md
+++ b/content/influxdb/v1.1/administration/security_best_practices.md
@@ -1,0 +1,27 @@
+---
+title: Security Best Practices
+menu:
+  influxdb_1_1:
+    weight: 110
+    parent: administration
+---
+
+## InfluxDB security best practices
+
+
+These are best practices for exposing InfluxDB to the open internet.
+We always recommend never opening InfluxDB to the open internet if possible.
+
+
+Things to do on InfluxDB
+- Use HTTPS (valid cert), might need a separate doc
+- Turn on auth
+- Create users with only read/write permissions
+
+Things to do on Telegraf
+- Set credentials in the config
+
+Things to do on host (AWS specific)
+- Close all ports except 8086 or use a proxy to 8086
+- Encrypt the disk/volume
+

--- a/content/influxdb/v1.1/administration/security_best_practices.md
+++ b/content/influxdb/v1.1/administration/security_best_practices.md
@@ -2,26 +2,46 @@
 title: Security Best Practices
 menu:
   influxdb_1_1:
-    weight: 110
+    weight: 80
     parent: administration
 ---
 
-## InfluxDB security best practices
+Exposing InfluxDB to the open internet also exposes your data.
+Check out the sections below for how protect the data in your InfluxDB instance.
 
+## Enable Authentication
 
-These are best practices for exposing InfluxDB to the open internet.
-We always recommend never opening InfluxDB to the open internet if possible.
+Password protect your InfluxDB instance to keep any unauthorized individuals
+from accessing you data.
 
+Resources:
+[Set up Authentication](/influxdb/v1.1/query_language/authentication_and_authorization/#set-up-authentication)
 
-Things to do on InfluxDB
-- Use HTTPS (valid cert), might need a separate doc
-- Turn on auth
-- Create users with only read/write permissions
+## Manage Users and their Permissions
 
-Things to do on Telegraf
-- Set credentials in the config
+Prevent unintentional mishaps by creating individual users and assigning them
+the relevant read and/or write permissions.
 
-Things to do on host (AWS specific)
-- Close all ports except 8086 or use a proxy to 8086
-- Encrypt the disk/volume
+Resources:
+[User Types and Privileges](/influxdb/v1.1/query_language/authentication_and_authorization/#user-types-and-privileges),
+[User Management Commands](/influxdb/v1.1/query_language/authentication_and_authorization/#user-management-commands)
 
+## Set up HTTPS
+
+HTTPS secures the communication between clients and the InfluxDB server, and, in
+some cases, HTTPS verifies the authenticity of the InfluxDB server to clients.
+
+Resources:
+[HTTPS Setup](/influxdb/v1.1/administration/https_setup/)
+
+## Secure your Host
+
+Keep InfluxDB safe by securing its host.
+
+### Ports
+If you're only running InfluxDB, close all ports on the host except for port `8086`.
+You can also use a proxy to port `8086`.
+
+### AWS Recommendations
+
+If you're hosting InfluxDB on AWS, be sure to encrypt the disk/volume.

--- a/content/influxdb/v1.1/administration/security_best_practices.md
+++ b/content/influxdb/v1.1/administration/security_best_practices.md
@@ -36,12 +36,14 @@ Resources:
 
 ## Secure your Host
 
-Keep InfluxDB safe by securing its host.
-
 ### Ports
 If you're only running InfluxDB, close all ports on the host except for port `8086`.
 You can also use a proxy to port `8086`.
 
+InfluxDB uses port `8088` for remote [backups and restores](/influxdb/v1.1/administration/backup_and_restore/).
+We highly recommend closing that port and, if performing a remote backup,
+giving specific permission only to the remote machine.
+
 ### AWS Recommendations
 
-If you're hosting InfluxDB on AWS, be sure to encrypt the disk/volume.
+We recommend implementing on-disk encryption; InfluxDB does not offer built-in support to encrypt the data.

--- a/content/influxdb/v1.1/administration/stability_and_compatibility.md
+++ b/content/influxdb/v1.1/administration/stability_and_compatibility.md
@@ -2,7 +2,7 @@
 title: Stability and Compatibility
 menu:
   influxdb_1_1:
-    weight: 80
+    weight: 90
     parent: administration
 ---
 

--- a/content/influxdb/v1.1/query_language/authentication_and_authorization.md
+++ b/content/influxdb/v1.1/query_language/authentication_and_authorization.md
@@ -148,6 +148,30 @@ password:
 >
 ```
 
+>
+## Authenticate Telegraf requests to InfluxDB
+>
+Authenticating [Telegraf](/telegraf/v1.1/) requests to an InfluxDB instance with
+authentication enabled requires some additional steps.
+In Telegraf's configuration file (`/etc/telegraf/telegraf.conf`), uncomment
+and edit the `username` and `password` settings:
+>
+    ###############################################################################
+    #                            OUTPUT PLUGINS                                   #
+    ###############################################################################
+>
+    [...]
+>
+    ## Write timeout (for the InfluxDB client), formatted as a string.
+    ## If not provided, will default to 5s. 0s means no timeout (not recommended).
+    timeout = "5s"
+    username = "telegraf" #💥
+    password = "metricsmetricsmetricsmetrics" #💥
+>
+    [...]
+>
+Next, restart Telegraf and you're all set!
+
 ## Authorization
 
 Authorization is only enforced once you've [enabled authentication](#set-up-authentication).


### PR DESCRIPTION
Includes two additional guides. One is a guide to set up InfluxDB with HTTPS and the other guide is how to secure InfluxDB when exposing it to the open internet.

@rkuchan 

Fixes: https://github.com/influxdata/docs.influxdata.com/issues/932