### PR TITLE
Fix some issues

### DIFF
--- a/content/enterprise/v1.1/about-the-project/release-notes-changelog.md
+++ b/content/enterprise/v1.1/about-the-project/release-notes-changelog.md
@@ -167,16 +167,19 @@ Backup and restore has been updated to fix issues and refine existing capabiliti
 
 ## v1.1.1 [2016-12-06]
 
-There are no new features in version 1.1.1.
-
 This release is built with Go 1.7.4.
 It resolves a security vulnerability reported in Go version 1.7.3 which impacts all
 users currently running on the Mac OS X platform, powered by the Darwin operating system.
 
+### Features
+
+- Add the [`autologout` configuration setting](/enterprise/v1.1/administration/configuration/#autologout-false) to enable a forced logout on browser close
+
 ## v1.1.0 [2016-11-14]
 
-There are no new features or bugfixes in version 1.1.0.
-This release is for maintaining version parity with clustering.
+### Features
+
+- Add the [`session-lifetime` configuration setting](/enterprise/v1.1/administration/configuration/#session-lifetime-24h) to configure the time after which users are automatically logged out
 
 ## v1.0.3 [2016-10-07]
 

--- a/content/enterprise/v1.1/administration/configuration.md
+++ b/content/enterprise/v1.1/administration/configuration.md
@@ -924,6 +924,14 @@ Contact [sales@influxdb.com](mailto:sales@influxdb.com) to become an annual subs
 
 Environment variable: `LICENSE_FILE`
 
+### session-lifetime  = "24h"
+
+The time after which users are automatically logged out of the web console.
+
+### autologout = false
+
+Set to `true` to force a logout when the browser session ends.
+
 ## [influxdb]
 ### shared-secret = "long pass phrase used for signing tokens"
 

--- a/content/enterprise/v1.1/administration/upgrading.md
+++ b/content/enterprise/v1.1/administration/upgrading.md
@@ -17,7 +17,8 @@ menu:
 
 The `influxd-ctl join` command has been renamed to `influxd-ctl add-meta`. If you have existing scripts that use `influxd-ctl join`, they will need to use `influxd-ctl add-meta` or be updated to use the new cluster setup command.
 
-This release should be a drop-in replacement for 1.0 with no data migration required. There are some configuration changes that may need to be updated prior to upgrading to avoid downtime. Please review the [Changelog](/enterprise/v1.1/about-the-project/release-notes-changelog/) prior to upgrading.
+This release should be a drop-in replacement for 1.0 with no data migration required. There are some configuration changes that need to be updated prior to upgrading to avoid downtime.
+Please review the [Changelog](/enterprise/v1.1/about-the-project/release-notes-changelog/) prior to upgrading.
 
 ## Upgrading from version 0.7 to 1.1
 

--- a/content/enterprise/v1.1/production_installation/data_node_installation.md
+++ b/content/enterprise/v1.1/production_installation/data_node_installation.md
@@ -21,7 +21,7 @@ Bad things can happen if you complete the following steps without meta nodes.
 
 The Production Installation process sets up two [data nodes](/enterprise/v1.1/concepts/glossary#data-node)
 and each data node runs on its own server.
-You **must** have a minimum of two data in a cluster.
+You **must** have a minimum of two data nodes in a cluster.
 InfluxEnterprise clusters require at least two data nodes for high
 availability and redundancy.
 Note that there is no requirement for each data node to run on its own

--- a/content/enterprise/v1.1/quickstart_installation/cluster_installation.md
+++ b/content/enterprise/v1.1/quickstart_installation/cluster_installation.md
@@ -31,11 +31,6 @@ a [data node](/enterprise/v1.1/concepts/glossary/#data-node), that is, each serv
 runs both the [meta service](/enterprise/v1.1/concepts/glossary/#meta-service)
 and the [data service](/enterprise/v1.1/concepts/glossary/#data-service).
 
-In a production environment there is no need to use three servers; meta nodes and data
-nodes can run on separate servers.
-Please see the [Production Installation](/enterprise/v1.1/production_installation/)
-documentation if you'd like to set up a cluster with a different server-node configuration.
-
 ### Requirements
 
 #### License Key or File

--- a/content/influxdb/v1.1/administration/config.md
+++ b/content/influxdb/v1.1/administration/config.md
@@ -18,6 +18,9 @@ Most of the settings in the local configuration file
 commented-out settings will be determined by the internal defaults.
 Any uncommented settings in the local configuration file override the
 internal defaults.
+If you uncomment and configure a setting you will also need to
+[uncomment that setting's section header](/influxdb/v1.1/troubleshooting/frequently-asked-questions/#why-doesn-t-influxdb-acknowledge-my-local-configuration-settings)
+for that setting to take effect.
 Note that the local configuration file does not need to include every
 configuration setting.
 

--- a/content/influxdb/v1.1/tools/web_admin.md
+++ b/content/influxdb/v1.1/tools/web_admin.md
@@ -13,7 +13,8 @@ The built-in web administration GUI is deprecated in InfluxDB 1.1 and is disable
 
 ## Accessing the UI
 
-To enable the Admin UI, [edit the configuration file](/influxdb/v1.1/administration/config/#enabled-false) to set `enabled = true` in the `[admin]` section. You must restart the process for any configuration changes to take effect.
+To enable the Admin UI, [edit the configuration file](/influxdb/v1.1/administration/config/#enabled-false) to set `enabled = true` in the `[admin]` section. Be sure to uncomment both the `[admin]` section header and the `enabled = true` setting.
+You must restart the process for any configuration changes to take effect.
 
 Once enabled, the Admin UI is available by default at port `8083`, i.e. [http://localhost:8083](http://localhost:8083).
 You can control the port in the InfluxDB config file using the `port` option in the `[admin]` section.

--- a/content/influxdb/v1.1/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.1/troubleshooting/frequently-asked-questions.md
@@ -18,6 +18,7 @@ Where applicable, it links to outstanding issues on GitHub.
 * [How can I identify my version of InfluxDB?](#how-can-i-identify-my-version-of-influxdb)  
 * [What is the relationship between shard group durations and retention policies?](#what-is-the-relationship-between-shard-group-durations-and-retention-policies)
 * [Why aren't data dropped after I've altered a retention policy?](#why-aren-t-data-dropped-after-i-ve-altered-a-retention-policy)
+* [Why doesn't InfluxDB acknowledge my local configuration settings?](#why-doesn-t-influxdb-acknowledge-my-local-configuration-settings)
 
 **Command Line Interface (CLI)**
 
@@ -149,6 +150,26 @@ InfluxDB will drop that shard group once all of its data are outside the new
 `DURATION`.
 The system will then begin writing data to shard groups that have the new,
 shorter `SHARD DURATION` preventing any further unexpected data retention.
+
+## Why doesn't InfluxDB acknowledge my local configuration settings?
+
+In version 1.1.x, if you uncomment and configure a configuration setting you
+will also need to uncomment that setting's section header for those changes
+to take effect.
+
+#### Example
+
+To enable the [admin interface](/influxdb/v1.1/tools/web_admin/), uncomment the `[admin]` section header, the
+`enabled = false` setting, and change `enabled = false` to `enabled = true`:
+
+```
+[admin]
+  # Determines whether the admin service is enabled.
+  enabled = true
+```
+
+Once you've saved your changes, restart InfluxDB for your local configuration settings
+to take effect.
 
 ## How do I make InfluxDB’s CLI return human readable timestamps?
 


### PR DESCRIPTION
This PR takes care of a couple issues:

* Updates the Enterprise v1.1 documentation, including the  Upgrading, Configuration, and Release notes/Changelog pages, to include the new web console configuration settings (`session-lifetime` and `autologout`) in 1.1.0 and 1.1.1. Fixes #938.

* Fixes the typo on the Enterprise v1.1 Production Installation page. `Data` is now `data nodes`. Fixes #941.

* Adds to the InfluxDB v1.1. docs that it's necessary to uncomment the releveant setting's section header in the local configuration file for any local configurations to take effect. That's added to the configuration doc, the admin interface doc, and the FAQ doc. Fixes #940.

* Removes an unnecessary sentence about the Production Installation from Enterprise's v1.1 QuickStart Installation Guide. Fixes #942.