### PR TITLE
Small updates to the 1.2 docs

### DIFF
--- a/content/enterprise/v1.2/production_installation/data_node_installation.md
+++ b/content/enterprise/v1.2/production_installation/data_node_installation.md
@@ -62,7 +62,8 @@ data nodes on port `8086` (the default port for the [HTTP API](/influxdb/v1.2/to
 ## Step 1: Modify the /etc/hosts File
 
 Add your servers' hostnames and IP addresses to **each** cluster server's `/etc/hosts`
-file (the hostnames are representative):
+file (the hostnames below are representative).
+Currently, hostnames **must** be all lowercase.
 
 ```
 <Data_1_IP> enterprise-data-01

--- a/content/enterprise/v1.2/production_installation/meta_node_installation.md
+++ b/content/enterprise/v1.2/production_installation/meta_node_installation.md
@@ -63,7 +63,8 @@ setting in the meta node configuration file.
 ## Step 1: Modify the /etc/hosts File
 
 Add your servers' hostnames and IP addresses to **each** cluster server's `/etc/hosts`
-file (the hostnames are representative):
+file (the hostnames below are representative).
+Currently, hostnames **must** be all lowercase.
 
 ```
 <Meta_1_IP> enterprise-meta-01

--- a/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
+++ b/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
@@ -61,7 +61,8 @@ data nodes on port `8086` (the default port for the [HTTP API](/influxdb/v1.2/to
 ## Step 1: Modify the /etc/hosts file
 
 Add your three servers' hostnames and IP addresses to **each** server's `/etc/hosts`
-file (the hostnames are representative):
+file (the hostnames below are representative).
+Currently, hostnames **must** be all lowercase.
 
 ```
 <Server_1_IP> quickstart-cluster-01

--- a/content/influxdb/v1.2/query_language/math_operators.md
+++ b/content/influxdb/v1.2/query_language/math_operators.md
@@ -128,6 +128,9 @@ SELECT mean(10 * "value") FROM "cpu"
 ```
 will yield a parse error.
 
+> **Note:** Starting with version 1.2, InfluxQL supports [subqueries](/influxdb/v1.2/query_language/data_exploration/#subqueries) which offer similar functionality to using mathematical operators inside a function call.
+See [Data Exploration](/influxdb/v1.2/query_language/data_exploration/#subqueries) for more information.
+
 ## Unsupported Operators
 
 ### Inequalities


### PR DESCRIPTION
Adds a note about hostnames requiring lowercase characters to the Enterprise quickstart cluster install and the production meta/data install docs. Fixes #975.

Adds a note to the InfluxDB mathematical operations doc about subqueries.
