### PR TITLE
Add SHOW FIELD KEYS details and examples to the Line Protocol ref

### DIFF
--- a/content/influxdb/v1.2/query_language/schema_exploration.md
+++ b/content/influxdb/v1.2/query_language/schema_exploration.md
@@ -12,7 +12,7 @@ The following sections cover useful query syntax for exploring your [schema](/in
 <table style="width:100%">
   <tr>
     <td><a href="#show-databases">SHOW DATABASES</a></td>
-    <td><a href="#Show-retention-policies">SHOW RETENTION POLICIES</a></td>
+    <td><a href="#show-retention-policies">SHOW RETENTION POLICIES</a></td>
     <td><a href="#show-series">SHOW SERIES</a></td>
   </tr>
   <tr>
@@ -1057,3 +1057,35 @@ water_level         float
 
 The query returns the fields keys and field value data types for the `h2o_feet`
 measurement in the `NOAA_water_database` database.
+
+### Common Issues with SHOW FIELD KEYS
+
+#### Issue 1: SHOW FIELD KEYS and field type discrepancies
+Field value
+[data types](/influxdb/v1.2/write_protocols/line_protocol_reference/#data-types)
+cannot differ within a [shard](/influxdb/v1.2/concepts/glossary/#shard) but they
+can differ across shards.
+`SHOW FIELD KEYS` returns every data type, across every shard, associated with
+the field key.
+
+##### Example
+<br>
+The `all_the_types` field stores four different data types:
+
+```
+> SHOW FIELD KEYS
+
+name: mymeas
+fieldKey        fieldType
+--------        ---------
+all_the_types   integer
+all_the_types   float
+all_the_types   string
+all_the_types   boolean
+```
+
+Note that `SHOW FIELD KEYS` handles field type discrepancies differently from
+`SELECT` statements.
+See the
+[FAQ](/influxdb/v1.2/troubleshooting/frequently-asked-questions/#how-does-influxdb-handle-field-type-discrepancies-across-shards)
+page for more information.

--- a/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
@@ -252,21 +252,22 @@ For example, `SELECT * FROM "hamlet" WHERE "bool"=True` returns all points with 
 
 Field values can be floats, integers, strings, or booleans.
 Field value types cannot differ within a
-[shard](/influxdb/v1.2/concepts/glossary/#shard), but they can differ across
-shards.
+[shard](/influxdb/v1.2/concepts/glossary/#shard), but they can [differ](/influxdb/v1.2/write_protocols/line_protocol_reference/#example-7-attempt-to-write-a-string-to-a-field-that-previously-accepted-floats) across shards.
 
-A `SELECT * FROM <measurement_name>` query returns all field values **if** all
-values have the same type.
+### The SELECT statement
+
+The
+[`SELECT` statement](/influxdb/v1.2/query_language/data_exploration/#the-basic-select-statement)
+returns all field values **if** all values have the same type.
 If field value types differ across shards, InfluxDB first performs any
-applicable
-[cast](/influxdb/v1.2/query_language/data_exploration/#cast-operations)
+applicable [cast](/influxdb/v1.2/query_language/data_exploration/#cast-operations)
 operations and then returns all values with the type that occurs first in the
 following list: float, integer, string, boolean.
 
 If your data have field value type discrepancies, use the syntax
 `<field_key>::<type>` to query the different data types.
 
-Example:
+#### Example:
 
 The measurement `just_my_type` has a single field called `my_field`.
 `my_field` has four field values across four different shards, and each value has
@@ -276,6 +277,7 @@ a different data type (float, integer, string, and boolean).
 Note that InfluxDB casts the integer value to a float in the response.
 ```
 SELECT * FROM just_my_type
+
 name: just_my_type
 ------------------
 time		                	my_field
@@ -291,6 +293,7 @@ casts the float `9.879034` to an integer in the second column.
 InfluxDB cannot cast floats or integers to strings or booleans.
 ```
 SELECT "my_field"::float,"my_field"::integer,"my_field"::string,"my_field"::boolean FROM just_my_type
+
 name: just_my_type
 ------------------
 time			               my_field	 my_field_1	 my_field_2		 my_field_3
@@ -298,6 +301,30 @@ time			               my_field	 my_field_1	 my_field_2		 my_field_3
 2016-06-03T16:45:00Z	 7	        7
 2016-06-03T17:45:00Z			                     a string
 2016-06-03T18:45:00Z					                                true
+```
+
+### The SHOW FIELD KEYS query
+
+`SHOW FIELD KEYS` returns every data type, across every shard, associated with
+the field key.
+
+#### Example
+
+The measurement `just_my_type` has a single field called `my_field`.
+`my_field` has four field values across four different shards, and each value has
+a different data type (float, integer, string, and boolean).
+`SHOW FIELD KEYS` returns all four data types:
+
+```
+> SHOW FIELD KEYS
+
+name: just_my_type
+fieldKey   fieldType
+--------   ---------
+my_field   float
+my_field   string
+my_field   integer
+my_field   boolean
 ```
 
 ## What are the minimum and maximum integers that InfluxDB can store?

--- a/content/influxdb/v1.2/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.2/write_protocols/line_protocol_tutorial.md
@@ -16,10 +16,14 @@ write points (unless you're using a [service plugin](/influxdb/v1.2/tools/#servi
 Using fictional temperature data, this page introduces Line Protocol.
 It covers:
 
-* [Syntax](#syntax)
-* [Data types](#data-types)
-* [Quoting](#quoting)
-* [Special characters and keywords](#special-characters-and-keywords)
+<table style="width:100%">
+  <tr>
+    <td><a href="#syntax">Syntax</a></td>
+    <td><a href="#data-types">Data Types</a></td>
+    <td><a href="#quoting">Quoting</a></td>
+    <td><a href="#special-characters-and-keywords">Special Characters and Keywords</a></td>
+  </tr>
+</table>
 
 The final section, [Writing data to InfluxDB](#writing-data-to-influxdb),
 describes how to get data into InfluxDB and how InfluxDB handles Line


### PR DESCRIPTION
### SHOW FIELD KEYS updates

Adds a Common Issue section to the `SHOW FIELD KEYS` documentation in the Schema Exploration page. It covers how `SHOW FIELD KEYS` handles field type discrepancies across shards. This edit also adds a section about `SHOW FIELD KEYS` to the FAQ about field type discrepancies: the `SELECT` statement and the `SHOW FIELD KEYS` query handle them differently.

Fixes #944

### Line Protocol doc updates

Does some simple formatting updates and adds some more detail to the data types table in the Line Protocol reference doc. This also adds an example of writing a field value with scientific notation to the database.

Fixes #920
