### PR TITLE
Add NTP requirement

### DIFF
--- a/content/enterprise/v1.2/introduction/installation_guidelines.md
+++ b/content/enterprise/v1.2/introduction/installation_guidelines.md
@@ -54,6 +54,12 @@ whichever is used in the configuration files.
 For simplicity, ensure that all nodes can reach all other nodes on ports `8086`, `8088`, `8089`, and `8091`.
 If you alter the default ports in the configuration file(s), ensure the configured ports are open between the nodes.
 
+#### Synchronize time between hosts
+
+InfluxEnterprise uses hosts' local time in UTC to assign timestamps to data and for
+coordination purposes.
+Use the Network Time Protocol (NTP) to synchronize time between hosts.
+
 #### Use SSDs
 
 Clusters require sustained availability of 1000-2000 IOPS from the attached storage.

--- a/content/influxdb/v1.2/introduction/installation.md
+++ b/content/influxdb/v1.2/introduction/installation.md
@@ -24,6 +24,14 @@ require [custom ports](/influxdb/v1.2/administration/ports/).
 All port mappings can be modified through the [configuration file](/influxdb/v1.2/administration/config),
 which is located at `/etc/influxdb/influxdb.conf` for default installations.
 
+### NTP
+
+InfluxDB uses a host's local time in UTC to assign timestamps to data and for
+coordination purposes.
+Use the Network Time Protocol (NTP) to synchronize time between hosts; if hosts'
+clocks aren't synchronized with NTP, the timestamps on the data written to InfluxDB
+can be inaccurate.
+
 ## Installation
 
 For users who don't want to install any software and are ready to use InfluxDB,

--- a/content/influxdb/v1.2/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.2/write_protocols/line_protocol_reference.md
@@ -34,7 +34,7 @@ and timestamp.
 | [Field set](/influxdb/v1.2/concepts/glossary/#field-set) | Required. Points must have at least one field. | All field key-value pairs for the point. | [Field keys](/influxdb/v1.2/concepts/glossary/#field-key) are strings. [Field values](/influxdb/v1.2/concepts/glossary/#field-value) can be floats, integers, strings, or booleans.
 | [Timestamp](/influxdb/v1.2/concepts/glossary/#timestamp) | Optional. InfluxDB uses the server's local nanosecond timestamp in UTC if the timestamp is not included with the point. | The timestamp for the data point. InfluxDB accepts one timestamp per point. | Unix nanosecond timestamp. Specify alternative precisions with the [HTTP API](/influxdb/v1.2/tools/api/#write).
 
-> #### Performance tips:
+> #### Performance and Setup Tips:
 >
 * Sort tags by key before sending them to the database.
 The sort should match the results from the
@@ -42,6 +42,10 @@ The sort should match the results from the
 * Use the coarsest
 [precision](/influxdb/v1.2/tools/api/#write) possible for timestamps.
 This can result in significant improvements in compression.
+* Use the Network Time Protocol (NTP) to synchronize time between hosts.
+InfluxDB uses a host's local time in UTC to assign timestamps to data; if
+hosts' clocks aren't synchronized with NTP, the timestamps on the data written
+to InfluxDB can be inaccurate.
 
 ## Data Types
 

--- a/content/influxdb/v1.2/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.2/write_protocols/line_protocol_tutorial.md
@@ -145,6 +145,13 @@ We recommend using the coarsest precision possible as this can result in
 significant improvements in compression.
 See the [API Reference](/influxdb/v1.2/tools/api/#write) for more information.
 
+> #### Setup Tip:
+>
+Use the Network Time Protocol (NTP) to synchronize time between hosts.
+InfluxDB uses a host's local time in UTC to assign timestamps to data; if
+hosts' clocks aren't synchronized with NTP, the timestamps on the data written
+to InfluxDB can be inaccurate.
+
 ## Data types
 
 This section covers the data types of Line Protocol's major components:

--- a/content/telegraf/v1.2/concepts/data_formats_input.md
+++ b/content/telegraf/v1.2/concepts/data_formats_input.md
@@ -29,6 +29,10 @@ These four parts are easily defined when using InfluxDB line-protocol as a
 data format. But there are other data formats that users may want to use which
 require more advanced configuration to create usable Telegraf metrics.
 
+Telegraf uses a host's local time in UTC to assign timestamps to data.
+Use the Network Time Protocol (NTP) to synchronize time between hosts; if hosts' clocks
+aren't synchronized with NTP, the timestamps on the data can be inaccurate.
+
 Plugins such as `exec` and `kafka_consumer` parse textual data. Up until now,
 these plugins were statically configured to parse just a single
 data format. `exec` mostly only supported parsing JSON, and `kafka_consumer` only

--- a/content/telegraf/v1.2/introduction/installation.md
+++ b/content/telegraf/v1.2/introduction/installation.md
@@ -19,6 +19,12 @@ require custom ports.
 All port mappings can be modified through the configuration file
 which is located at `/etc/telegraf/telegraf.conf` for default installations.
 
+### NTP
+
+Telegraf uses a host's local time in UTC to assign timestamps to data.
+Use the Network Time Protocol (NTP) to synchronize time between hosts; if hosts' clocks
+aren't synchronized with NTP, the timestamps on the data can be inaccurate.
+
 ## Installation
 
 {{< vertical-tabs >}}


### PR DESCRIPTION
Adds a note about needing to synchronize time between hosts to:

* InfluxDB's installation page
* InfluxDB's line protocol reference page
* InfluxDB's line protocol tutorial page
* Telegraf's installation page
* Telegraf's input data formats page
* Enterprise's installation overview page

This fixes: https://github.com/influxdata/docs.influxdata.com/issues/993