### PR TITLE
Add note about time as a keyword, #998

### DIFF
--- a/content/influxdb/v1.2/query_language/spec.md
+++ b/content/influxdb/v1.2/query_language/spec.md
@@ -123,6 +123,26 @@ TO            USER          USERS         VALUES        WHERE         WITH
 WRITE
 ```
 
+If you use an InfluxQL keywords as an
+[identifier](/influxdb/v1.2/concepts/glossary/#identifier) you will need to
+double quote that identifier in every query.
+
+The keyword `time` is a special case.
+`time` can be a
+[continuous query](/influxdb/v1.2/concepts/glossary/#continuous-query-cq) name,
+database name,
+[measurement](/influxdb/v1.2/concepts/glossary/#measurement) name,
+[retention policy](/influxdb/v1.2/concepts/glossary/#retention-policy-rp) name,
+[subscription](/influxdb/v1.2/concepts/glossary/#subscription) name, and
+[user](/influxdb/v1.2/concepts/glossary/#user) name.
+In those cases, `time` does not require double quotes in queries.
+`time` cannot be a [field key](/influxdb/v1.2/concepts/glossary/#field-key) or
+[tag key](/influxdb/v1.2/concepts/glossary/#tag-key).
+If [Line Protocol](/influxdb/v1.2/concepts/glossary/#line-protocol) includes
+`time` as a field key or tag key, InfluxDB accepts the write and returns a `204`,
+but InfluxDB silently drops that field key or tag key and its associated value.
+See [Frequently Asked Questions](/influxdb/v1.2/troubleshooting/frequently-asked-questions/#time) for more information.
+
 ## Literals
 
 ### Integers

--- a/content/influxdb/v1.2/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.2/write_protocols/line_protocol_reference.md
@@ -233,6 +233,22 @@ In general, we recommend avoiding using InfluxQL keywords in your schema as
 it can cause
 [confusion](/influxdb/v1.2/troubleshooting/errors/#error-parsing-query-found-expected-identifier-at-line-char) when querying the data.
 
+The keyword `time` is a special case.
+`time` can be a
+[continuous query](/influxdb/v1.2/concepts/glossary/#continuous-query-cq) name,
+database name,
+[measurement](/influxdb/v1.2/concepts/glossary/#measurement) name,
+[retention policy](/influxdb/v1.2/concepts/glossary/#retention-policy-rp) name,
+[subscription](/influxdb/v1.2/concepts/glossary/#subscription) name, and
+[user](/influxdb/v1.2/concepts/glossary/#user) name.
+In those cases, `time` does not require double quotes in queries.
+`time` cannot be a [field key](/influxdb/v1.2/concepts/glossary/#field-key) or
+[tag key](/influxdb/v1.2/concepts/glossary/#tag-key).
+If [Line Protocol](/influxdb/v1.2/concepts/glossary/#line-protocol) includes
+`time` as a field key or tag key, InfluxDB accepts the write and returns a `204`,
+but InfluxDB silently drops that field key or tag key and its associated value.
+See [Frequently Asked Questions](/influxdb/v1.2/troubleshooting/frequently-asked-questions/#time) for more information.
+
 ## Line Protocol in Practice
 
 See the [Tools](/influxdb/v1.2/tools/) section for how to

--- a/content/influxdb/v1.2/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.2/write_protocols/line_protocol_tutorial.md
@@ -392,6 +392,22 @@ In general, we recommend avoiding using InfluxQL keywords in your schema as
 it can cause
 [confusion](/influxdb/v1.2/troubleshooting/errors/#error-parsing-query-found-expected-identifier-at-line-char) when querying the data.
 
+The keyword `time` is a special case.
+`time` can be a
+[continuous query](/influxdb/v1.2/concepts/glossary/#continuous-query-cq) name,
+database name,
+[measurement](/influxdb/v1.2/concepts/glossary/#measurement) name,
+[retention policy](/influxdb/v1.2/concepts/glossary/#retention-policy-rp) name,
+[subscription](/influxdb/v1.2/concepts/glossary/#subscription) name, and
+[user](/influxdb/v1.2/concepts/glossary/#user) name.
+In those cases, `time` does not require double quotes in queries.
+`time` cannot be a [field key](/influxdb/v1.2/concepts/glossary/#field-key) or
+[tag key](/influxdb/v1.2/concepts/glossary/#tag-key).
+If [Line Protocol](/influxdb/v1.2/concepts/glossary/#line-protocol) includes
+`time` as a field key or tag key, InfluxDB accepts the write and returns a `204`,
+but InfluxDB silently drops that field key or tag key and its associated value.
+See [Frequently Asked Questions](/influxdb/v1.2/troubleshooting/frequently-asked-questions/#time) for more information.
+
 ## Writing data to InfluxDB
 
 ### Getting data in the database


### PR DESCRIPTION
`time` is a valid cq name, database name, measurement name, rp name, subscription name, and user name. It can't, however, be a field key or tag key. If `time` is a field key or tag key in line protocol, the write returns a `204` with no error and silently drops the key and its associated value.

This adds a description of that behavior to the InfluxQL spec, the FAQ page (including a couple examples), and the write protocol tutorial/reference pages.