### PR TITLE
Remove rp as query string param

### DIFF
--- a/content/influxdb/v1.2/tools/api.md
+++ b/content/influxdb/v1.2/tools/api.md
@@ -119,7 +119,6 @@ $ curl -XPOST 'http://localhost:8086/query' --data-urlencode 'q=CREATE DATABASE 
 | epoch=[h,m,s,ms,u,ns] | Optional | Returns epoch timestamps with the specified precision. By default, InfluxDB returns timestamps in RFC3339 format with nanosecond precision. |
 | p=\<password> | Optional if you haven't [enabled authentication](/influxdb/v1.2/query_language/authentication_and_authorization/#set-up-authentication). Required if you've enabled authentication.** | Sets the password for authentication if you've enabled authentication. Use with the query string parameter `u`. |
 | pretty=true | Optional | Enables pretty-printed JSON output. While this is useful for debugging it is not recommended for production use as it consumes unnecessary network bandwidth. |
-| rp=\<retention_policy_name> | Optional | Sets the target [retention policy](/influxdb/v1.2/concepts/glossary/#retention-policy-rp) for the query. InfluxDB queries the database's default retention policy if you do not specify a retention policy.  |
 | u=\<username> | Optional if you haven't [enabled authentication](/influxdb/v1.2/query_language/authentication_and_authorization/#set-up-authentication). Required if you've enabled authentication.* | Sets the username for authentication if you've enabled authentication. The user must have read access to the database. Use with the query string parameter `p`. |
 
 \* InfluxDB automatically truncates the number of rows returned for requests without the `chunked` parameter.


### PR DESCRIPTION
Because of: https://github.com/influxdata/influxdb/issues/7973