### PR TITLE
[InfluxDB, Enterprise] Small additions

### DIFF
--- a/content/enterprise/v1.2/guides/backup-and-restore.md
+++ b/content/enterprise/v1.2/guides/backup-and-restore.md
@@ -18,9 +18,13 @@ Currently, InfluxEnterprise supports backups and restores for all data in the
 cluster; a single database; a single database and retention policy; and a
 single [shard](/influxdb/v0.13/concepts/glossary/#shard).
 
-> **Note:** Backups are not interchangeable between OSS InfluxDB and InfluxEnterprise.
+> **Note:** Backups are not interchangeable between [OSS InfluxDB](/influxdb/v1.2/) and InfluxEnterprise.
 You cannot restore an OSS backup to an InfluxEnterprise data node, nor can you restore
 an InfluxEnterprise backup to an OSS instance.
+>
+If you are working with OSS InfluxDB, please see the [Backup
+and Restore documentation](/influxdb/v1.2/administration/backup_and_restore/) in the
+OSS InfluxDB documentation.
 
 ## Terminology and behavior
 

--- a/content/influxdb/v1.2/administration/backup_and_restore.md
+++ b/content/influxdb/v1.2/administration/backup_and_restore.md
@@ -16,10 +16,13 @@ There are two types of data to backup, the metastore and the metrics themselves.
 The [metastore](/influxdb/v1.2/concepts/glossary/#metastore) is backed up in its entirety.
 The metrics are backed up per-database in a separate operation from the metastore backup.
 
-> **Note:** Backups are not interchangeable between OSS InfluxDB and InfluxEnterprise.
+> **Note:** Backups are not interchangeable between OSS InfluxDB and [InfluxEnterprise](/enterprise/v1.2/).
 You cannot restore an OSS backup to an InfluxEnterprise data node, nor can you restore
 an InfluxEnterprise backup to an OSS instance.
-
+>
+If you are working with an InfluxEnterprise cluster, please see the [Backup
+and Restore Guide](/enterprise/v1.2/guides/backup-and-restore/) in the
+InfluxEnterprise documentation.
 
 ### Backing up the Metastore
 

--- a/content/influxdb/v1.2/query_language/data_exploration.md
+++ b/content/influxdb/v1.2/query_language/data_exploration.md
@@ -387,6 +387,37 @@ In the CLI, specify the database to query data in a database other than the
 In the HTTP API, specify the database in place of using the `db` query
 string parameter if desired.
 
+### Common Issues with the SELECT statement
+
+#### Issue 1: Selecting tag keys in the SELECT clause
+A query requires at least one [field key](/influxdb/v1.2/concepts/glossary/#field-key)
+in the `SELECT` clause to return data.
+If the `SELECT` clause only includes a single [tag key](/influxdb/v1.2/concepts/glossary/#tag-key) or several tag keys, the
+query returns an empty response.
+This behavior is a result of how the system stores data.
+
+##### Example
+<br>
+The following query returns no data because it specifies a single tag key (`location`) in
+the `SELECT` clause:
+```
+> SELECT "location" FROM "h2o_feet"
+>
+```
+To return any data associated with the `location` tag key, the query's `SELECT`
+clause must include at least one field key (`water_level`):
+```
+> SELECT "water_level","location" FROM "h2o_feet" LIMIT 3
+name: h2o_feet
+time                   water_level  location
+----                   -----------  --------
+2015-08-18T00:00:00Z   8.12         coyote_creek
+2015-08-18T00:00:00Z   2.064        santa_monica
+[...]
+2015-09-18T21:36:00Z   5.066        santa_monica
+2015-09-18T21:42:00Z   4.938        santa_monica
+```
+
 ## The `WHERE` clause
 The `WHERE` filters data based on
 [fields](/influxdb/v1.2/concepts/glossary/#field),

--- a/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
@@ -544,15 +544,25 @@ time                    sunflowers                 time                  mean
 There are several possible explanations for why a query returns no data or partial data.
 We list some of the most frequent cases below:
 
+### Retention Policies
 The first and most common explanation involves [retention policies](/influxdb/v1.2/concepts/glossary/#retention-policy-rp) (RP).
 InfluxDB automatically queries data in a database’s `DEFAULT` RP.
 If your data are stored in an RP other than the `DEFAULT` RP, InfluxDB won’t return any results unless you [specify](/influxdb/v1.2/query_language/data_exploration/#example-7-select-all-data-from-a-fully-qualified-measurement) the alternative RP.
 
+### Tag Keys in the SELECT clause
+A query requires at least one [field key](/influxdb/v1.2/concepts/glossary/#field-key)
+in the `SELECT` clause to return data.
+If the `SELECT` clause only includes a single [tag key](/influxdb/v1.2/concepts/glossary/#tag-key) or several tag keys, the
+query returns an empty response.
+Please see the [Data Exploration](/influxdb/v1.2/query_language/data_exploration/#common-issues-with-the-select-statement) page for additional information.
+
+### Query Time Range
 Another possible explanation has to do with your query’s time range.
 By default, most [`SELECT` queries](/influxdb/v1.2/query_language/data_exploration/#the-basic-select-statement) cover the time range between `1677-09-21 00:12:43.145224194` and `2262-04-11T23:47:16.854775806Z` UTC. `SELECT` queries that also include a [`GROUP BY time()` clause](/influxdb/v1.2/query_language/data_exploration/#group-by-time-intervals), however, cover the time range between `1677-09-21 00:12:43.145224194` and [`now()`](/influxdb/v1.2/concepts/glossary/#now).
 If any of your data occur after `now()` a `GROUP BY time()` query will not cover those data points.
 Your query will need to provide [an alternative upper bound](/influxdb/v1.2/query_language/data_exploration/#time-syntax) for the time range if the query includes a `GROUP BY time()` clause and if any of your data occur after `now()`.
 
+### Identifier Names
 The final common explanation involves [schemas](/influxdb/v1.2/concepts/glossary/#schema) with [fields](/influxdb/v1.2/concepts/glossary/#field) and [tags](/influxdb/v1.2/concepts/glossary/#tag) that have the same key.
 If a field and tag have the same key, the field will take precedence in all queries.
 You’ll need to use the [`::tag` syntax](/influxdb/v1.2/query_language/data_exploration/#description-of-syntax) to specify the tag key in queries.


### PR DESCRIPTION
* Adds a `Common Issue` to the `SELECT` clause documentation about how `SELECT tag_key` doesn't return anything. Links to that common issue from the FAQ page as well.

* Adds a link to the OSS InfluxDB backup and restore docs to the InfluxEnterprise backup and restore docs, and vice-versa. An attempt to keep [this](https://github.com/influxdata/docs.influxdata.com/issues/1012) from happening - because distinguishing between the two is not the clearest.