### PR TITLE
[Enterprise] Add content about the 1.2.x release

### DIFF
--- a/content/enterprise/v1.2/administration/upgrading.md
+++ b/content/enterprise/v1.2/administration/upgrading.md
@@ -8,21 +8,85 @@ menu:
 
 ## Upgrading from version 1.1 to 1.2
 
-The 1.2 release is a drop-in replacement for 1.1 with no data migration
-required - just download and install the
-[1.2 packages](https://portal.influxdata.com/licenses) and restart the processes.
-We recommend that you review the
-[Changelog](/enterprise/v1.2/about-the-project/release-notes-changelog/) prior
-to upgrading.
+For users currently on clustering version 1.1.x, please do not upgrade to clustering version 1.2.x.
+We are currently addressing and testing several issues identified in the 1.2.x release.
+We've include a list of those issues below.
 
-Because of
-[a small change](/enterprise/v1.2/about-the-project/release-notes-changelog/#features)
-to the data node's configuration file, installing the new data package will
-prompt you to either keep or overwrite your current configuration file.
-We recommend that you keep a copy of your current configuration file and
-migrate any customizations to the new 1.2 configuration file.
+For users currently on clustering version 1.2.0, please upgrade to version 1.2.1 immediately.
+Clustering version 1.2.1 fixes [two issues](/enterprise/v1.2/about-the-project/release-notes-changelog/#v1-2-1-2017-01-25) that were identified in clustering version 1.2.0.
+The relevant 1.2.1 packages are listed below.
 
-## Upgrading from versions prior to 1.1 to 1.2
+We are currently addressing and testing several issues in the clustering version 1.2.1 release.
+We've include a list of those issues below.
+Please do not attempt to downgrade your cluster from version 1.2.x to 1.1.x; reverting from version 1.2.x to version 1.1.x is not a supported process.
+If you have any issues with your cluster, please do not hesitate to contact support at the email provided to you when you received your InfluxEnterprise license.
 
-Please review the [1.1 documentation](/enterprise/v1.1/administration/upgrading/)
-if you're upgrading to version 1.2 from a version prior to 1.1.
+## Clustering version 1.2.1 packages
+
+### Ubuntu & Debian (64-bit)
+
+#### Meta nodes
+```
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.0-c1.2.1_amd64.deb
+sudo dpkg -i influxdb-meta_1.2.0-c1.2.1_amd64.deb
+```
+
+#### Data nodes
+```
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.0-c1.2.1_amd64.deb
+sudo dpkg -i influxdb-data_1.2.0-c1.2.1_amd64.deb
+```
+
+### RedHat & CentOS (64-bit)
+
+#### Meta nodes
+```
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.0_c1.2.1.x86_64.rpm
+sudo yum localinstall influxdb-meta-1.2.0_c1.2.1.x86_64.rpm
+```
+
+#### Data nodes
+```
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.0_c1.2.1.x86_64.rpm
+sudo yum localinstall influxdb-data-1.2.0_c1.2.1.x86_64.rpm
+```
+
+## Known issues in clustering version 1.2.1
+
+### OSS issues (these issues also apply to InfluxEnterprise clusters)
+
+#### Regular expressions
+- [#7877](https://github.com/influxdata/influxdb/issues/7877): For some queries, the new shard mapper implementation ignores regular expressions.
+- [#7906](https://github.com/influxdata/influxdb/issues/7906): Regular expressions mistakenly use an exact match for case-insensitive expressions.
+
+#### Subqueries
+- [#7885](https://github.com/influxdata/influxdb/issues/7885): The `LIMIT` and `OFFSET` clauses do not function correctly in subqueries.
+- [#7888](https://github.com/influxdata/influxdb/pull/7888): Some subqueries return duplicate columns and points in the wrong order.
+- [#7910](https://github.com/influxdata/influxdb/issues/7910): Subqueries with an expression in parentheses cause a Go (golang) stack overflow.
+- [#7946](https://github.com/influxdata/influxdb/issues/7946): Non-admin users cannot perform subqueries.
+- [#7966](https://github.com/influxdata/influxdb/pull/7966): Queries that include an aggregation function and a `GROUP BY <tag-key>` clause in the subquery, and reference that tag key in the main query result in a panic.
+
+#### Other
+- [#7895](https://github.com/influxdata/influxdb/issues/7895): The system performs incorrect math when aggregate functions emit different timestamps.
+- [#7905](https://github.com/influxdata/influxdb/issues/7905): The `ORDER BY time DESC` clause sometimes returns results in the wrong order.
+- [#7929](https://github.com/influxdata/influxdb/issues/7929): Tags can become dereferenced during iteration which causes a segmentation fault.
+
+### Cluster-specific issues
+
+#### Backup and Restore
+- Backups return a `shard not found` error if they encounter an empty shard.
+- Restores return a `shard not found` error if they encounter an empty shard.
+- Restores from an incremental backup do not handle file paths correctly.
+- Incremental backups with restrictions (for example, they use the `-db` or `-rp` flags) cannot be stored in the same directory.
+- Restores from an incremental backup require the user to be on the meta node leader.
+
+#### Hinted Handoff
+- Dropped writes are not recorded when the hinted handoff queue reaches the maximum size.
+- The hinted handoff queue becomes blocked if it experiences field type errors.
+
+#### Other
+- A panic occurs when the system fails to process points.
+- Cluster hostnames must be lowercase.
+- The `retryCAS` code doesn't wait for a newer snapshot before retrying.
+- Raft log buildup occurs on meta nodes.
+- RPM packages include sysvinit package dependency.

--- a/content/enterprise/v1.2/guides/migration.md
+++ b/content/enterprise/v1.2/guides/migration.md
@@ -104,14 +104,14 @@ If you have settings that you’d like to keep, please make a copy of your confi
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.0-c1.2.1_amd64.deb
-sudo dpkg -i influxdb-data_1.2.0-c1.2.1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.1-c1.1.1_amd64.deb
+sudo dpkg -i influxdb-data_1.1.1-c1.1.1_amd64.deb
 ```
 
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.0_c1.2.1.x86_64.rpm
-sudo yum localinstall influxdb-data-1.2.0_c1.2.1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.1_c1.1.1.x86_64.rpm
+sudo yum localinstall influxdb-data-1.1.1_c1.1.1.x86_64.rpm
 ```
 
 ### 5. Update the configuration file

--- a/content/enterprise/v1.2/production_installation/data_node_installation.md
+++ b/content/enterprise/v1.2/production_installation/data_node_installation.md
@@ -94,15 +94,17 @@ Perform the following steps on each data server.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.0-c1.2.1_amd64.deb
-sudo dpkg -i influxdb-data_1.2.0-c1.2.1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.1-c1.1.1_amd64.deb
+sudo dpkg -i influxdb-data_1.1.1-c1.1.1_amd64.deb
 ```
 
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.0_c1.2.1.x86_64.rpm
-sudo yum localinstall influxdb-data-1.2.0_c1.2.1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.1_c1.1.1.x86_64.rpm
+sudo yum localinstall influxdb-data-1.1.1_c1.1.1.x86_64.rpm
 ```
+
+<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
 
 ### II. Edit the Configuration File
 
@@ -212,15 +214,15 @@ The expected output is:
     Data Nodes
     ==========
     ID   TCP Address               Version
-    4    enterprise-data-01:8088   1.2.0-c1.2.1
-    5    enterprise-data-02:8088   1.2.0-c1.2.1    
+    4    enterprise-data-01:8088   1.1.1-c1.1.1
+    5    enterprise-data-02:8088   1.1.1-c1.1.1    
 >
     Meta Nodes
     ==========
     TCP Address               Version
-    enterprise-meta-01:8091   1.2.0-c1.2.1
-    enterprise-meta-02:8091   1.2.0-c1.2.1
-    enterprise-meta-03:8091   1.2.0-c1.2.1
+    enterprise-meta-01:8091   1.1.1-c1.1.1
+    enterprise-meta-02:8091   1.1.1-c1.1.1
+    enterprise-meta-03:8091   1.1.1-c1.1.1
 
 The output should include every data node that was added to the cluster.
 The first data node added should have `ID=N`, where `N` is equal to one plus the number of meta nodes.

--- a/content/enterprise/v1.2/production_installation/meta_node_installation.md
+++ b/content/enterprise/v1.2/production_installation/meta_node_installation.md
@@ -95,15 +95,17 @@ Perform the following steps on each meta server.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.0-c1.2.1_amd64.deb
-sudo dpkg -i influxdb-meta_1.2.0-c1.2.1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.1.1-c1.1.1_amd64.deb
+sudo dpkg -i influxdb-meta_1.1.1-c1.1.1_amd64.deb
 ```
 
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.0_c1.2.1.x86_64.rpm
-sudo yum localinstall influxdb-meta-1.2.0_c1.2.1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.1.1_c1.1.1.x86_64.rpm
+sudo yum localinstall influxdb-meta-1.1.1_c1.1.1.x86_64.rpm
 ```
+
+<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
 
 ### II. Edit the Configuration File
 
@@ -202,9 +204,9 @@ The expected output is:
     Meta Nodes
     ==========
     TCP Address               Version
-    enterprise-meta-01:8091   1.2.0-c1.2.1
-    enterprise-meta-02:8091   1.2.0-c1.2.1
-    enterprise-meta-03:8091   1.2.0-c1.2.1
+    enterprise-meta-01:8091   1.1.1-c1.1.1
+    enterprise-meta-02:8091   1.1.1-c1.1.1
+    enterprise-meta-03:8091   1.1.1-c1.1.1
 
 Note that your cluster must have at least three meta nodes.
 If you do not see your meta nodes in the output, please retry adding them to

--- a/content/enterprise/v1.2/production_installation/web_console_installation.md
+++ b/content/enterprise/v1.2/production_installation/web_console_installation.md
@@ -27,14 +27,17 @@ a separate server.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise_1.2.1_amd64.deb
-sudo dpkg -i influx-enterprise_1.2.1_amd64.deb
+wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise_1.1.1_amd64.deb
+sudo dpkg -i influx-enterprise_1.1.1_amd64.deb
 ```
 #### RedHat & CentOS (64-bit)
 ```
-wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise-1.2.1.x86_64.rpm
-sudo yum localinstall influx-enterprise-1.2.1.x86_64.rpm
+wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise-1.1.1.x86_64.rpm
+sudo yum localinstall influx-enterprise-1.1.1.x86_64.rpm
 ```
+
+<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
+
 > **Notes:**
 >
 * For other distributions, visit

--- a/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
+++ b/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
@@ -102,11 +102,11 @@ Perform the following steps on all three servers.
 
 Download:
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.0-c1.2.1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.1.1-c1.1.1_amd64.deb
 ```
 Install:
 ```
-sudo dpkg -i influxdb-meta_1.2.0-c1.2.1_amd64.deb
+sudo dpkg -i influxdb-meta_1.1.1-c1.1.1_amd64.deb
 ```
 
 {{% /tab-content %}}
@@ -115,17 +115,19 @@ sudo dpkg -i influxdb-meta_1.2.0-c1.2.1_amd64.deb
 
 Download:
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.0_c1.2.1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.1.1_c1.1.1.x86_64.rpm
 ```
 Install:
 ```
-sudo yum localinstall influxdb-meta-1.2.0_c1.2.1.x86_64.rpm
+sudo yum localinstall influxdb-meta-1.1.1_c1.1.1.x86_64.rpm
 ```
 
 {{% /tab-content %}}
 
 {{< /tab-content-container >}}
 {{< /vertical-tabs >}}
+
+<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
 
 ### II. Edit the Meta Service Configuration File
 
@@ -196,11 +198,11 @@ Perform the following steps on all three servers.
 
 Download:
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.0-c1.2.1_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.1-c1.1.1_amd64.deb
 ```
 Install:
 ```
-sudo dpkg -i influxdb-data_1.2.0-c1.2.1_amd64.deb
+sudo dpkg -i influxdb-data_1.1.1-c1.1.1_amd64.deb
 ```
 
 {{% /tab-content %}}
@@ -209,11 +211,11 @@ sudo dpkg -i influxdb-data_1.2.0-c1.2.1_amd64.deb
 
 Download:
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.0_c1.2.1.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.1_c1.1.1.x86_64.rpm
 ```
 Install:
 ```
-sudo yum localinstall influxdb-data-1.2.0_c1.2.1.x86_64.rpm
+sudo yum localinstall influxdb-data-1.1.1_c1.1.1.x86_64.rpm
 ```
 
 {{% /tab-content %}}
@@ -221,6 +223,7 @@ sudo yum localinstall influxdb-data-1.2.0_c1.2.1.x86_64.rpm
 {{< /tab-content-container >}}
 {{< /vertical-tabs >}}
 
+<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
 
 ### II. Edit the Data Service Configuration File
 
@@ -371,16 +374,16 @@ The expected output is:
 Data Nodes
 ==========
 ID   TCP Address                  Version
-2    quickstart-cluster-01:8088   1.2.0-c1.2.1
-4    quickstart-cluster-02:8088   1.2.0-c1.2.1
-6    quickstart-cluster-03:8088   1.2.0-c1.2.1
+2    quickstart-cluster-01:8088   1.1.1-c1.1.1
+4    quickstart-cluster-02:8088   1.1.1-c1.1.1
+6    quickstart-cluster-03:8088   1.1.1-c1.1.1
 
 Meta Nodes
 ==========
 TCP Address                  Version
-quickstart-cluster-01:8091   1.2.0-c1.2.1
-quickstart-cluster-02:8091   1.2.0-c1.2.1
-quickstart-cluster-03:8091   1.2.0-c1.2.1
+quickstart-cluster-01:8091   1.1.1-c1.1.1
+quickstart-cluster-02:8091   1.1.1-c1.1.1
+quickstart-cluster-03:8091   1.1.1-c1.1.1
 ```
 
 Your cluster should have three data nodes and three meta nodes.

--- a/content/enterprise/v1.2/quickstart_installation/web_console_installation.md
+++ b/content/enterprise/v1.2/quickstart_installation/web_console_installation.md
@@ -25,14 +25,17 @@ a separate server.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise_1.2.1_amd64.deb
-sudo dpkg -i influx-enterprise_1.2.1_amd64.deb
+wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise_1.1.1_amd64.deb
+sudo dpkg -i influx-enterprise_1.1.1_amd64.deb
 ```
 #### RedHat & CentOS (64-bit)
 ```
-wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise-1.2.1.x86_64.rpm
-sudo yum localinstall influx-enterprise-1.2.1.x86_64.rpm
+wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise-1.1.1.x86_64.rpm
+sudo yum localinstall influx-enterprise-1.1.1.x86_64.rpm
 ```
+
+<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
+
 > **Notes:**
 >
 * For other distributions, visit

--- a/content/enterprise/v1.2/troubleshooting/reporting-issues.md
+++ b/content/enterprise/v1.2/troubleshooting/reporting-issues.md
@@ -13,7 +13,7 @@ support team.
 
 Please include the following in your email:
 
-* the version of InfluxEnterprise, e.g. 1.2.0-c1.2.1
+* the version of InfluxEnterprise, e.g. 1.1.1-c1.1.1
 * the version of Telegraf or Kapacitor, if applicable
 * what you expected to happen
 * what did happen


### PR DESCRIPTION
This removes the old content from the upgrading pages and adds content about:
* 1.1.x users not upgrading to 1.2.x
* 1.2.0 users upgrading to 1.2.1 (including a list of the 1.2.1 packages)
* 1.2.1 users not downgrading to 1.1.x
* All known issues with 1.2.0 OSS and 1.2.0 clustering

The clustering packages in the installation guides have been reverted to 1.1.1. I did the same to the web console packages as I couldn't verify if the 1.2.1 web console would work with 1.1.1 clustering. Those guides now include a link to the upgrading page for users looking to upgrade to 1.2.x.

