### PR TITLE
Move retention-autocreate from meta to data nodes, #1028

### DIFF
--- a/content/enterprise/v1.2/about-the-project/release-notes-changelog.md
+++ b/content/enterprise/v1.2/about-the-project/release-notes-changelog.md
@@ -34,8 +34,8 @@ Please see the OSS [release notes](https://github.com/influxdata/influxdb/blob/1
 
 ### Upgrading
 
-* The [`retention-autocreate`](/enterprise/v1.2/administration/configuration/#retention-autocreate-true) setting now appears on data nodes as well as meta nodes.
-If you set `retention-autocreate` to `false` on your meta nodes, you now need to disable it in the [data node configuration files](/enterprise/v1.2/administration/configuration/#retention-autocreate-true-1) as well.
+* The `retention-autocreate` configuration option has moved from the meta node configuration file to the [data node configuration file](/enterprise/v1.2/administration/configuration/#retention-autocreate-true).
+To disable the auto-creation of retention policies, set `retention-autocreate` to `false` in your data node configuration files.
 * The previously deprecated `influxd-ctl force-leave` command has been removed. The replacement command to remove a meta node which is never coming back online is [`influxd-ctl remove-meta -force`](/enterprise/v1.2/features/cluster-commands/).
 
 #### Cluster-specific Features

--- a/content/enterprise/v1.2/administration/configuration.md
+++ b/content/enterprise/v1.2/administration/configuration.md
@@ -254,20 +254,6 @@ user's perspective.
 
 Environment variable: `INFLUXDB_META_ANNOUNCEMENT_EXPIRATION`
 
-###  retention-autocreate = true
-
-Set to `false` to disable the automatic creation of an `autogen` [retention policy](/influxdb/v1.2/concepts/glossary/#retention-policy-rp) for new databases.
-
-If set to `true`, InfluxDB automatically creates a `DEFAULT` retention policy
-when a database is created.
-That retention policy is called `autogen`, has an infinite
-[duration](/influxdb/v1.2/concepts/glossary/#duration), a one week [shard duration](/influxdb/v1.2/concepts/glossary/#shard-duration), and a
-[replication factor](/influxdb/v1.2/concepts/glossary/#replication-factor) set
-to the number of nodes in the cluster.
-If set to `false`, you must explicitly create a `DEFAULT` retention policy on every new database before that database can accept any writes.
-
-Environment variable: `INFLUXDB_META_RETENTION_AUTOCREATE`
-
 ###  election-timeout = "1s"
 
 The duration a Raft candidate spends in the candidate state without a leader


### PR DESCRIPTION
This PR moves the `retention-autocreate` setting from the meta node configuration to the data node configuration. It also clarifies the description in the changelog about that change as I had initially misunderstood the [changelog entry](https://github.com/influxdata/plutonium/blob/master/CHANGELOG.md#upgrading).

Fixes: https://github.com/influxdata/docs.influxdata.com/issues/1028