### PR TITLE
Issue fixes

### DIFF
--- a/content/influxdb/v1.2/query_language/data_exploration.md
+++ b/content/influxdb/v1.2/query_language/data_exploration.md
@@ -3085,7 +3085,13 @@ The main query supports all clauses listed in this document.
 
 The subquery appears in the main query's `FROM` clause, and it requires surrounding parentheses.
 The subquery supports all clauses listed in this document.
-Note that there can be multiple subqueries per main query.
+
+InfluxQL supports multiple nested subqueries per main query.
+Sample syntax for multiple subqueries:
+
+```
+SELECT_clause FROM ( SELECT_clause FROM ( SELECT_statement ) [...] ) [...]
+```
 
 ### Examples
 
@@ -3222,3 +3228,20 @@ time                   water_level_derivative
 
 Next, InfluxDB performs the main query and calculates the sum of the `water_level_derivative` values for each tag value of `location`.
 Notice that the main query specifies `water_level_derivative`, not `water_level` or `derivative`, as the field key in the `SUM()` function.
+
+### Common Issues with Subqueries
+
+#### Issue 1: Multiple SELECT statements in a subquery
+
+InfluxQL supports multiple nested subqueries per main query:
+```
+SELECT_clause FROM ( SELECT_clause FROM ( SELECT_statement ) [...] ) [...]
+                     ------------------   ----------------
+                         Subquery 1          Subquery 2
+```
+
+InfluxQL does not support multiple [`SELECT` statements](#the-basic-select-statement) per subquery:
+```
+SELECT_clause FROM (SELECT_statement; SELECT_statement) [...]
+```
+The system returns a parsing error if a subquery includes multiple `SELECT` statements.

--- a/content/kapacitor/v1.2/nodes/alert_node.md
+++ b/content/kapacitor/v1.2/nodes/alert_node.md
@@ -1936,7 +1936,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -1948,7 +1948,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/combine_node.md
+++ b/content/kapacitor/v1.2/nodes/combine_node.md
@@ -461,7 +461,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -473,7 +473,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/default_node.md
+++ b/content/kapacitor/v1.2/nodes/default_node.md
@@ -399,7 +399,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -411,7 +411,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/delete_node.md
+++ b/content/kapacitor/v1.2/nodes/delete_node.md
@@ -398,7 +398,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -410,7 +410,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/derivative_node.md
+++ b/content/kapacitor/v1.2/nodes/derivative_node.md
@@ -419,7 +419,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -431,7 +431,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/eval_node.md
+++ b/content/kapacitor/v1.2/nodes/eval_node.md
@@ -496,7 +496,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -508,7 +508,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/flatten_node.md
+++ b/content/kapacitor/v1.2/nodes/flatten_node.md
@@ -432,7 +432,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -444,7 +444,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/from_node.md
+++ b/content/kapacitor/v1.2/nodes/from_node.md
@@ -614,7 +614,7 @@ Returns: [FromNode](/kapacitor/v1.2/nodes/from_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -626,7 +626,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/group_by_node.md
+++ b/content/kapacitor/v1.2/nodes/group_by_node.md
@@ -409,7 +409,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -421,7 +421,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/http_out_node.md
+++ b/content/kapacitor/v1.2/nodes/http_out_node.md
@@ -369,7 +369,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -381,7 +381,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/influx_q_l_node.md
+++ b/content/kapacitor/v1.2/nodes/influx_q_l_node.md
@@ -405,7 +405,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -417,7 +417,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/join_node.md
+++ b/content/kapacitor/v1.2/nodes/join_node.md
@@ -559,7 +559,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -571,7 +571,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/k8s_autoscale_node.md
+++ b/content/kapacitor/v1.2/nodes/k8s_autoscale_node.md
@@ -587,7 +587,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -599,7 +599,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/log_node.md
+++ b/content/kapacitor/v1.2/nodes/log_node.md
@@ -395,7 +395,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -407,7 +407,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/no_op_node.md
+++ b/content/kapacitor/v1.2/nodes/no_op_node.md
@@ -358,7 +358,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -370,7 +370,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/query_node.md
+++ b/content/kapacitor/v1.2/nodes/query_node.md
@@ -566,7 +566,7 @@ Returns: [FlattenNode](/kapacitor/v1.2/nodes/flatten_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -578,7 +578,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/sample_node.md
+++ b/content/kapacitor/v1.2/nodes/sample_node.md
@@ -373,7 +373,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -385,7 +385,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/shift_node.md
+++ b/content/kapacitor/v1.2/nodes/shift_node.md
@@ -371,7 +371,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -383,7 +383,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/stats_node.md
+++ b/content/kapacitor/v1.2/nodes/stats_node.md
@@ -404,7 +404,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -416,7 +416,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/u_d_f_node.md
+++ b/content/kapacitor/v1.2/nodes/u_d_f_node.md
@@ -409,7 +409,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -421,7 +421,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/union_node.md
+++ b/content/kapacitor/v1.2/nodes/union_node.md
@@ -395,7 +395,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -407,7 +407,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/where_node.md
+++ b/content/kapacitor/v1.2/nodes/where_node.md
@@ -367,7 +367,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -379,7 +379,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 

--- a/content/kapacitor/v1.2/nodes/window_node.md
+++ b/content/kapacitor/v1.2/nodes/window_node.md
@@ -457,7 +457,7 @@ Returns: [GroupByNode](/kapacitor/v1.2/nodes/group_by_node/)
 
 ### HoltWinters
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 
 
 ```javascript
@@ -469,7 +469,7 @@ Returns: [InfluxQLNode](/kapacitor/v1.2/nodes/influx_q_l_node/)
 
 ### HoltWintersWithFit
 
-Compute the holt-winters forecast of a data set. 
+Compute the [holt-winters](/influxdb/v1.2/query_language/functions/#holt-winters) forecast of a data set. 
 This method also outputs all the points used to fit the data in addition to the forecasted data. 
 
 


### PR DESCRIPTION
Links the Kapacitor Holt-Winters documentation to the InfluxDB documentation. Fixes: https://github.com/influxdata/docs.influxdata.com/issues/1039

Clarifies that InfluxQL's subqueries support multiple nested subqueries per main query, not multiple `SELECT` statements per subquery. Adds sample syntax for multiple nested subqueries to the `Description of Syntax` section and adds a common issue to the `Common Issues` section that highlights the difference between multiple nested subqueries and multiple `SELECT` statements. Fixes the issue outlined in: https://github.com/influxdata/influxdb/issues/8043