### PR TITLE
[InfluxDB] Fix API responses

### DIFF
--- a/content/influxdb/v1.2/guides/querying_data.md
+++ b/content/influxdb/v1.2/guides/querying_data.md
@@ -23,10 +23,11 @@ The results of your query appear in the `"results"` array.
 If an error occurs, InfluxDB sets an `"error"` key with an explanation of the error.
 <br>
 
-```json
+```
 {
     "results": [
         {
+            "statement_id": 0,
             "series": [
                 {
                     "name": "cpu_load_short",
@@ -37,11 +38,11 @@ If an error occurs, InfluxDB sets an `"error"` key with an explanation of the er
                     "values": [
                         [
                             "2015-01-29T21:55:43.702900257Z",
-                            0.55
+                            2
                         ],
                         [
                             "2015-01-29T21:55:43.702900257Z",
-                            23422
+                            0.55
                         ],
                         [
                             "2015-06-11T20:46:02Z",
@@ -69,10 +70,11 @@ curl -G 'http://localhost:8086/query?pretty=true' --data-urlencode "db=mydb" --d
 
 returns:  
 <br>
-```json
+```
 {
     "results": [
         {
+            "statement_id": 0,
             "series": [
                 {
                     "name": "cpu_load_short",
@@ -83,11 +85,11 @@ returns:
                     "values": [
                         [
                             "2015-01-29T21:55:43.702900257Z",
-                            0.55
+                            2
                         ],
                         [
                             "2015-01-29T21:55:43.702900257Z",
-                            23422
+                            0.55
                         ],
                         [
                             "2015-06-11T20:46:02Z",
@@ -98,6 +100,7 @@ returns:
             ]
         },
         {
+            "statement_id": 1,
             "series": [
                 {
                     "name": "cpu_load_short",
@@ -152,3 +155,5 @@ curl -G 'http://localhost:8086/query' --data-urlencode "db=deluge" --data-urlenc
 ### InfluxQL
 ---
 Now that you know how to query data, check out the [Data Exploration page](/influxdb/v1.2/query_language/data_exploration/) to get acquainted with InfluxQL.
+For more information about querying data with the HTTP API, please see the [API reference documentation](/influxdb/v1.2/tools/api/#query).
+

--- a/content/influxdb/v1.2/guides/writing_data.md
+++ b/content/influxdb/v1.2/guides/writing_data.md
@@ -121,9 +121,14 @@ returns:
 <br>
 
 ```bash
-HTTP/1.2 400 Bad Request
-[...]
-write failed: field type conflict: input field "booleanonly" on measurement "tobeornottobe" is type float64, already exists as type boolean
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Request-Id: [...]
+X-Influxdb-Version: 1.2.x
+Date: Wed, 01 Mar 2017 19:38:01 GMT
+Content-Length: 150
+
+{"error":"field type conflict: input field \"booleanonly\" on measurement \"tobeornottobe\" is type float, already exists as type boolean dropped=1"}
 ```
 
 * Writing a point to a database that doesn't exist:
@@ -136,11 +141,19 @@ returns:
 <br>
 
 ```bash
-HTTP/1.2 404 Not Found
-[...]
-database not found: "atlantis"
+HTTP/1.1 404 Not Found
+Content-Type: application/json
+Request-Id: [...]
+X-Influxdb-Version: 1.2.x
+Date: Wed, 01 Mar 2017 19:38:35 GMT
+Content-Length: 45
+
+{"error":"database not found: \"atlantis\""}
 ```
 
 ### Next steps
 ---
 Now that you know how to write data with the built-in HTTP API discover how to query them with the [Querying Data](/influxdb/v1.2/guides/querying_data/) guide!
+For more information about writing data with the HTTP API, please see the [API reference documentation](/influxdb/v1.2/tools/api/#write).
+
+

--- a/content/influxdb/v1.2/query_language/data_exploration.md
+++ b/content/influxdb/v1.2/query_language/data_exploration.md
@@ -3012,11 +3012,10 @@ time                   water_level
 With InfluxDB's [HTTP API](/influxdb/v1.2/tools/api/):
 
 ```
-~# curl -G 'http://localhost:8086/query?db=NOAA_water_database' --data-urlencode 'q=SELECT MEAN("water_level") FROM "h2o_feet"; SELECT "water_level" FROM "h2o_feet" LIMIT 2'
-
 {
     "results": [
         {
+            "statement_id": 0,
             "series": [
                 {
                     "name": "h2o_feet",
@@ -3027,13 +3026,14 @@ With InfluxDB's [HTTP API](/influxdb/v1.2/tools/api/):
                     "values": [
                         [
                             "1970-01-01T00:00:00Z",
-                            4.442107025822521
+                            4.442107025822522
                         ]
                     ]
                 }
             ]
         },
         {
+            "statement_id": 1,
             "series": [
                 {
                     "name": "h2o_feet",

--- a/content/influxdb/v1.2/query_language/schema_exploration.md
+++ b/content/influxdb/v1.2/query_language/schema_exploration.md
@@ -124,6 +124,7 @@ Specify the database with the `db` query string parameter:
 {
     "results": [
         {
+            "statement_id": 0,
             "series": [
                 {
                     "columns": [
@@ -263,6 +264,7 @@ Specify the database with the `db` query string parameter:
 {
     "results": [
         {
+            "statement_id": 0,
             "series": [
                 {
                     "columns": [
@@ -427,36 +429,38 @@ Specify the database with the `db` query string parameter:
 ~# curl -G "http://localhost:8086/query?db=NOAA_water_database&pretty=true" --data-urlencode "q=SHOW MEASUREMENTS"
 
 {
-    "results": [
-        {
-            "series": [
-                {
-                    "name": "measurements",
-                    "columns": [
-                        "name"
-                    ],
-                    "values": [
-                        [
-                            "average_temperature"
-                        ],
-                        [
-                            "h2o_feet"
-                        ],
-                        [
-                            "h2o_pH"
-                        ],
-                        [
-                            "h2o_quality"
-                        ],
-                        [
-                            "h2o_temperature"
-                        ]
-                    ]
-                }
-            ]
-        }
-    ]
-}
+  {
+      "results": [
+          {
+              "statement_id": 0,
+              "series": [
+                  {
+                      "name": "measurements",
+                      "columns": [
+                          "name"
+                      ],
+                      "values": [
+                          [
+                              "average_temperature"
+                          ],
+                          [
+                              "h2o_feet"
+                          ],
+                          [
+                              "h2o_pH"
+                          ],
+                          [
+                              "h2o_quality"
+                          ],
+                          [
+                              "h2o_temperature"
+                          ]
+                      ]
+                  }
+              ]
+          }
+      ]
+  }
 ```
 
 {{% /tab-content %}}
@@ -621,6 +625,7 @@ Specify the database with the `db` query string parameter:
 {
     "results": [
         {
+            "statement_id": 0,
             "series": [
                 {
                     "name": "average_temperature",
@@ -797,6 +802,7 @@ Specify the database with the `db` query string parameter:
 {
     "results": [
         {
+            "statement_id": 0,
             "series": [
                 {
                     "name": "h2o_quality",
@@ -962,6 +968,7 @@ Specify the database with the `db` query string parameter:
 {
     "results": [
         {
+            "statement_id": 0,
             "series": [
                 {
                     "name": "average_temperature",

--- a/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
@@ -80,24 +80,41 @@ and when authentication requests.
 ## How can I identify my version of InfluxDB?
 There a number of ways to identify the version of InfluxDB that you're using:
 
-* Check the return when you `curl` the `/ping` endpoint.
-For example, if you're using 1.2.0 `curl -i 'http://localhost:8086/ping'` returns:  
+#### Run `influxd version` in your terminal:
+```
+$ influxd version
 
-`HTTP/1.2 204 No Content`  
-`Request-Id: 874101f6-e23e-11e5-8097-000000000000`  
-✨`X-Influxdb-Version: 1.2.0`✨  
-`Date: Fri, 04 Mar 2016 19:23:08 GMT`
+InfluxDB ✨ v1.2.0 ✨ (git: master b7bb7e8359642b6e071735b50ae41f5eb343fd42)
+```
 
-If authentication is enabled you will need to use `https` in the URL.
+#### `curl` the `/ping` endpoint:
 
-* Check the text that appears when you [launch](/influxdb/v1.2/tools/shell/) the CLI:
+```
+$ url -i 'http://localhost:8086/ping'
 
-`Connected to http://localhost:8086`✨`version 1.2.0`✨  
-`InfluxDB shell 1.2.0`
+HTTP/1.1 204 No Content
+Content-Type: application/json
+Request-Id: 1e08aeb6-fec0-11e6-8486-000000000000
+✨ X-Influxdb-Version: 1.2.0 ✨
+Date: Wed, 01 Mar 2017 20:46:17 GMT
+```
 
-* Check the HTTP response in your logs:  
+#### Launch InfluxDB's [Command Line Interface](/influxdb/v1.2/tools/shell/):
 
-`[http] 2016/03/04 11:25:13 ::1 - - [04/Mar/2016:11:25:13 -0800] GET /query?db=&epoch=ns&q=show+databases HTTP/1.2 200 98 -`     ✨`InfluxDBShell/1.2.0`✨`d16e7a83-e23e-11e5-80a7-000000000000 529.543µs`
+```
+$ influx
+
+Connected to http://localhost:8086✨ version 1.2.0 ✨  
+InfluxDB shell version: 1.2.0
+```
+
+#### Check the HTTP response in your logs:  
+
+```
+$ journald-ctl -u influxdb.service
+
+Mar 01 20:49:45 rk-api influxd[29560]: [httpd] 127.0.0.1 - - [01/Mar/2017:20:49:45 +0000] "POST /query?db=&epoch=ns&q=SHOW+DATABASES HTTP/1.1" 200 151 "-" ✨ "InfluxDBShell/1.2.0" ✨ 9a4371a1-fec0-11e6-84b6-000000000000 1709
+```
 
 ## What is the relationship between shard group durations and retention policies?
 


### PR DESCRIPTION
As of version 1.2.0, API responses now include `"statement_id"`. 

Updates:

* API Reference documentation
* Writing data with the HTTP API guide
* Querying data with the HTTP API guide
* Data Exploration
* Schema Exploration
* Frequently Asked Questions

Fixes: #1032



