### PR TITLE
Link to https://www.influxdata.com/

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,5 +1,5 @@
 <nav class="navbar" id="main-nav">
-    <a href="{{ .Site.BaseURL }}" target="_blank" title="Go to Documentation Home"><span class="icon logotype navbar--logo"></span></a>
+    <a href="https://www.influxdata.com/" target="_blank" title="Go to Documentation Home"><span class="icon logotype navbar--logo"></span></a>
     {{ partial "product-switcher.html" . }}
     {{ partial "search.html" . }}
     {{ partial "theme-switcher.html" . }}


### PR DESCRIPTION
Per marketing's request, this changes the link associated with the influxdata logo at the top of the page from https://docs.influxdata.com/ (the docs landing page) to https://www.influxdata.com/ (the influxdata website).

![image](https://cloud.githubusercontent.com/assets/8750814/23634000/e43b155e-027c-11e7-9134-c27b8ddb1660.png)

### Implications and possible source of confusion

The change is a little strange because we don't link to https://docs.influxdata.com/ from anywhere else in the documentation. But - it is possible to get to the documentation for the different products from the dropdown at the top of the page. If this becomes a problem please let us know and we'll get a better fix out.

Dropdown for the documentation for other products:

![image](https://cloud.githubusercontent.com/assets/8750814/23634229/02e3326a-027e-11e7-80e1-8deacfd94517.png)
