### PR TITLE
add where-can-i-find-enterprise-logs section

### DIFF
--- a/content/enterprise/v1.2/troubleshooting/frequently_asked_questions.md
+++ b/content/enterprise/v1.2/troubleshooting/frequently_asked_questions.md
@@ -22,7 +22,7 @@ In the `Account Details` section, select the checkbox next to `Admin` and click
 
 ## Where can I find InfluxEnterprise logs?
 
-On systemd operating systems service logs can be accessed using the journalctl command.
+On systemd operating systems service logs can be accessed using the `journalctl` command.
 
 Meta: `journalctl -u influxdb-meta`
 
@@ -30,7 +30,7 @@ Data : `journalctl -u influxdb`
 
 Enterprise console: `journalctl -u influx-enterprise`
 
-The journalctl output can be redirected to print the logs to a text file. With systemd, log retention depends on the system's journald settings.
+The `journalctl` output can be redirected to print the logs to a text file. With systemd, log retention depends on the system's journald settings.
 
 
 # Known Errors

--- a/content/enterprise/v1.2/troubleshooting/frequently_asked_questions.md
+++ b/content/enterprise/v1.2/troubleshooting/frequently_asked_questions.md
@@ -20,6 +20,19 @@ In the `Account Details` section, select the checkbox next to `Admin` and click
 
 ![Web Console Admin User](/img/enterprise/admin_user_1.png)
 
+## Where can I find InfluxEnterprise logs?
+
+On systemd operating systems service logs can be accessed using the journalctl command.
+
+Meta: `journalctl -u influxdb-meta`
+
+Data : `journalctl -u influxdb`
+
+Enterprise console: `journalctl -u influx-enterprise`
+
+The journalctl output can be redirected to print the logs to a text file. With systemd, log retention depends on the system's journald settings.
+
+
 # Known Errors
 
 ## Why am I seeing a `503 Service Unavailable` error in my meta node logs?


### PR DESCRIPTION
This comes up pretty often - adjusted for Enterprise.

Related to https://github.com/influxdata/docs.influxdata.com/pull/1048