### PR TITLE
Update docs for max-row-limit change

### DIFF
--- a/content/influxdb/v1.2/administration/config.md
+++ b/content/influxdb/v1.2/administration/config.md
@@ -514,10 +514,17 @@ The shared secret used for JWT signing.
 
 Environment variable: `INFLUXDB_HTTP_SHARED_SECRET`
 
-### max-row-limit = 10000
+### max-row-limit = 0
 
-This limits the number of rows that can be returned in a non-chunked query.
-InfluxDB includes a `"partial":true` tag in the response body if query results exceed `max-row-limit`.
+Limits the number of rows that the system can return in a [non-chunked](/influxdb/v1.2/tools/api/#query-string-parameters) query.
+The default setting (`0`) allows for an unlimited number of rows.
+InfluxDB includes a `"partial":true` tag in the response body if query results exceed the `max-row-limit` setting.
+
+<dt>
+In versions 1.2.0 and 1.2.1, the `max-row-limit` option is set to 10,000 by default.
+That default setting can lead to unexpected behavior in [Grafana](https://grafana.com/) panels; if a panel's query returns more than 10,000 points, the panel appears to show [truncated/partial data](https://github.com/influxdata/influxdb/issues/8050).
+In version 1.2.2, `max-row-limit` is set to `0` by default and allows an unlimited number of returned rows.
+</dt>
 
 Environment variable: `INFLUXDB_HTTP_MAX_ROW_LIMIT`
 

--- a/content/influxdb/v1.2/guides/querying_data.md
+++ b/content/influxdb/v1.2/guides/querying_data.md
@@ -138,9 +138,14 @@ Authentication in InfluxDB is disabled by default.
 See [Authentication and Authorization](/influxdb/v1.2/query_language/authentication_and_authorization/) for how to enable and set up authentication.
 
 #### Maximum Row Limit
-InfluxDB limits the maximum number of returned results to prevent itself from running out of memory while it aggregates the results.
-By default, InfluxDB truncates the number of rows returned to 10,000 and, if there are more than 10,000 rows to return, includes a `"partial":true` tag in the response body.
-The [`max-row-limit` setting](/influxdb/v1.2/administration/config/#max-row-limit-10000) is configurable in the `[http]` section of the configuration file.
+The [`max-row-limit` configuration option](/influxdb/v1.2/administration/config/#max-row-limit-0) allows users to limit the maximum number of returned results to prevent InfluxDB from running out of memory while it aggregates the results.
+
+In versions 1.2.0 and 1.2.1, InfluxDB truncates the number of rows returned to 10,000 by default.
+If there are more than 10,000 rows to return, the response body includes a `"partial":true` tag.
+That default setting can lead to unexpected behavior in [Grafana](https://grafana.com/) panels; if a panel's query returns more than 10,000 points, the panel appears to show [truncated/partial data](https://github.com/influxdata/influxdb/issues/8050).
+
+In version 1.2.2, the `max-row-limit` configuration option is set to `0` by default.
+That default setting allows for an unlimited number of rows returned per request.
 
 The maximum row limit only applies to non-chunked queries. Chunked queries can return an unlimited number of points.
 

--- a/content/influxdb/v1.2/tools/api.md
+++ b/content/influxdb/v1.2/tools/api.md
@@ -142,10 +142,12 @@ A successful [`CREATE DATABASE` query](/influxdb/v1.2/query_language/database_ma
 | pretty=true | Optional | Enables pretty-printed JSON output. While this is useful for debugging it is not recommended for production use as it consumes unnecessary network bandwidth. |
 | u=\<username> | Optional if you haven't [enabled authentication](/influxdb/v1.2/query_language/authentication_and_authorization/#set-up-authentication). Required if you've enabled authentication.* | Sets the username for authentication if you've enabled authentication. The user must have read access to the database. Use with the query string parameter `p`. |
 
-\* InfluxDB automatically truncates the number of rows returned for requests without the `chunked` parameter.
+\* In versions 1.2.0 and 1.2.1, InfluxDB automatically truncates the number of rows returned for requests without the `chunked` parameter.
 By default, the maximum number of rows returned is set to 10,000.
 If a query has more than 10,000 rows to return, InfluxDB includes a `"partial":true` tag in the response body.
-The [`max-row-limit` setting](/influxdb/v1.2/administration/config/#max-row-limit-10000) is configurable in the `[http]` section of the configuration file.
+The [`max-row-limit` setting](/influxdb/v1.2/administration/config/#max-row-limit-0) is configurable in the `[http]` section of the configuration file.
+In version 1.2.2, the `max-row-limit` configuration option is set to `0` by default.
+That default setting allows for an unlimited number of rows returned per request.
 
 \** The HTTP API also supports basic authentication.
 Use basic authentication if you've [enabled authentication](/influxdb/v1.2/query_language/authentication_and_authorization/#set-up-authentication)


### PR DESCRIPTION
In version 1.2.0 and 1.2.1, the configuration file set `max-row-limit`  to `10000` by default. That setting created issues with Grafana panels that returned more than 10,000 rows worth of data. In version 1.2.2, the configuration file sets `max-row-limit` to `0`. The `0` allows for an unlimited number of rows in the response.

This PR updates the configuration doc, the querying data with the HTTP API doc, and the API reference doc with that change.