### PR TITLE
Unrelated doc fixes

### DIFF
--- a/content/enterprise/v1.2/administration/configuration.md
+++ b/content/enterprise/v1.2/administration/configuration.md
@@ -6,14 +6,37 @@ menu:
     parent: Administration
 ---
 
-<table style="width:100%">
-  <tr>
-    <td><a href="#using-configuration-files">Using Configuration Files</a></td>
-    <td><a href="#meta-node-configuration">Meta Node Configuration File</a></td>
-    <td><a href="#data-node-configuration">Data Node Configuration File</a></td>
-    <td><a href="#web-console-configuration">Web Console Configuration File</a></td>
-  </tr>
-</table>
+#### Content
+
+* [Using configuration files](#using-configuration-files)
+* [Meta node configuration sections](#meta-node-configuration)
+    * [Global options](#global-options)
+    * [[enterprise]](#enterprise)
+    * [[meta]](#meta)
+* [Data node configuration sections](#data-node-configuration)
+    * [Global options](#global-options-1)
+    * [[enterprise]](#enterprise-1)
+    * [[meta]](#meta-1)
+    * [[data]](#data)
+    * [[cluster]](#cluster)
+    * [[retention]](#retention)
+    * [[shard-precreation]](#shard-precreation)
+    * [[admin]](#admin)
+    * [[monitor]](#monitor)
+    * [[subscriber]](#subscriber)
+    * [[http]](#http)
+    * [[graphite]](#graphite)
+    * [[collectd]](#collectd)
+    * [[opentsdb]](#opentsdb)
+    * [[udp]](#udp)
+    * [[continuous-queries]](#continuous-queries)
+    * [[hinted-handoff]](#hinted-handoff)
+* [Web console configuration sections](#web-console-configuration)
+    * [Global options](#global-options-2)
+    * [[influxdb]](#influxdb)
+    * [[smtp]](#smtp)
+    * [[database]](#database)
+
 <br>
 # Using Configuration Files
 
@@ -1011,6 +1034,8 @@ Environment variable: `INFLUXDB_HINTED_HANDOFF_PURGE_INTERVAL`
 <br>
 <br>
 # Web Console Configuration
+
+## Global options
 
 ### url = "http://IP_or_hostname:3000"
 

--- a/content/enterprise/v1.2/administration/index.md
+++ b/content/enterprise/v1.2/administration/index.md
@@ -8,3 +8,5 @@ menu:
 ## [Logs](/enterprise/v1.2/administration/logs/)
 
 ## [Upgrading from Previous Versions](/enterprise/v1.2/administration/upgrading/)
+
+## [Configuration](/enterprise/v1.2/administration/configuration/)

--- a/content/enterprise/v1.2/features/clustering-features.md
+++ b/content/enterprise/v1.2/features/clustering-features.md
@@ -23,18 +23,17 @@ Subscriptions used by Kapacitor work in a cluster. Writes to any node will be fo
 
 ## PProf Endpoints
 
-The meta nodes now expose the /debug/pprof endpoints for profiling and troubleshooting.
+Meta nodes expose the /debug/pprof endpoints for profiling and troubleshooting.
 
 ## Shard Movement
 
-* Copy Shard support - copy a shard from one node to another
-* Copy Shard Status - query the status of a copy shard request
-* Kill Copy Shard - kill a running shard copy
-* Remove Shard - remove a shard from a node (this deletes data)
-* Truncate Shards - truncate all active shard groups and start new shards immediately (This is useful when adding nodes or changing replication factors.)
+* [Copy Shard](/enterprise/v1.2/features/cluster-commands/#copy-shard) support - copy a shard from one node to another
+* [Copy Shard Status](/enterprise/v1.2/features/cluster-commands/#copy-shard-status) - query the status of a copy shard request
+* [Kill Copy Shard](/enterprise/v1.2/features/cluster-commands/#kill-copy-shard) - kill a running shard copy
+* [Remove Shard](/enterprise/v1.2/features/cluster-commands/#remove-shard) - remove a shard from a node (this deletes data)
+* [Truncate Shards](/enterprise/v1.2/features/cluster-commands/#truncate-shards) - truncate all active shard groups and start new shards immediately (This is useful when adding nodes or changing replication factors.)
 
-This functionality is exposed via an API on the meta service and through `influxd-ctl` sub-commands.
-The `control.Client` provides a Go client to access this functionality as well.
+This functionality is exposed via an API on the meta service and through [`influxd-ctl` sub-commands](/enterprise/v1.2/features/cluster-commands/).
 
 ## OSS Conversion
 
@@ -54,7 +53,3 @@ InfluxEnterprise clusters support backup and restore functionality starting with
 version 0.7.1.
 See [Backup and Restore](/enterprise/v1.2/guides/backup-and-restore/) for
 more information.
-
-## Features Under Development
-
-HTTP API for performing all cluster and user management functions

--- a/content/enterprise/v1.2/production_installation/data_node_installation.md
+++ b/content/enterprise/v1.2/production_installation/data_node_installation.md
@@ -104,8 +104,6 @@ wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.1_c1.2.2.x8
 sudo yum localinstall influxdb-data-1.2.1_c1.2.2.x86_64.rpm
 ```
 
-<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
-
 ### II. Edit the Configuration File
 
 First, in `/etc/influxdb/influxdb.conf`, uncomment:

--- a/content/enterprise/v1.2/production_installation/meta_node_installation.md
+++ b/content/enterprise/v1.2/production_installation/meta_node_installation.md
@@ -105,8 +105,6 @@ wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.1_c1.2.2.x8
 sudo yum localinstall influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
 ```
 
-<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
-
 ### II. Edit the Configuration File
 
 In `/etc/influxdb/influxdb-meta.conf`:

--- a/content/enterprise/v1.2/production_installation/web_console_installation.md
+++ b/content/enterprise/v1.2/production_installation/web_console_installation.md
@@ -36,8 +36,6 @@ wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise-1.2.2
 sudo yum localinstall influx-enterprise-1.2.2.x86_64.rpm
 ```
 
-<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
-
 > **Notes:**
 >
 * For other distributions, visit

--- a/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
+++ b/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
@@ -91,41 +91,17 @@ Perform the following steps on all three servers.
 
 ### I. Download and Install the Meta Service
 
-{{< vertical-tabs >}}
-{{% tabs %}}
-[Ubuntu & Debian (64-bit)](#)
-[RedHat & CentOS (64-bit)](#)
-{{% /tabs %}}
-{{< tab-content-container >}}
 
-{{% tab-content %}}
-
-Download:
+#### Ubuntu & Debian (64-bit)
 ```
 wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.1-c1.2.2_amd64.deb
-```
-Install:
-```
 sudo dpkg -i influxdb-meta_1.2.1-c1.2.2_amd64.deb
 ```
-
-{{% /tab-content %}}
-
-{{% tab-content %}}
-
-Download:
+#### RedHat & CentOS (64-bit)]
 ```
 wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
-```
-Install:
-```
 sudo yum localinstall influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
 ```
-
-{{% /tab-content %}}
-
-{{< /tab-content-container >}}
-{{< /vertical-tabs >}}
 
 <dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
 
@@ -187,41 +163,16 @@ Perform the following steps on all three servers.
 
 ### I. Download and Install the Data Service
 
-{{< vertical-tabs >}}
-{{% tabs %}}
-[Ubuntu & Debian (64-bit)](#)
-[RedHat & CentOS (64-bit)](#)
-{{% /tabs %}}
-{{< tab-content-container >}}
-
-{{% tab-content %}}
-
-Download:
+#### Ubuntu & Debian (64-bit)
 ```
 wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.1-c1.2.2_amd64.deb
-```
-Install:
-```
 sudo dpkg -i influxdb-data_1.2.1-c1.2.2_amd64.deb
 ```
-
-{{% /tab-content %}}
-
-{{% tab-content %}}
-
-Download:
+#### RedHat & CentOS (64-bit)
 ```
 wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.1_c1.2.2.x86_64.rpm
-```
-Install:
-```
 sudo yum localinstall influxdb-data-1.2.1_c1.2.2.x86_64.rpm
 ```
-
-{{% /tab-content %}}
-
-{{< /tab-content-container >}}
-{{< /vertical-tabs >}}
 
 <dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
 

--- a/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
+++ b/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
@@ -103,8 +103,6 @@ wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.1_c1.2.2.x8
 sudo yum localinstall influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
 ```
 
-<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
-
 ### II. Edit the Meta Service Configuration File
 
 In `/etc/influxdb/influxdb-meta.conf`:
@@ -173,8 +171,6 @@ sudo dpkg -i influxdb-data_1.2.1-c1.2.2_amd64.deb
 wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.1_c1.2.2.x86_64.rpm
 sudo yum localinstall influxdb-data-1.2.1_c1.2.2.x86_64.rpm
 ```
-
-<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
 
 ### II. Edit the Data Service Configuration File
 

--- a/content/enterprise/v1.2/quickstart_installation/web_console_installation.md
+++ b/content/enterprise/v1.2/quickstart_installation/web_console_installation.md
@@ -34,8 +34,6 @@ wget https://s3.amazonaws.com/influx-enterprise/releases/influx-enterprise-1.2.2
 sudo yum localinstall influx-enterprise-1.2.2.x86_64.rpm
 ```
 
-<dt>For users looking to upgrade to version 1.2.x, please see the [Upgrading](/enterprise/v1.2/administration/upgrading/) document for important information about that release.</dt>
-
 > **Notes:**
 >
 * For other distributions, visit

--- a/content/influxdb/v1.2/administration/config.md
+++ b/content/influxdb/v1.2/administration/config.md
@@ -8,6 +8,128 @@ menu:
 
 The InfluxDB configuration file contains configuration settings specific to a local node.
 
+#### Content
+
+* [Using configuration files](#using-configuration-files)
+    * [Configuration options overview](#configuration-options-overview)
+    * [Environment variables](#environment-variables)
+* [Configuration options by section](#configuration-options-by-section)
+    * [Global options](#global-options)
+        * [reporting-disabled](#reporting-disabled-false)
+        * [bind-address](#bind-address-8088)
+    * [[meta]](#meta)
+        * [dir](#dir-var-lib-influxdb-meta)
+        * [retention-autocreate](#retention-autocreate-true)
+        * [logging-enabled](#logging-enabled-true)
+    * [[data]](#data)
+        * [dir](#dir-var-lib-influxdb-data)
+        * [wal-dir](#wal-dir-var-lib-influxdb-wal)
+        * [trace-logging-enabled](#trace-logging-enabled-false)
+        * [query-log-enabled](#query-log-enabled-true)
+        * [cache-max-memory-size](#cache-max-memory-size-1048576000)
+        * [cache-snapshot-memory-size](#cache-snapshot-memory-size-26214400)
+        * [cache-snapshot-write-cold-duration](#cache-snapshot-write-cold-duration-10m)
+        * [compact-full-write-cold-duration](#compact-full-write-cold-duration-4h)
+        * [max-series-per-database](#max-series-per-database-1000000)
+        * [max-values-per-tag](#max-values-per-tag-100000)
+    * [[coordinator]](#coordinator)
+        * [write-timeout](#write-timeout-10s)
+        * [max-concurrent-queries](#max-concurrent-queries-0)
+        * [query-timeout](#query-timeout-0s)
+        * [log-queries-after](#log-queries-after-0s)
+        * [max-select-point](#max-select-point-0)
+        * [max-select-series](#max-select-series-0)
+        * [max-select-buckets](#max-select-buckets-0)
+    * [[retention]](#retention)
+        * [enabled](#enabled-true)
+        * [check-interval](#check-interval-30m0s)
+    * [[shard-precreation]](#shard-precreation)
+        * [enabled](#enabled-true-1)
+        * [check-interval](#check-interval-10m)
+        * [advance-period](#advance-period-30m)
+    * [[admin]](#admin)
+        * [enabled](#enabled-false)
+        * [bind-address](#bind-address-8083)
+        * [https-enabled](#https-enabled-false)
+        * [https-certificate](#https-certificate-etc-ssl-influxdb-pem)
+    * [[monitor]](#monitor)
+        * [store-enabled](#store-enabled-true)
+        * [store-database](#store-database-internal)
+        * [store-interval](#store-interval-10s)
+    * [[subscriber]](#subscriber)
+        * [enabled](#enabled-true-3)
+        * [http-timeout](#http-timeout-30s)
+        * [insecure-skip-verify](#insecure-skip-verify-false)
+        * [ca-certs](#ca-certs)
+        * [write-concurrency](#write-concurrency-40)
+        * [write-buffer-size](#write-buffer-size-1000)
+    * [[http]](#http)
+        * [enabled](#enabled-true-2)
+        * [bind-address](#bind-address-8086)
+        * [auth-enabled](#auth-enabled-false)
+        * [realm](#realm-influxdb)
+        * [log-enabled](#log-enabled-true)
+        * [write-tracing](#write-tracing-false)
+        * [pprof-enabled](#pprof-enabled-true)
+        * [https-enabled](#https-enabled-false-1)
+        * [https-certificate](#https-certificate-etc-ssl-influxdb-pem-1)
+        * [https-private-key](#https-private-key)
+        * [shared-secret](#shared-secret)
+        * [max-row-limit](#max-row-limit-0)
+        * [max-connection-limit](#max-connection-limit-0)
+        * [unix-socket-enabled](#unix-socket-enabled-false)
+        * [bind-socket](#bind-socket-var-run-influxdb-sock)
+    * [[[graphite]]](#graphite)
+        * [enabled](#enabled-false-1)
+        * [database](#database-graphite)
+        * [retention-policy](#retention-policy)
+        * [bind-address](#bind-address-2003)
+        * [protocol](#protocol-tcp)
+        * [consistency-level](#consistency-level-one)
+        * [batch-size](#batch-size-5000)
+        * [batch-pending](#batch-pending-10)
+        * [batch-timeout](#batch-timeout-1s)
+        * [udp-read-buffer](#udp-read-buffer-0)
+        * [separator](#separator)
+    * [[[collectd]]](#collectd)
+        * [enabled](#enabled-false-2)
+        * [bind-address](#bind-address-25826)
+        * [database](#database-collectd)
+        * [retention-policy](#retention-policy-1)
+        * [typesdb](#typesdb-usr-local-share-collectd)
+        * [security-level](#security-level-none)
+        * [auth-file](#auth-file-etc-collectd-auth-file)
+        * [batch-size](#batch-size-5000-1)
+        * [batch-pending](#batch-pending-10-1)
+        * [batch-timeout](#batch-timeout-10s)
+        * [read-buffer](#read-buffer-0)
+    * [[[opentsdb]]](#opentsdb)
+        * [enabled](#enabled-false-3)
+        * [bind-address](#bind-address-4242)
+        * [database](#database-opentsdb)
+        * [retention-policy](#retention-policy-2)
+        * [consistency-level](#consistency-level-one-1)
+        * [tls-enabled](#tls-enabled-false)
+        * [certificate](#certificate-etc-ssl-influxdb-pem)
+        * [log-point-errors](#log-point-errors-true)
+        * [batch-size](#batch-size-1000)
+        * [batch-pending](#batch-pending-5)
+        * [batch-timeout](#batch-timeout-1s-1)
+    * [[[udp]]](#udp)
+        * [enabled](#enabled-false-4)
+        * [bind-address](#bind-address-8089)
+        * [database](#database-udp)
+        * [retention-policy](#retention-policy-3)
+        * [batch-size](#batch-size-5000-2)
+        * [batch-pending](#batch-pending-10-2)
+        * [batch-timeout](#batch-timeout-1s-2)
+        * [read-buffer](#read-buffer-0-1)
+        * [precision](#precision)
+    * [[continuous_queries]](#continuous-queries)
+        * [enabled](#enabled-true-4)
+        * [log-enabled](#log-enabled-true-1)
+        * [run-interval](#run-interval-1s)
+
 ## Using Configuration Files
 
 The system has internal defaults for every configuration file setting.
@@ -43,7 +165,26 @@ For example:
 InfluxDB first checks for the `-config` option and then for the environment
 variable.
 
-### Environment variables
+### Configuration Options Overview
+
+Every configuration section has configuration options and every configuration option is optional.
+If you do not uncomment a configuration option, the system uses its default setting.
+The configuration options in this document are set to their default settings.
+
+Configuration options that specify a duration support the following duration units:
+
+`ns`&nbsp;&nbsp;&emsp;&emsp;&emsp;&nbsp;&thinsp;&thinsp;nanoseconds  
+`us` or `µs`&emsp;microseconds  
+`ms`&nbsp;&nbsp;&emsp;&emsp;&emsp;&nbsp;&thinsp;&thinsp;milliseconds  
+`s`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;seconds  
+`m`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;minutes  
+`h`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;hours  
+`d`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;days  
+`w`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;weeks
+
+>**Note:** This page documents configuration options for the latest official release - the [sample configuration file on GitHub](https://github.com/influxdb/influxdb/blob/master/etc/config.sample.toml) will always be slightly ahead of what is documented here.
+
+### Environment Variables
 
 All configuration options can be specified in the configuration file or in an
 environment variable.
@@ -82,43 +223,6 @@ relevant position number (in this case: `0`):
 For the Nth Graphite configuration in the configuration file, the relevant
 environment variables would be of the form `INFLUXDB_GRAPHITE_(N-1)_BATCH_PENDING`.
 For each section of the configuration file the numbering restarts at zero.
-
-## Configuration Sections
-
-* [Global Options](#global-options)
-* [[meta]](#meta)
-* [[data]](#data)
-* [[coordinator]](#coordinator)
-* [[retention]](#retention)
-* [[shard-precreation]](#shard-precreation)
-* [[admin]](#admin)
-* [[monitor]](#monitor)
-* [[subscriber]](#subscriber)
-* [[http]](#http)
-* [[[graphite]]](#graphite)
-* [[[collectd]]](#collectd)
-* [[[opentsdb]]](#opentsdb)
-* [[[udp]]](#udp)
-* [[continuous_queries]](#continuous-queries)
-
-## Configuration Options
-
-Every configuration section has configuration options and every configuration option is optional.
-If you do not uncomment a configuration option, the system uses its default setting.
-The configuration options in this document are set to their default settings.
-
-Configuration options that specify a duration support the following duration units:
-
-`ns`&nbsp;&nbsp;&emsp;&emsp;&emsp;&nbsp;&thinsp;&thinsp;nanoseconds  
-`us` or `µs`&emsp;microseconds  
-`ms`&nbsp;&nbsp;&emsp;&emsp;&emsp;&nbsp;&thinsp;&thinsp;milliseconds  
-`s`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;seconds  
-`m`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;minutes  
-`h`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;hours  
-`d`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;days  
-`w`&nbsp;&emsp;&emsp;&emsp;&emsp;&nbsp;weeks
-
->**Note:** This page documents configuration options for the latest official release - the [sample configuration file on GitHub](https://github.com/influxdb/influxdb/blob/master/etc/config.sample.toml) will always be slightly ahead of what is documented here.
 
 ## Global Options
 

--- a/content/influxdb/v1.2/concepts/insights_tradeoffs.md
+++ b/content/influxdb/v1.2/concepts/insights_tradeoffs.md
@@ -12,7 +12,7 @@ Below is a list of some of those design insights that lead to tradeoffs:
 
 1. For the time series use case, we assume that if the same data is sent multiple times, it is the exact same data that a client just sent several times.
   * *Pro:* Simplified [conflict resolution](/influxdb/v1.2/troubleshooting/frequently-asked-questions/#how-does-influxdb-handle-duplicate-points) increases write performance
-  * *Con:* May lose data in rare circumstances
+  * *Con:* Cannot store duplicate data; may overwrite data in rare circumstances
 1. Deletes are a rare occurrence.
 When they do occur it is almost always against large ranges of old data that are cold for writes.
   * *Pro:* Restricting access to deletes allows for increased query and write performance

--- a/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
@@ -73,6 +73,7 @@ Where applicable, it links to outstanding issues on GitHub.
 * [What words and characters should I avoid when writing data to InfluxDB?](#what-words-and-characters-should-i-avoid-when-writing-data-to-influxdb)  
 * [When should I single quote and when should I double quote when writing data?](#when-should-i-single-quote-and-when-should-i-double-quote-when-writing-data)  
 * [Does the precision of the timestamp matter?](#does-the-precision-of-the-timestamp-matter)
+* [What are the configuration recommendations and schema guidelines for writing sparse, historical data?](#what-are-the-configuration-recommendations-and-schema-guidelines-for-writing-sparse-historical-data)
 
 ## How do I include a single quote in a password?
 Escape the single quote with a backslash (`\`) both when creating the password
@@ -1146,3 +1147,16 @@ curl -i -XPOST "http://localhost:8086/write?db=weather" --data-binary 'temperatu
 
 curl -i -XPOST "http://localhost:8086/write?db=weather&precision=s" --data-binary 'temperature,location=1 value=90 1472666050'
 ```
+
+## What are the configuration recommendations and schema guidelines for writing sparse, historical data?
+
+For users who want to write sparse, historical data to InfluxDB, we recommend:
+
+First, lengthening your [retention policy](/influxdb/v1.2/concepts/glossary/#retention-policy-rp)‘s [shard group](/influxdb/v1.2/concepts/glossary/#shard-group) duration to cover several years.
+The default shard group duration is one week and if your data cover several hundred years – well, that’s a lot of shards!
+Having an extremely high number of shards is inefficient for InfluxDB.
+Increase the shard group duration for your data’s retention policy with the [`ALTER RETENTION POLICY` query](/influxdb/v1.2/query_language/database_management/#modify-retention-policies-with-alter-retention-policy).
+
+Second, temporarily lowering the [`cache-snapshot-write-cold-duration` configuration setting](/influxdb/v1.2/administration/config/#cache-snapshot-write-cold-duration-10m).
+If you’re writing a lot of historical data, the default setting (`10m`) can cause the system to hold all of your data in cache for every shard.
+Temporarily lowering the `cache-snapshot-write-cold-duration` setting to `10s` while you write the historical data makes the process more efficient.


### PR DESCRIPTION
This includes several fixes:

#### Configuration documentation

* [Enterprise] Add the missing configuration doc link to the administration index page 
* [Enterprise] Add a more substantial content header to the configuration doc
* [InfluxDB] Add a more substantial content header to the configuration doc

#### General cleanup

* [Enterprise] Remove outdated wording from the cluster features doc
* [InfluxDB] Edit wording in the insights and tradeoffs doc
* [Enterprise] Remove codeblocks that sometimes show up as blank from the installation guides
* [Enterprise] Remove unnecessary warnings about upgrading from the installation guides

#### New content

* [InfluxDB] Add a new FAQ about what to do when writing a lot of sparse, historical data