### PR TITLE
[InfluxDB & Enterprise] 1.2.4/1.2.5 release

### DIFF
--- a/content/enterprise/v1.1/about-the-project/release-notes-changelog.md
+++ b/content/enterprise/v1.1/about-the-project/release-notes-changelog.md
@@ -8,6 +8,13 @@ menu:
 
 # Clustering
 
+## v1.1.5 [2017-04-28]
+
+### Bugfixes
+
+- Prevent certain user permissions from having a database-specific scope.
+- Fix security escalation bug in subscription management.
+
 ## v1.1.3 [2017-02-27]
 
 ## Release Notes

--- a/content/enterprise/v1.1/administration/upgrading.md
+++ b/content/enterprise/v1.1/administration/upgrading.md
@@ -44,8 +44,8 @@ up-to-date configuration settings.
 
 ##### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.1.4-c1.1.3_amd64.deb
-sudo dpkg -i influxdb-meta_1.1.4-c1.1.3_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.1.5-c1.1.5_amd64.deb
+sudo dpkg -i influxdb-meta_1.1.5-c1.1.5_amd64.deb
 ```
 
 > **Note:** If you're running Ubuntu 16.04.1, you may need to enter
@@ -53,21 +53,21 @@ sudo dpkg -i influxdb-meta_1.1.4-c1.1.3_amd64.deb
 
 ##### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.1.4_c1.1.3.x86_64.rpm
-sudo yum localinstall influxdb-meta-1.1.4_c1.1.3.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.1.5_c1.1.5.x86_64.rpm
+sudo yum localinstall influxdb-meta-1.1.5_c1.1.5.x86_64.rpm
 ```
 
 #### Data nodes
 
 ##### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.4-c1.1.3_amd64.deb
-sudo dpkg -i influxdb-data_1.1.4-c1.1.3_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.5-c1.1.5_amd64.deb
+sudo dpkg -i influxdb-data_1.1.5-c1.1.5_amd64.deb
 ```
 ##### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.4_c1.1.3.x86_64.rpm
-sudo yum localinstall influxdb-data-1.1.4_c1.1.3.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.5_c1.1.5.x86_64.rpm
+sudo yum localinstall influxdb-data-1.1.5_c1.1.5.x86_64.rpm
 ```
 #### Web console
 

--- a/content/enterprise/v1.1/guides/migration.md
+++ b/content/enterprise/v1.1/guides/migration.md
@@ -104,14 +104,14 @@ If you have settings that you’d like to keep, please make a copy of your confi
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.4-c1.1.3_amd64.deb
-sudo dpkg -i influxdb-data_1.1.4-c1.1.3_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.5-c1.1.5_amd64.deb
+sudo dpkg -i influxdb-data_1.1.5-c1.1.5_amd64.deb
 ```
 
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.4_c1.1.3.x86_64.rpm
-sudo yum localinstall influxdb-data-1.1.4_c1.1.3.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.5_c1.1.5.x86_64.rpm
+sudo yum localinstall influxdb-data-1.1.5_c1.1.5.x86_64.rpm
 ```
 
 ### 5. Update the configuration file

--- a/content/enterprise/v1.1/production_installation/data_node_installation.md
+++ b/content/enterprise/v1.1/production_installation/data_node_installation.md
@@ -93,14 +93,14 @@ Perform the following steps on each data server.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.4-c1.1.3_amd64.deb
-sudo dpkg -i influxdb-data_1.1.4-c1.1.3_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.5-c1.1.5_amd64.deb
+sudo dpkg -i influxdb-data_1.1.5-c1.1.5_amd64.deb
 ```
 
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.4_c1.1.3.x86_64.rpm
-sudo yum localinstall influxdb-data-1.1.4_c1.1.3.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.5_c1.1.5.x86_64.rpm
+sudo yum localinstall influxdb-data-1.1.5_c1.1.5.x86_64.rpm
 ```
 
 ### II. Edit the Configuration File

--- a/content/enterprise/v1.1/production_installation/meta_node_installation.md
+++ b/content/enterprise/v1.1/production_installation/meta_node_installation.md
@@ -94,14 +94,14 @@ Perform the following steps on each meta server.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.1.4-c1.1.3_amd64.deb
-sudo dpkg -i influxdb-meta_1.1.4-c1.1.3_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.1.5-c1.1.5_amd64.deb
+sudo dpkg -i influxdb-meta_1.1.5-c1.1.5_amd64.deb
 ```
 
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.1.4_c1.1.3.x86_64.rpm
-sudo yum localinstall influxdb-meta-1.1.4_c1.1.3.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.1.5_c1.1.5.x86_64.rpm
+sudo yum localinstall influxdb-meta-1.1.5_c1.1.5.x86_64.rpm
 ```
 
 ### II. Edit the Configuration File

--- a/content/enterprise/v1.1/quickstart_installation/cluster_installation.md
+++ b/content/enterprise/v1.1/quickstart_installation/cluster_installation.md
@@ -101,11 +101,11 @@ Perform the following steps on all three servers.
 
 Download:
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.1.4-c1.1.3_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.1.5-c1.1.5_amd64.deb
 ```
 Install:
 ```
-sudo dpkg -i influxdb-meta_1.1.4-c1.1.3_amd64.deb
+sudo dpkg -i influxdb-meta_1.1.5-c1.1.5_amd64.deb
 ```
 
 {{% /tab-content %}}
@@ -114,11 +114,11 @@ sudo dpkg -i influxdb-meta_1.1.4-c1.1.3_amd64.deb
 
 Download:
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.1.4_c1.1.3.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.1.5_c1.1.5.x86_64.rpm
 ```
 Install:
 ```
-sudo yum localinstall influxdb-meta-1.1.4_c1.1.3.x86_64.rpm
+sudo yum localinstall influxdb-meta-1.1.5_c1.1.5.x86_64.rpm
 ```
 
 {{% /tab-content %}}
@@ -195,11 +195,11 @@ Perform the following steps on all three servers.
 
 Download:
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.4-c1.1.3_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.1.5-c1.1.5_amd64.deb
 ```
 Install:
 ```
-sudo dpkg -i influxdb-data_1.1.4-c1.1.3_amd64.deb
+sudo dpkg -i influxdb-data_1.1.5-c1.1.5_amd64.deb
 ```
 
 {{% /tab-content %}}
@@ -208,11 +208,11 @@ sudo dpkg -i influxdb-data_1.1.4-c1.1.3_amd64.deb
 
 Download:
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.4_c1.1.3.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.1.5_c1.1.5.x86_64.rpm
 ```
 Install:
 ```
-sudo yum localinstall influxdb-data-1.1.4_c1.1.3.x86_64.rpm
+sudo yum localinstall influxdb-data-1.1.5_c1.1.5.x86_64.rpm
 ```
 
 {{% /tab-content %}}
@@ -371,16 +371,16 @@ The expected output is:
 Data Nodes
 ==========
 ID   TCP Address                  Version
-2    quickstart-cluster-01:8088   1.1.4-c1.1.3rc1
-4    quickstart-cluster-02:8088   1.1.4-c1.1.3rc1
-6    quickstart-cluster-03:8088   1.1.4-c1.1.3rc1
+2    quickstart-cluster-01:8088   1.1.5-c1.1.5rc1
+4    quickstart-cluster-02:8088   1.1.5-c1.1.5rc1
+6    quickstart-cluster-03:8088   1.1.5-c1.1.5rc1
 
 Meta Nodes
 ==========
 TCP Address                  Version
-quickstart-cluster-01:8091   1.1.4-c1.1.3rc1
-quickstart-cluster-02:8091   1.1.4-c1.1.3rc1
-quickstart-cluster-03:8091   1.1.4-c1.1.3rc1
+quickstart-cluster-01:8091   1.1.5-c1.1.5rc1
+quickstart-cluster-02:8091   1.1.5-c1.1.5rc1
+quickstart-cluster-03:8091   1.1.5-c1.1.5rc1
 ```
 
 Your cluster should have three data nodes and three meta nodes.

--- a/content/enterprise/v1.1/troubleshooting/reporting-issues.md
+++ b/content/enterprise/v1.1/troubleshooting/reporting-issues.md
@@ -13,7 +13,7 @@ support team.
 
 Please include the following in your email:
 
-* the version of InfluxEnterprise, e.g. 1.1.4-c1.1.3
+* the version of InfluxEnterprise, e.g. 1.1.5-c1.1.5
 * the version of Telegraf or Kapacitor, if applicable
 * what you expected to happen
 * what did happen

--- a/content/enterprise/v1.2/about-the-project/release-notes-changelog.md
+++ b/content/enterprise/v1.2/about-the-project/release-notes-changelog.md
@@ -17,6 +17,21 @@ menu:
 <br>
 # Clustering
 
+## v1.2.5 [2017-05-16]
+
+This release builds off of the 1.2.4 release of OSS InfluxDB.
+Please see the OSS [release notes](/influxdb/v1.2/about_the_project/releasenotes-changelog/#v1-2-4-2017-05-08) for more information about the OSS releases.
+
+#### Bugfixes
+
+- Fix issue where the [`ALTER RETENTION POLICY` query](/influxdb/v1.2/query_language/database_management/#modify-retention-policies-with-alter-retention-policy) does not update the default retention policy.
+- Hinted-handoff: remote write errors containing `partial write` are considered droppable.
+- Fix the broken `influxd-ctl remove-data -force` command.
+- Fix security escalation bug in subscription management.
+- Prevent certain user permissions from having a database-specific scope.
+- Reduce the cost of the admin user check for clusters with large numbers of users.
+- Fix hinted-handoff remote write batching.
+
 ## v1.2.2 [2017-03-15]
 
 This release builds off of the 1.2.1 release of OSS InfluxDB.
@@ -124,6 +139,13 @@ To disable the auto-creation of retention policies, set `retention-autocreate` t
 - Fix issue where subscriptions send duplicate data for [Continuous Query](/influxdb/v1.2/query_language/continuous_queries/) results
 - Fix the output for `influxd-ctl show-shards`
 - Send the correct RPC response for `ExecuteStatementRequestMessage`
+
+## v1.1.5 [2017-04-28]
+
+### Bugfixes
+
+- Prevent certain user permissions from having a database-specific scope.
+- Fix security escalation bug in subscription management.
 
 ## v1.1.3 [2017-02-27]
 

--- a/content/enterprise/v1.2/administration/configuration.md
+++ b/content/enterprise/v1.2/administration/configuration.md
@@ -316,6 +316,8 @@ To disable retention policy auto-creation, users on version 1.2.0 and 1.2.1 must
 In version 1.2.2, we've removed the `retention-autocreate` setting from the data node configuration file.
 As of version 1.2.2, users may remove `retention-autocreate` from the data node configuration file.
 To disable retention policy auto-creation, set `retention-autocreate` to `false` in the meta node configuration file only.
+
+This change only affects users who have disabled the `retention-autocreate` option and have installed version 1.2.0 or 1.2.1.
 </dt>
 
 Environment variable: `INFLUXDB_META_RETENTION_AUTOCREATE`
@@ -891,11 +893,17 @@ See the [OSS documentation](/influxdb/v1.2/administration/config/#https-private-
 
 Environment variable: `INFLUXDB_HTTP_HTTPS_PRIVATE_KEY`
 
-###  max-row-limit = 10000
+###  max-row-limit = 0
 
 This limits the number of rows that can be returned in a non-chunked query.
-InfluxDB includes a `"partial":true` tag in the response body if query results exceed `max-row-limit`.
-Set this option to `0` to allow an unlimited number of returned rows.
+The default setting (`0`) allows for an unlimited number of rows.
+InfluxDB includes a `"partial":true` tag in the response body if query results exceed the `max-row-limit` setting.
+
+<dt>
+In InfluxEnterprise Cluster versions 1.2.0 through 1.2.2, the `max-row-limit` option is set to `10,000` by default.
+That default setting can lead to unexpected behavior in [Grafana](https://grafana.com/) panels; if a panel’s query returns more than 10,000 points, the panel appears to show [truncated/partial data](https://github.com/influxdata/influxdb/issues/8050).
+In version 1.2.5, the configuration file sets `max-row-limit` to `0` by default; that setting allows an unlimited number of returned rows.
+</dt>
 
 Environment variable: `INFLUXDB_HTTP_MAX_ROW_LIMIT`
 

--- a/content/enterprise/v1.2/administration/upgrading.md
+++ b/content/enterprise/v1.2/administration/upgrading.md
@@ -6,75 +6,75 @@ menu:
     parent: Administration
 ---
 
-## Upgrading from version 1.1 to 1.2.2
+## Upgrading from version 1.1 to 1.2.5
 
-Version 1.2.2 is a drop-in replacement for version 1.1.x with no data migration required.
+Version 1.2.5 is a drop-in replacement for version 1.1.x with no data migration required.
 
-Version 1.2.2 introduces changes to the meta node configuration file and the data node configuration file.
+Version 1.2.5 introduces changes to the meta node configuration file and the data node configuration file.
 Please update the configuration files prior to upgrading to avoid any unnecessary downtime.
 The steps below outline the upgrade process and include a list of the required configuration changes.
 
-### Step 1: Download the 1.2.2 packages
+### Step 1: Download the 1.2.5 packages
 
 #### Meta node package download
 **Ubuntu & Debian (64-bit)**
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.1-c1.2.2_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.4-c1.2.5_amd64.deb
 ```
 
 **RedHat & CentOS (64-bit)**
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.4_c1.2.5.x86_64.rpm
 ```
 
 #### Data node package download
 **Ubuntu & Debian (64-bit)**
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.1-c1.2.2_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.4-c1.2.5_amd64.deb
 ```
 
 **RedHat & CentOS (64-bit)**
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.1_c1.2.2.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.4_c1.2.5.x86_64.rpm
 ```
 
-### Step 2: Install the 1.2.2 packages
+### Step 2: Install the 1.2.5 packages
 
 #### Meta node package Install
 
-When you run the install command, your terminal asks if you'd like to keep your current configuration file or overwrite your current configuration file with the file for version 1.2.2.
+When you run the install command, your terminal asks if you'd like to keep your current configuration file or overwrite your current configuration file with the file for version 1.2.5.
 Please keep your current configuration file by entering `N` or `O`;
-we update the configuration file with the necessary changes for version 1.2.2 in step 3.
+we update the configuration file with the necessary changes for version 1.2.5 in step 3.
 
 **Ubuntu & Debian (64-bit)**
 ```
-sudo dpkg -i influxdb-meta_1.2.1-c1.2.2_amd64.deb
+sudo dpkg -i influxdb-meta_1.2.4-c1.2.5_amd64.deb
 ```
 
 **RedHat & CentOS (64-bit)**
 ```
-sudo yum localinstall influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
+sudo yum localinstall influxdb-meta-1.2.4_c1.2.5.x86_64.rpm
 ```
 
 #### Data node package install
 
-When you run the install command, your terminal asks if you'd like to keep your current configuration file or overwrite your current configuration file with the file for version 1.2.2.
+When you run the install command, your terminal asks if you'd like to keep your current configuration file or overwrite your current configuration file with the file for version 1.2.5.
 Please keep your current configuration file by entering `N` or `O`;
-we update the configuration file with the necessary changes for version 1.2.2 in step 3.
+we update the configuration file with the necessary changes for version 1.2.5 in step 3.
 
 **Ubuntu & Debian (64-bit)**
 ```
-sudo dpkg -i influxdb-data_1.2.1-c1.2.2_amd64.deb
+sudo dpkg -i influxdb-data_1.2.4-c1.2.5_amd64.deb
 ```
 
 **RedHat & CentOS (64-bit)**
 ```
-sudo yum localinstall influxdb-data-1.2.1_c1.2.2.x86_64.rpm
+sudo yum localinstall influxdb-data-1.2.4_c1.2.5.x86_64.rpm
 ```
 
 ### Step 3: Update the meta node configuration file
 
-> The configuration options in this section are not new to version 1.2.2.
+> The configuration options in this section are not new to version 1.2.5.
 They were, however, missing from the sample configuration file (`/etc/influxdb/influxdb-meta.conf`) in version 1.1.x.
 
 In the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`), add the following options:
@@ -89,9 +89,12 @@ Follow the links for more information about those options.
 
 ### Step 4: Update the data node configuration file
 
-> Most of the configuration options in this section are not new to version 1.2.2.
+> Most of the configuration options in this section are not new to version 1.2.5.
 They were, however, missing from the sample configuration file (`/etc/influxdb/influxdb.conf`) in version 1.1.x.
-The only actual configuration change in version 1.2.2 is the removal of the `shard-writer-timeout` option in the `[cluster]` section; in version 1.2.2, the system internally sets `shard-writer-timeout`.
+The only actual configuration changes between version 1.1.1 and version 1.2.5 are:
+>
+* `shard-writer-timeout` is removed from the `[cluster]` section; the system now internally sets `shard-writer-timeout`
+* `max-row-limit` in the `[http]` section is set to `0` by default instead of `10000`
 
 Uncomment all commented section headers: `[cluster]`, `[retention]`, `[shard-precreation]`, `[admin]`, `[monitor]`, `[subscriber]`, `[http]`, `[[graphite]]`, `[[collectd]]`, `[[opentsdb]]`, `[[udp]]`, and `[[continuous_queries]]`.
 That change ensures that any future configuration changes to those sections will take effect upon a restart with no additional steps.
@@ -109,6 +112,10 @@ In the `[[collectd]]` section, add:
 
 * [security-level = "none"](/influxdb/v1.2/administration/config/#security-level-none)
 * [auth-file = "/etc/collectd/auth_file"](/influxdb/v1.2/administration/config/#auth-file-etc-collectd-auth-file)
+
+In the `[http] section`, change:
+
+* `max-row-limit = 10000` to [max-row-limit = 0](/enterprise/v1.2/administration/configuration/#max-row-limit-0)
 
 In the `[[udp]]` section, add [precision = ""](/influxdb/v1.2/administration/config/#precision).
 
@@ -150,16 +157,16 @@ The [`influxd-ctl` tool](/enterprise/v1.2/features/cluster-commands/) is availab
 Data Nodes
 ==========
 ID	TCP Address		Version
-4	rk-upgrading-01:8088	1.2.1_c1.2.2   # 1.2.1_c1.2.2 = 👍
-5	rk-upgrading-02:8088	1.2.1_c1.2.2
-6	rk-upgrading-03:8088	1.2.1_c1.2.2
+4	rk-upgrading-01:8088	1.2.4_c1.2.5   # 1.2.4_c1.2.5 = 👍
+5	rk-upgrading-02:8088	1.2.4_c1.2.5
+6	rk-upgrading-03:8088	1.2.4_c1.2.5
 
 Meta Nodes
 ==========
 TCP Address		Version
-rk-upgrading-01:8091	1.2.1_c1.2.2
-rk-upgrading-02:8091	1.2.1_c1.2.2
-rk-upgrading-03:8091	1.2.1_c1.2.2
+rk-upgrading-01:8091	1.2.4_c1.2.5
+rk-upgrading-02:8091	1.2.4_c1.2.5
+rk-upgrading-03:8091	1.2.4_c1.2.5
 ```
 
 If you have any issues upgrading your cluster, please do not hesitate to contact support at the email provided to you when you received your InfluxEnterprise license.

--- a/content/enterprise/v1.2/features/cluster-commands.md
+++ b/content/enterprise/v1.2/features/cluster-commands.md
@@ -733,19 +733,19 @@ $ influxd-ctl show
 Data Nodes
 ==========
 ID	 TCP Address		        Version
-2   cluster-node-01:8088	1.2.1-c1.2.2
-4   cluster-node-02:8088	1.2.1-c1.2.2
+2   cluster-node-01:8088	1.2.4-c1.2.5
+4   cluster-node-02:8088	1.2.4-c1.2.5
 
 Meta Nodes
 ==========
 TCP Address		        Version
-cluster-node-01:8091	1.2.1-c1.2.2
-cluster-node-02:8091	1.2.1-c1.2.2
-cluster-node-03:8091	1.2.1-c1.2.2
+cluster-node-01:8091	1.2.4-c1.2.5
+cluster-node-02:8091	1.2.4-c1.2.5
+cluster-node-03:8091	1.2.4-c1.2.5
 ```
 
 The output shows that the cluster includes three meta nodes and two data nodes.
-Every node is using InfluxEnterprise version `1.2.1-c1.2.2`.
+Every node is using InfluxEnterprise version `1.2.4-c1.2.5`.
 
 #### show-shards      
 

--- a/content/enterprise/v1.2/guides/migration.md
+++ b/content/enterprise/v1.2/guides/migration.md
@@ -104,14 +104,14 @@ If you have settings that you’d like to keep, please make a copy of your confi
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.1-c1.2.2_amd64.deb
-sudo dpkg -i influxdb-data_1.2.1-c1.2.2_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.4-c1.2.5_amd64.deb
+sudo dpkg -i influxdb-data_1.2.4-c1.2.5_amd64.deb
 ```
 
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.1_c1.2.2.x86_64.rpm
-sudo yum localinstall influxdb-data-1.2.1_c1.2.2.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.4_c1.2.5.x86_64.rpm
+sudo yum localinstall influxdb-data-1.2.4_c1.2.5.x86_64.rpm
 ```
 
 ### 5. Update the configuration file

--- a/content/enterprise/v1.2/production_installation/data_node_installation.md
+++ b/content/enterprise/v1.2/production_installation/data_node_installation.md
@@ -94,14 +94,14 @@ Perform the following steps on each data server.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.1-c1.2.2_amd64.deb
-sudo dpkg -i influxdb-data_1.2.1-c1.2.2_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.4-c1.2.5_amd64.deb
+sudo dpkg -i influxdb-data_1.2.4-c1.2.5_amd64.deb
 ```
 
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.1_c1.2.2.x86_64.rpm
-sudo yum localinstall influxdb-data-1.2.1_c1.2.2.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.4_c1.2.5.x86_64.rpm
+sudo yum localinstall influxdb-data-1.2.4_c1.2.5.x86_64.rpm
 ```
 
 ### II. Edit the Configuration File
@@ -212,15 +212,15 @@ The expected output is:
     Data Nodes
     ==========
     ID   TCP Address               Version
-    4    enterprise-data-01:8088   1.2.1-c1.2.2
-    5    enterprise-data-02:8088   1.2.1-c1.2.2    
+    4    enterprise-data-01:8088   1.2.4-c1.2.5
+    5    enterprise-data-02:8088   1.2.4-c1.2.5    
 >
     Meta Nodes
     ==========
     TCP Address               Version
-    enterprise-meta-01:8091   1.2.1-c1.2.2
-    enterprise-meta-02:8091   1.2.1-c1.2.2
-    enterprise-meta-03:8091   1.2.1-c1.2.2
+    enterprise-meta-01:8091   1.2.4-c1.2.5
+    enterprise-meta-02:8091   1.2.4-c1.2.5
+    enterprise-meta-03:8091   1.2.4-c1.2.5
 
 
 The output should include every data node that was added to the cluster.

--- a/content/enterprise/v1.2/production_installation/meta_node_installation.md
+++ b/content/enterprise/v1.2/production_installation/meta_node_installation.md
@@ -95,14 +95,14 @@ Perform the following steps on each meta server.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.1-c1.2.2_amd64.deb
-sudo dpkg -i influxdb-meta_1.2.1-c1.2.2_amd64.de
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.4-c1.2.5_amd64.deb
+sudo dpkg -i influxdb-meta_1.2.4-c1.2.5_amd64.de
 ```
 
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
-sudo yum localinstall influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.4_c1.2.5.x86_64.rpm
+sudo yum localinstall influxdb-meta-1.2.4_c1.2.5.x86_64.rpm
 ```
 
 ### II. Edit the Configuration File
@@ -202,9 +202,9 @@ The expected output is:
     Meta Nodes
     ==========
     TCP Address               Version
-    enterprise-meta-01:8091   1.2.1-c1.2.2
-    enterprise-meta-02:8091   1.2.1-c1.2.2
-    enterprise-meta-03:8091   1.2.1-c1.2.2
+    enterprise-meta-01:8091   1.2.4-c1.2.5
+    enterprise-meta-02:8091   1.2.4-c1.2.5
+    enterprise-meta-03:8091   1.2.4-c1.2.5
 
 Note that your cluster must have at least three meta nodes.
 If you do not see your meta nodes in the output, please retry adding them to

--- a/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
+++ b/content/enterprise/v1.2/quickstart_installation/cluster_installation.md
@@ -94,13 +94,13 @@ Perform the following steps on all three servers.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.1-c1.2.2_amd64.deb
-sudo dpkg -i influxdb-meta_1.2.1-c1.2.2_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.2.4-c1.2.5_amd64.deb
+sudo dpkg -i influxdb-meta_1.2.4-c1.2.5_amd64.deb
 ```
 #### RedHat & CentOS (64-bit)]
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
-sudo yum localinstall influxdb-meta-1.2.1_c1.2.2.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.2.4_c1.2.5.x86_64.rpm
+sudo yum localinstall influxdb-meta-1.2.4_c1.2.5.x86_64.rpm
 ```
 
 ### II. Edit the Meta Service Configuration File
@@ -163,13 +163,13 @@ Perform the following steps on all three servers.
 
 #### Ubuntu & Debian (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.1-c1.2.2_amd64.deb
-sudo dpkg -i influxdb-data_1.2.1-c1.2.2_amd64.deb
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.2.4-c1.2.5_amd64.deb
+sudo dpkg -i influxdb-data_1.2.4-c1.2.5_amd64.deb
 ```
 #### RedHat & CentOS (64-bit)
 ```
-wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.1_c1.2.2.x86_64.rpm
-sudo yum localinstall influxdb-data-1.2.1_c1.2.2.x86_64.rpm
+wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.2.4_c1.2.5.x86_64.rpm
+sudo yum localinstall influxdb-data-1.2.4_c1.2.5.x86_64.rpm
 ```
 
 ### II. Edit the Data Service Configuration File
@@ -321,16 +321,16 @@ The expected output is:
 Data Nodes
 ==========
 ID   TCP Address                  Version
-2    quickstart-cluster-01:8088   1.2.1-c1.2.2
-4    quickstart-cluster-02:8088   1.2.1-c1.2.2
-6    quickstart-cluster-03:8088   1.2.1-c1.2.2
+2    quickstart-cluster-01:8088   1.2.4-c1.2.5
+4    quickstart-cluster-02:8088   1.2.4-c1.2.5
+6    quickstart-cluster-03:8088   1.2.4-c1.2.5
 
 Meta Nodes
 ==========
 TCP Address                  Version
-quickstart-cluster-01:8091   1.2.1-c1.2.2
-quickstart-cluster-02:8091   1.2.1-c1.2.2
-quickstart-cluster-03:8091   1.2.1-c1.2.2
+quickstart-cluster-01:8091   1.2.4-c1.2.5
+quickstart-cluster-02:8091   1.2.4-c1.2.5
+quickstart-cluster-03:8091   1.2.4-c1.2.5
 ```
 
 Your cluster should have three data nodes and three meta nodes.

--- a/content/enterprise/v1.2/troubleshooting/frequently_asked_questions.md
+++ b/content/enterprise/v1.2/troubleshooting/frequently_asked_questions.md
@@ -11,7 +11,7 @@ menu:
 **Known Issues**
 
 * [Why are my Grafana panels returning truncated/partial data?](#why-are-my-grafana-panels-returning-truncated-partial-data)
-* [Why do queries that use math on several selector functions return more than one point in versions 1.2.0-1.2.2?](#why-do-queries-that-use-math-on-several-selector-functions-return-more-than-one-point-in-versions-1-2-0-2-2-2)
+* [Why do queries that use math on several selector functions return more than one point?](#why-do-queries-that-use-math-on-several-selector-functions-return-more-than-one-point)
 * [What should I do if I see the panic: `unexpected fault address xxxxxxxxxxxxxx`?](#what-should-i-do-if-i-see-the-panic-unexpected-fault-address-xxxxxxxxxxxxxx)
 
 **Log Errors**
@@ -30,19 +30,21 @@ menu:
 
 ## Why are my Grafana panels returning truncated/partial data?
 
-In InfluxEnterprise version 1.2.x, the system sets the [`max-row-limit` configuration option](/enterprise/v1.2/administration/configuration/#max-row-limit-10000) to 10,000 by default.
+In InfluxEnterprise versions 1.2.0-1.2.2, the system sets the [`max-row-limit` configuration option](/enterprise/v1.2/administration/configuration/#max-row-limit-0) to 10,000 by default.
 That option limits the number of rows returned per query to 10,000 rows.
 If a query in Grafana exceeds that 10,000 row limit, the panel appears to show [truncated data](https://github.com/influxdata/influxdb/issues/8050).
-
 To prevent that issue, set `max-row-limit` to `0` to allow an unlimited number of returned rows.
 
-## Why do queries that use math on several selector functions return more than one point in versions 1.2.0-2.2.2?
+This issue is fixed in version 1.2.5.
+In version 1.2.5, the configuration file sets `max-row-limit` to `0` by default.
 
-In versions prior to 1.2.0, queries that use [math](/influxdb/v1.2/query_language/math_operators/) on several [selector functions](/influxdb/v1.2/query_language/functions/#selectors) return one point with the epoch 0 (`1970-01-01T00:00:00Z`) timestamp.
+## Why do queries that use math on several selector functions return more than one point?
+
+In InfluxEnterprise versions prior to 1.2.0, queries that use [math](/influxdb/v1.2/query_language/math_operators/) on several [selector functions](/influxdb/v1.2/query_language/functions/#selectors) return one point with the epoch 0 (`1970-01-01T00:00:00Z`) timestamp.
 In versions 1.2.0-1.2.2, those queries return `N` points, where `N` is the number of unique timestamps returned by the individual selector functions.
-This is a [known issue](https://github.com/influxdata/influxdb/issues/8167) and it will be fixed in version 1.3.0.
-
 As a workaround, use InfluxQL's [subqueries](/influxdb/v1.2/query_language/data_exploration/#subqueries) in versions 1.2.0-1.2.2 to replicate the query behavior in versions prior to 1.2.0.
+
+This issue is fixed in version 1.2.5.
 
 ### Example
 
@@ -87,9 +89,11 @@ The workaround uses InfluxQL's subqueries to replicate the query behavior in ver
 
 ## What should I do if I see the panic: `unexpected fault address xxxxxxxxxxxxxx`?
 
-There is a [known issue](https://github.com/influxdata/influxdb/issues/8022) where the data node process stops and reports the panic `unexpected fault address xxxxxxxxxxxxxx` in the logs.
+In InfluxEnterprise versions 1.2.0-1.2.2, there is a [known issue](https://github.com/influxdata/influxdb/issues/8022) where the data node process stops and reports the panic `unexpected fault address xxxxxxxxxxxxxx` in the logs.
 If you experience this panic please restart the data node process.
 We are working to address this issue; see GitHub Issue [#8022](https://github.com/influxdata/influxdb/issues/8022) for additional information.
+
+This issue is fixed in version 1.2.5.
 
 ## Where can I find InfluxEnterprise logs?
 

--- a/content/enterprise/v1.2/troubleshooting/reporting-issues.md
+++ b/content/enterprise/v1.2/troubleshooting/reporting-issues.md
@@ -13,7 +13,7 @@ support team.
 
 Please include the following in your email:
 
-* the version of InfluxEnterprise, e.g. 1.2.1-c1.2.2
+* the version of InfluxEnterprise, e.g. 1.2.4-c1.2.5
 * the version of Telegraf or Kapacitor, if applicable
 * what you expected to happen
 * what did happen

--- a/content/influxdb/v1.2/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.2/about_the_project/releasenotes-changelog.md
@@ -6,6 +6,24 @@ menu:
     parent: about_the_project
 ---
 
+## v1.2.4 [2017-05-08]
+
+### Bugfixes
+
+- Prefix partial write errors with `partial write:` to generalize identification in other subsystems.
+
+## v1.2.3 [2017-04-17]
+
+### Bugfixes
+
+- Redact passwords before saving them to the history file.
+- Add the missing DefaultDatabase method to several InfluxQL statements.
+- Fix segment violation in models.Tags.Get.
+- Simplify the admin user check.
+- Fix a regression when math was used with selectors.
+- Ensure the input for certain functions in the query engine are ordered.
+- Fix issue where deleted `time` field keys created unparseable points.
+
 ## v1.2.2 [2017-03-14]
 
 ### Release Notes
@@ -112,6 +130,13 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - Ensure Subscriber service can be disabled.
 - Fix race in storage engine.
 - InfluxDB should do a partial write on mismatched type errors.
+
+## v1.1.5 [2017-05-08]
+
+### Bugfixes
+
+- Redact passwords before saving them to the history file.
+- Add the missing DefaultDatabase method to several InfluxQL statements.
 
 ## v1.1.4 [2017-02-27]
 

--- a/content/influxdb/v1.2/administration/config.md
+++ b/content/influxdb/v1.2/administration/config.md
@@ -627,7 +627,7 @@ InfluxDB includes a `"partial":true` tag in the response body if query results e
 <dt>
 In versions 1.2.0 and 1.2.1, the `max-row-limit` option is set to 10,000 by default.
 That default setting can lead to unexpected behavior in [Grafana](https://grafana.com/) panels; if a panel's query returns more than 10,000 points, the panel appears to show [truncated/partial data](https://github.com/influxdata/influxdb/issues/8050).
-In version 1.2.2, `max-row-limit` is set to `0` by default and allows an unlimited number of returned rows.
+In versions 1.2.2+, `max-row-limit` is set to `0` by default and allows an unlimited number of returned rows.
 </dt>
 
 Environment variable: `INFLUXDB_HTTP_MAX_ROW_LIMIT`


### PR DESCRIPTION
### Basic updates

Updates:
* The release notes/changelog pages for InfluxDB (1.1.5 and 1.2.4 entries) and InfluxEnterprise (1.2.5 changes)
* The Enterprise version numbers in the 1.2 docs to 1.2.4_1.2.5
* The Enterprise version numbers in the 1.1 docs to 1.1.5_1.1.5

### Content Changes

Updates:
* The relevant Enterprise known issues on the FAQ page
* The Enterprise upgrading page with the `max-row-limit` config change
* The Enterprise config docs with the `max-row-limit` config change

### TODO:

* [x] Add in change for Enterprise v1.2.5  to changelog
