### PR TITLE
Move "next options control batching" to the correct place

### DIFF
--- a/content/influxdb/v1.2/administration/config.md
+++ b/content/influxdb/v1.2/administration/config.md
@@ -796,10 +796,6 @@ This defaults to `collectd`.
 
 Environment variable: `INFLUXDB_COLLECTD_DATABASE`
 
-*The next three options control how batching works.
-You should have this enabled otherwise you could get dropped metrics or poor performance.
-Batching will buffer points in memory if you have many coming in.*
-
 ### retention-policy = ""
 
 The relevant retention policy.
@@ -824,6 +820,10 @@ Environment variable: `INFLUXDB_COLLECTD_SECURITY_LEVEL`
 ### auth-file = "/etc/collectd/auth_file"
 
 Environment variable: `INFLUXDB_COLLECTD_AUTH_FILE`
+
+*The next three options control how batching works.
+You should have this enabled otherwise you could get dropped metrics or poor performance.
+Batching will buffer points in memory if you have many coming in.*
 
 ### batch-size = 5000
 


### PR DESCRIPTION
In the documentation for collectd options, the paragraph saying "The next three options control how batching works" wasn't actually above the three options for batching.

f2cece9a08 added documentation for `retention-policy` between the "batching options follow" paragraph and the `batch-size` option. e80a4b1215 further worsened this by adding `typesdb`, `security-level`, and `auth-file` below `retention-policy`.

This commit moves the paragraph to the correct place, right above `batch-size`.
