### PR TITLE
Add log as supported event handler

### DIFF
--- a/content/chronograf/v1.3/troubleshooting/frequently-asked-questions.md
+++ b/content/chronograf/v1.3/troubleshooting/frequently-asked-questions.md
@@ -27,6 +27,7 @@ Chronograf supports the following event handlers:
 * Exec
 * HipChat
 * HTTP/Post
+* Log
 * OpsGenie
 * PagerDuty
 * Sensu


### PR DESCRIPTION
Support for `log` was added [here](https://github.com/influxdata/chronograf/pull/1477)