### PR TITLE
Update time keyword docs for 1.2.4

### DIFF
--- a/content/influxdb/v1.2/query_language/spec.md
+++ b/content/influxdb/v1.2/query_language/spec.md
@@ -138,9 +138,9 @@ database name,
 In those cases, `time` does not require double quotes in queries.
 `time` cannot be a [field key](/influxdb/v1.2/concepts/glossary/#field-key) or
 [tag key](/influxdb/v1.2/concepts/glossary/#tag-key).
-If [Line Protocol](/influxdb/v1.2/concepts/glossary/#line-protocol) includes
-`time` as a field key or tag key, InfluxDB accepts the write and returns a `204`,
-but InfluxDB silently drops that field key or tag key and its associated value.
+In versions 1.2.0-1.2.3,
+InfluxDB accepts writes with `time` as a field or tag key but it silently drops the field key or tag key and its associated value.
+In version 1.2.4, InfluxDB rejects writes with `time` as a field key or tag key and returns an error.
 See [Frequently Asked Questions](/influxdb/v1.2/troubleshooting/frequently-asked-questions/#time) for more information.
 
 ## Literals

--- a/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
@@ -1034,9 +1034,9 @@ database name,
 In those cases, `time` does not require double quotes in queries.
 `time` cannot be a [field key](/influxdb/v1.2/concepts/glossary/#field-key) or
 [tag key](/influxdb/v1.2/concepts/glossary/#tag-key).
-If [Line Protocol](/influxdb/v1.2/concepts/glossary/#line-protocol) includes
-`time` as a field key or tag key, InfluxDB accepts the write and returns a `204`,
-but InfluxDB silently drops that field key or tag key and its associated value.
+In versions 1.2.0-1.2.3,
+InfluxDB accepts writes with `time` as a field or tag key but it silently drops the field key or tag key and its associated value.
+In version 1.2.4, InfluxDB rejects writes with `time` as a field key or tag key and returns an error.
 
 #### Examples
 
@@ -1056,6 +1056,7 @@ time                            value
 
 ##### Example 2: Write `time` as a field key and attempt to query it
 <br>
+Versions 1.2.0-1.2.3:
 ```
 > INSERT mymeas time=1
 
@@ -1071,8 +1072,17 @@ ERR: error parsing query: at least 1 non-time field must be queried
 `time` is not a valid field key in InfluxDB.
 The system does not return an error and does not write `time=1` to the database.
 
+Version 1.2.4:
+```
+> INSERT mymeas time=1
+ERR: {"error":"partial write: invalid field name: input field \"time\" on measurement \"mymeas\" is invalid dropped=1"}
+```
+`time` is not a valid field key in InfluxDB.
+The system does does not write the point and returns a `400`.
+
 ##### Example 3: Write `time` as a tag key and attempt to query it
 <br>
+Versions 1.2.0-1.2.3:
 ```
 > INSERT mymeas,time=1 value=1
 
@@ -1093,6 +1103,15 @@ time                           value
 
 `time` is not a valid tag key in InfluxDB.
 The system does not return an error and does not write `time=1` to the database.
+
+Version 1.2.4:
+```
+> INSERT mymeas,time=1 value=1
+ERR: {"error":"partial write: invalid tag key: input tag \"time\" on measurement \"mymeas\" is invalid dropped=1"}
+```
+
+`time` is not a valid tag key in InfluxDB.
+The system does does not write the point and returns a `400`.
 
 ### Characters
 To keep regular expressions and quoting simple, avoid using the following characters in identifiers:  

--- a/content/influxdb/v1.2/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.2/write_protocols/line_protocol_reference.md
@@ -244,9 +244,9 @@ database name,
 In those cases, `time` does not require double quotes in queries.
 `time` cannot be a [field key](/influxdb/v1.2/concepts/glossary/#field-key) or
 [tag key](/influxdb/v1.2/concepts/glossary/#tag-key).
-If [Line Protocol](/influxdb/v1.2/concepts/glossary/#line-protocol) includes
-`time` as a field key or tag key, InfluxDB accepts the write and returns a `204`,
-but InfluxDB silently drops that field key or tag key and its associated value.
+In versions 1.2.0-1.2.3,
+InfluxDB accepts writes with `time` as a field or tag key but it silently drops the field key or tag key and its associated value.
+In version 1.2.4, InfluxDB rejects writes with `time` as a field key or tag key and returns an error.
 See [Frequently Asked Questions](/influxdb/v1.2/troubleshooting/frequently-asked-questions/#time) for more information.
 
 ## Line Protocol in Practice

--- a/content/influxdb/v1.2/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.2/write_protocols/line_protocol_tutorial.md
@@ -403,9 +403,9 @@ database name,
 In those cases, `time` does not require double quotes in queries.
 `time` cannot be a [field key](/influxdb/v1.2/concepts/glossary/#field-key) or
 [tag key](/influxdb/v1.2/concepts/glossary/#tag-key).
-If [Line Protocol](/influxdb/v1.2/concepts/glossary/#line-protocol) includes
-`time` as a field key or tag key, InfluxDB accepts the write and returns a `204`,
-but InfluxDB silently drops that field key or tag key and its associated value.
+IIn versions 1.2.0-1.2.3,
+InfluxDB accepts writes with `time` as a field or tag key but it silently drops the field key or tag key and its associated value.
+In version 1.2.4, InfluxDB rejects writes with `time` as a field key or tag key and returns an error.
 See [Frequently Asked Questions](/influxdb/v1.2/troubleshooting/frequently-asked-questions/#time) for more information.
 
 ## Writing data to InfluxDB


### PR DESCRIPTION
As of version 1.2.4, InfluxDB no longer accepts and silently drops writes that use `time` as a field key or tag key. Now, the database returns an error if the line protocol includes `time` as a field or tag key.

This updates the documentation to show both the 1.2.0-1.2.3 and 1.2.4 behavior.

Updated pages: InfluxQL reference, FAQ, write protocol tutorial, write protocol reference