### PR TITLE
Update the AWS recommended machine class info.

### DIFF
--- a/content/influxdb/v1.2/introduction/installation.md
+++ b/content/influxdb/v1.2/introduction/installation.md
@@ -238,7 +238,7 @@ The `influxdb/data` volume should have more disk space with lower IOPS and the `
 
 Each machine should have a minimum of 8G RAM.
 
-We’ve seen the best performance with the C3 class of machines.
+We’ve seen the best performance with the R4 class of machines, as they provide more memory than either of the C3/C4 class and the M4 class. 
 
 ### Configuring the Instance
 


### PR DESCRIPTION
We were suggesting C3 class machines --- these are pretty old at this point.

The R4 class machines provide more memory -- which is typically good for the database.