### PR TITLE
examples were switched to guides

### DIFF
--- a/content/kapacitor/v1.3/alerts/index.md
+++ b/content/kapacitor/v1.3/alerts/index.md
@@ -31,4 +31,4 @@ A handler definition has a few properties:
 
 ## Example
 
-See the [Using Alert Topics](../examples/using_alert_topics) example for a walk through defining and using alert topics.
+See the [Using Alert Topics](../guides/using_alert_topics) example for a walk through defining and using alert topics.

--- a/content/kapacitor/v1.3/guides/socket_udf.md
+++ b/content/kapacitor/v1.3/guides/socket_udf.md
@@ -10,7 +10,7 @@ menu:
     parent: guides
 ---
 
-In [another example](/kapacitor/v1.3/examples/anomaly_detection/) we saw how to write a process based UDF for custom anomaly detection workloads.
+In [another example](/kapacitor/v1.3/guides/anomaly_detection/) we saw how to write a process based UDF for custom anomaly detection workloads.
 In this example we are going to learn how to write a simple socket based UDF.
 
 ## What is a UDF?

--- a/content/kapacitor/v1.3/introduction/getting_started.md
+++ b/content/kapacitor/v1.3/introduction/getting_started.md
@@ -488,5 +488,5 @@ Play around until you are comfortable updating, testing, and running tasks in Ka
 
 ### What's next?
 
-Take a look at the [examples](/kapacitor/v1.3/examples/) page for more guides on how to use Kapacitor.
+Take a look at the [example guides](/kapacitor/v1.3/guides/) for how to use Kapacitor.
 These use cases demonstrate some of the more rich features of Kapacitor.


### PR DESCRIPTION
current link results in a 404. -- as reported by a customer via InfluxData Support.

updated link to point to:
https://docs.influxdata.com/kapacitor/v1.3/guides/using_alert_topics/
