### PR TITLE
[InfluxDB, Kapacitor] Issue Fixes

### DIFF
--- a/content/influxdb/v1.2/concepts/glossary.md
+++ b/content/influxdb/v1.2/concepts/glossary.md
@@ -230,7 +230,7 @@ Multiple shards may exist in a single shard group.
 Each shard contains a specific set of series.
 All points falling on a given series in a given shard group will be stored in the same shard (TSM file) on disk.
 
-Related entries: [series](/influxdb/v1.2/concepts/glossary/#series), [shard duration](/influxdb/v1.2/concepts/glossary/#shard-duration), [shard group](/influxdb/v1.2/concepts/glossary/#shard-group), [tsm](/influxdb/v1.2/concepts/glossary/#tsm)
+Related entries: [series](/influxdb/v1.2/concepts/glossary/#series), [shard duration](/influxdb/v1.2/concepts/glossary/#shard-duration), [shard group](/influxdb/v1.2/concepts/glossary/#shard-group), [tsm](/influxdb/v1.2/concepts/glossary/#tsm-time-structured-merge-tree)
 
 ## shard duration
 
@@ -325,7 +325,7 @@ The temporary cache for recently written points. To reduce the frequency with wh
 
 Points in the WAL can be queried, and they persist through a system reboot. On process start, all points in the WAL must be flushed before the system accepts new writes.
 
-Related entries: [tsm](/influxdb/v1.2/concepts/glossary/#tsm)
+Related entries: [tsm](/influxdb/v1.2/concepts/glossary/#tsm-time-structured-merge-tree)
 
 <!--
 

--- a/content/influxdb/v1.2/high_availability/clusters.md
+++ b/content/influxdb/v1.2/high_availability/clusters.md
@@ -14,4 +14,4 @@ menu:
 Open-source InfluxDB does not support clustering.
 For high availability or horizontal scaling of InfluxDB, please investigate our
 commercial clustered offering,
-[InfluxEnterprise](https://portal.influxdata.com/).
+[InfluxEnterprise](/enterprise/v1.2/).

--- a/content/kapacitor/v1.3/index.md
+++ b/content/kapacitor/v1.3/index.md
@@ -19,8 +19,8 @@ great choice for data processing.
 
 * Process both streaming data and batch data.
 * Query data from InfluxDB on a schedule, and receive data via the
-[line protocol](/influxdb/v1.3/write_protocols/line/) and any other method InfluxDB supports.
-* Perform any transformation currently possible in [InfluxQL](/influxdb/v1.3/query_language/spec/).
+[line protocol](/influxdb/v1.2/write_protocols/line/) and any other method InfluxDB supports.
+* Perform any transformation currently possible in [InfluxQL](/influxdb/v1.2/query_language/spec/).
 * Store transformed data back in InfluxDB.
 * Add custom user defined functions to detect anomalies.
 * Integrate with HipChat, OpsGenie, Alerta, Sensu, PagerDuty, Slack, and more.


### PR DESCRIPTION
Changes the link in the cluster doc to point to the Enterprise docs instead of portal.

Fixes:

* #1146 (The links to the TSM entries on the glossary page were wrong)
* #1139 (Kapacitor's links to the InfluxDB docs pointed to the v1.3 docs, which don't exist yet)