### PR TITLE
Add hyphen example to double-quote section of FAQ

### DIFF
--- a/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
@@ -684,6 +684,8 @@ Yes: `SELECT bikes_available FROM bikes WHERE station_id='9'`
 
 Yes: `SELECT "bikes_available" FROM "bikes" WHERE "station_id"='9'`
 
+Yes: `SELECT min("avgrq-sz") as "min_avgrq-sz" FROM telegraf ... `  
+
 Yes: `SELECT * from "cr@zy" where "p^e"='2'`
 
 No: `SELECT 'bikes_available' FROM 'bikes' WHERE 'station_id'="9"`


### PR DESCRIPTION
Requested change from someone who was struggling with a field/tag coming from the Telegraf sysstats plugin which contained a hyphen.