### PR TITLE
Remove relative url path

### DIFF
--- a/content/influxdb/v1.3/administration/differences.md
+++ b/content/influxdb/v1.3/administration/differences.md
@@ -30,7 +30,7 @@ see [InfluxDB's Changelog](/influxdb/v1.3/about_the_project/releasenotes-changel
 Version 1.3.0 marks the first official release of InfluxDB's new time series index (TSI) engine.
 
 The TSI engine is a significant technical advancement in InfluxDB.
-It offers a solution to the [time-structured merge tree](https://docs.influxdata.com/influxdb/v1.2/concepts/storage_engine/) engine's [high series cardinality issue](/influxdb/v1.3/troubleshooting/frequently-asked-questions/#why-does-series-cardinality-matter).
+It offers a solution to the [time-structured merge tree](https://docs.influxdata.com/influxdb/v1.2/concepts/storage_engine/) engine's [high series cardinality issue](https://docs.influxdata.com/influxdb/v1.3/troubleshooting/frequently-asked-questions/#why-does-series-cardinality-matter).
 With TSI, the number of series should be unbounded by the memory on the server hardware and the number of existing series will have a negligible impact on database startup time.
 See Paul Dix's blogpost [Path to 1 Billion Time Series: InfluxDB High Cardinality Indexing Ready for Testing](https://www.influxdata.com/path-1-billion-time-series-influxdb-high-cardinality-indexing-ready-testing/) for additional information.
 


### PR DESCRIPTION
This matches the rest of the document and means that clicking the link on any site other than influx's will work