### PR TITLE
Fix type for debian package install

### DIFF
--- a/content/enterprise_influxdb/v1.3/production_installation/meta_node_installation.md
+++ b/content/enterprise_influxdb/v1.3/production_installation/meta_node_installation.md
@@ -102,7 +102,7 @@ Perform the following steps on each meta server.
 #### Ubuntu & Debian (64-bit)
 ```
 wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.3.3-c1.3.3_amd64.deb
-sudo dpkg -i influxdb-meta_1.3.3-c1.3.3_amd64.de
+sudo dpkg -i influxdb-meta_1.3.3-c1.3.3_amd64.deb
 ```
 
 #### RedHat & CentOS (64-bit)


### PR DESCRIPTION
Fixes a typo where the last 'b' is missing from the name of the downloaded packgage in the install command.