### PR TITLE
Add Debian 9 install information

### DIFF
--- a/content/telegraf/v1.3/introduction/installation.md
+++ b/content/telegraf/v1.3/introduction/installation.md
@@ -57,6 +57,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+  test $VERSION_ID = "9" && echo "deb https://repos.influxdata.com/debian stretch stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
 
   Then, install and start the Telegraf service:


### PR DESCRIPTION
Telegraf repos already have Debian 9 packages, but information for installing them wasn't available in documentation.