### PR TITLE
influx_inspect report -detailed

### DIFF
--- a/content/influxdb/v1.3/tools/influx_inspect.md
+++ b/content/influxdb/v1.3/tools/influx_inspect.md
@@ -212,7 +212,7 @@ Include only files matching the specified pattern.
 
 `default` = ""
 
-#### `-pattern` boolean 
+#### `-detailed` boolean 
 Report detailed cardinality estimates.
 
 `default` = false

--- a/content/influxdb/v1.4/tools/influx_inspect.md
+++ b/content/influxdb/v1.4/tools/influx_inspect.md
@@ -208,7 +208,7 @@ Include only files matching the specified pattern.
 
 `default` = ""
 
-#### `-pattern` boolean 
+#### `-detailed` boolean 
 Report detailed cardinality estimates.
 
 `default` = false


### PR DESCRIPTION
-detailed flag was missing (cut/paste issue -- as it was incorrectly labeled "pattern"; the same as the previous flag).