### PR TITLE
Update different options for per-database backups

### DIFF
--- a/content/influxdb/v1.4/administration/backup_and_restore.md
+++ b/content/influxdb/v1.4/administration/backup_and_restore.md
@@ -9,12 +9,10 @@ menu:
 
 ## Backups
 
-InfluxDB has the ability to snapshot an instance at a point-in-time and restore it.
-All backups are full backups.
-InfluxDB does not yet support incremental backups.
 There are two types of data to backup, the metastore and the metrics themselves.
 The [metastore](/influxdb/v1.4/concepts/glossary/#metastore) is backed up in its entirety.
 The metrics are backed up per-database in a separate operation from the metastore backup.
+Per-database backups can be full, incremental (since a RFC3339 formatted time), or for a specific shard ID.
 
 > **Note:** Backups are not interchangeable between OSS InfluxDB and [InfluxEnterprise](/enterprise/latest/).
 You cannot restore an OSS backup to an InfluxEnterprise data node, nor can you restore


### PR DESCRIPTION
When reading the current documentation my colleagues and I got pretty confused and initially were under the impression that no form of incremental backup was supported.

I think this amendment makes the document a bit clearer and more accurate.

One thing that may be worth considering is that I have only updated the v1.4 documentation and perhaps it would be appropriate to update more than just that version, which I am happy to do. As far as I can tell the amendment I have made is accurate for all versions of influxdb since v0.10.0. The first commit I found in influxdata/influxdb with incremental backups was df1aeee7