### PR TITLE
fix broken influxql links

### DIFF
--- a/content/influxdb/v0.10/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v0.10/concepts/schema_and_data_layout.md
@@ -28,7 +28,7 @@ In no particular order, we recommend that you:
 
     This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
     Identifiers are are database names, [retention policy](/influxdb/v0.10/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v0.10/concepts/glossary/#user) names, [measurement](/influxdb/v0.10/concepts/glossary/#measurement) names, [tag keys](/influxdb/v0.10/concepts/glossary/#tag-key), and [field keys](/influxdb/v0.10/concepts/glossary/#field-key).
-    See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influxql/README.md#keywords) for words to avoid.
+    See [InfluxQL Keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) for words to avoid.
 
     Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 

--- a/content/influxdb/v0.10/guides/writing_data.md
+++ b/content/influxdb/v0.10/guides/writing_data.md
@@ -97,7 +97,7 @@ This consistency is good for those developing and consuming the API: everyone in
 
 REST, however, is a convention.
 InfluxDB makes do with three API endpoints.
-This simple, easy to understand system uses HTTP as a transfer system for [InfluxQL](https://github.com/influxdb/influxdb/blob/master/influxql/README.md).
+This simple, easy to understand system uses HTTP as a transfer system for [InfluxQL](https://github.com/influxdata/influxql/blob/master/README.md).
 The InfluxDB API makes no attempt to be RESTful.
 
 ### HTTP response summary

--- a/content/influxdb/v0.10/query_language/data_exploration.md
+++ b/content/influxdb/v0.10/query_language/data_exploration.md
@@ -98,7 +98,7 @@ While they all return the same result, they get to that result in slightly diffe
 * Separate multiple fields and tags of interest with a comma.
 Note that you must specify at least one field in the `SELECT` statement.
 
-* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) - then you need to double quote them.
+* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords) - then you need to double quote them.
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 
  Select everything from `h2o_feet` by fully qualifying the measurement:

--- a/content/influxdb/v0.10/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.10/troubleshooting/frequently_encountered_issues.md
@@ -191,7 +191,7 @@ To successfully query data that use a keyword as an identifier enclose that iden
 * `SELECT * FROM "grant" WHERE why = 9`
 
 While using double quotes is an acceptable workaround, we recommend that you avoid using InfluxQL keywords as identifiers for simplicity's sake.
-The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 
 ## Identifying write precision from returned timestamps
 InfluxDB stores all timestamps as nanosecond values regardless of the write precision supplied.
@@ -215,7 +215,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## Single quoting and double quoting in queries
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 You can double quote identifiers even if they don't fall into one of those categories but it isn't necessary.
 
 Yes: `SELECT bikes_available FROM bikes WHERE station_id='9'`
@@ -334,7 +334,7 @@ Convert the newline character and try sending the data again.
 > **Note:** If you generated your data file on a Windows machine, Windows uses carriage return and line feed (`\r\n`) as the newline character.
 
 ## Words and characters to avoid
-If you use any of the [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use any of the [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v0.10/troubleshooting/frequently_encountered_issues/#getting-the-expected-identifier-error-unexpectedly).
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 

--- a/content/influxdb/v0.11/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v0.11/concepts/schema_and_data_layout.md
@@ -28,7 +28,7 @@ In no particular order, we recommend that you:
 
     This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
     Identifiers are are database names, [retention policy](/influxdb/v0.11/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v0.11/concepts/glossary/#user) names, [measurement](/influxdb/v0.11/concepts/glossary/#measurement) names, [tag keys](/influxdb/v0.11/concepts/glossary/#tag-key), and [field keys](/influxdb/v0.11/concepts/glossary/#field-key).
-    See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influxql/README.md#keywords) for words to avoid.
+    See [InfluxQL Keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) for words to avoid.
 
     Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 

--- a/content/influxdb/v0.11/guides/writing_data.md
+++ b/content/influxdb/v0.11/guides/writing_data.md
@@ -98,7 +98,7 @@ This consistency is good for those developing and consuming the API: everyone in
 
 REST, however, is a convention.
 InfluxDB makes do with three API endpoints.
-This simple, easy to understand system uses HTTP as a transfer system for [InfluxQL](https://github.com/influxdb/influxdb/blob/master/influxql/README.md).
+This simple, easy to understand system uses HTTP as a transfer system for [InfluxQL](https://github.com/influxdata/influxql/blob/master/README.md).
 The InfluxDB API makes no attempt to be RESTful.
 
 ### HTTP response summary

--- a/content/influxdb/v0.11/query_language/data_exploration.md
+++ b/content/influxdb/v0.11/query_language/data_exploration.md
@@ -99,7 +99,7 @@ While they all return the same result, they get to that result in slightly diffe
 * Separate multiple fields and tags of interest with a comma.
 Note that you must specify at least one field in the `SELECT` statement.
 
-* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) - then you need to double quote them.
+* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords) - then you need to double quote them.
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 
  Select everything from `h2o_feet` by fully qualifying the measurement:

--- a/content/influxdb/v0.11/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.11/troubleshooting/frequently_encountered_issues.md
@@ -174,7 +174,7 @@ To successfully query data that use a keyword as an identifier enclose that iden
 * `SELECT * FROM "grant" WHERE why = 9`
 
 While using double quotes is an acceptable workaround, we recommend that you avoid using InfluxQL keywords as identifiers for simplicity's sake.
-The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 
 ## Identifying write precision from returned timestamps
 InfluxDB stores all timestamps as nanosecond values regardless of the write precision supplied.
@@ -198,7 +198,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## Single quoting and double quoting in queries
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 You can double quote identifiers even if they don't fall into one of those categories but it isn't necessary.
 
 Yes: `SELECT bikes_available FROM bikes WHERE station_id='9'`
@@ -330,7 +330,7 @@ Convert the newline character and try sending the data again.
 > **Note:** If you generated your data file on a Windows machine, Windows uses carriage return and line feed (`\r\n`) as the newline character.
 
 ## Words and characters to avoid
-If you use any of the [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use any of the [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v0.11/troubleshooting/frequently_encountered_issues/#getting-the-expected-identifier-error-unexpectedly).
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 

--- a/content/influxdb/v0.12/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v0.12/concepts/schema_and_data_layout.md
@@ -28,7 +28,7 @@ In no particular order, we recommend that you:
 
     This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
     Identifiers are database names, [retention policy](/influxdb/v0.12/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v0.12/concepts/glossary/#user) names, [measurement](/influxdb/v0.12/concepts/glossary/#measurement) names, [tag keys](/influxdb/v0.12/concepts/glossary/#tag-key), and [field keys](/influxdb/v0.12/concepts/glossary/#field-key).
-    See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influxql/README.md#keywords) for words to avoid.
+    See [InfluxQL Keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) for words to avoid.
 
     Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 

--- a/content/influxdb/v0.12/query_language/data_exploration.md
+++ b/content/influxdb/v0.12/query_language/data_exploration.md
@@ -99,7 +99,7 @@ While they all return the same result, they get to that result in slightly diffe
 * Separate multiple fields and tags of interest with a comma.
 Note that you must specify at least one field in the `SELECT` statement.
 
-* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) - then you need to double quote them.
+* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords) - then you need to double quote them.
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 
  Select everything from `h2o_feet` by fully qualifying the measurement:

--- a/content/influxdb/v0.12/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.12/troubleshooting/frequently_encountered_issues.md
@@ -174,7 +174,7 @@ To successfully query data that use a keyword as an identifier enclose that iden
 * `SELECT * FROM "grant" WHERE why = 9`
 
 While using double quotes is an acceptable workaround, we recommend that you avoid using InfluxQL keywords as identifiers for simplicity's sake.
-The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 
 ## Identifying write precision from returned timestamps
 InfluxDB stores all timestamps as nanosecond values regardless of the write precision supplied.
@@ -198,7 +198,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## Single quoting and double quoting in queries
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 You can double quote identifiers even if they don't fall into one of those categories but it isn't necessary.
 
 Examples:
@@ -342,7 +342,7 @@ Convert the newline character and try sending the data again.
 > **Note:** If you generated your data file on a Windows machine, Windows uses carriage return and line feed (`\r\n`) as the newline character.
 
 ## Words and characters to avoid
-If you use any of the [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use any of the [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v0.12/troubleshooting/frequently_encountered_issues/#getting-the-expected-identifier-error-unexpectedly).
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 

--- a/content/influxdb/v0.13/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v0.13/concepts/schema_and_data_layout.md
@@ -28,7 +28,7 @@ In no particular order, we recommend that you:
 
     This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
     Identifiers are database names, [retention policy](/influxdb/v0.13/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v0.13/concepts/glossary/#user) names, [measurement](/influxdb/v0.13/concepts/glossary/#measurement) names, [tag keys](/influxdb/v0.13/concepts/glossary/#tag-key), and [field keys](/influxdb/v0.13/concepts/glossary/#field-key).
-    See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influxql/README.md#keywords) for words to avoid.
+    See [InfluxQL Keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) for words to avoid.
 
     Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 

--- a/content/influxdb/v0.13/query_language/data_exploration.md
+++ b/content/influxdb/v0.13/query_language/data_exploration.md
@@ -101,7 +101,7 @@ While they all return the same result, they get to that result in slightly diffe
 * Separate multiple fields and tags of interest with a comma.
 Note that you must specify at least one field in the `SELECT` statement.
 
-* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) - then you need to double quote them.
+* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords) - then you need to double quote them.
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 
  Select everything from `h2o_feet` by fully qualifying the measurement:

--- a/content/influxdb/v0.13/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.13/troubleshooting/frequently_encountered_issues.md
@@ -152,7 +152,7 @@ To successfully query data that use a keyword as an identifier enclose that iden
 * `SELECT * FROM "grant" WHERE why = 9`
 
 While using double quotes is an acceptable workaround, we recommend that you avoid using InfluxQL keywords as identifiers for simplicity's sake.
-The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 
 ## Identifying write precision from returned timestamps
 InfluxDB stores all timestamps as nanosecond values regardless of the write precision supplied.
@@ -176,7 +176,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## Single quoting and double quoting in queries
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 You can double quote identifiers even if they don't fall into one of those categories but it isn't necessary.
 
 Examples:
@@ -315,7 +315,7 @@ Convert the newline character and try sending the data again.
 > **Note:** If you generated your data file on a Windows machine, Windows uses carriage return and line feed (`\r\n`) as the newline character.
 
 ## Words and characters to avoid
-If you use any of the [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use any of the [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v0.13/troubleshooting/frequently_encountered_issues/#getting-the-expected-identifier-error-unexpectedly).
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 

--- a/content/influxdb/v0.9/guides/writing_data.md
+++ b/content/influxdb/v0.9/guides/writing_data.md
@@ -98,7 +98,7 @@ This consistency is good for those developing and consuming the API: everyone in
 
 REST, however, is a convention.
 InfluxDB makes do with three API endpoints.
-This simple, easy to understand system uses HTTP as a transfer system for [InfluxQL](https://github.com/influxdb/influxdb/blob/master/influxql/README.md).
+This simple, easy to understand system uses HTTP as a transfer system for [InfluxQL](https://github.com/influxdata/influxql/blob/master/README.md).
 The InfluxDB API makes no attempt to be RESTful.
 
 ### HTTP response summary

--- a/content/influxdb/v0.9/query_language/data_exploration.md
+++ b/content/influxdb/v0.9/query_language/data_exploration.md
@@ -98,7 +98,7 @@ While they all return the same result, they get to that result in slightly diffe
 * Separate multiple fields and tags of interest with a comma.
 Note that you must specify at least one field in the `SELECT` statement.
 
-* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) - then you need to double quote them.
+* Leave identifiers unquoted unless they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords) - then you need to double quote them.
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 
  Select everything from `h2o_feet` by fully qualifying the measurement:

--- a/content/influxdb/v0.9/troubleshooting/frequently_encountered_issues.md
+++ b/content/influxdb/v0.9/troubleshooting/frequently_encountered_issues.md
@@ -193,7 +193,7 @@ To successfully query data that use a keyword as an identifier enclose that iden
 * `SELECT * FROM "grant" WHERE why = 9`
 
 While using double quotes is an acceptable workaround, we recommend that you avoid using InfluxQL keywords as identifiers for simplicity's sake.
-The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+The InfluxQL documentation has a comprehensive list of all [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 
 ## Identifying write precision from returned timestamps
 InfluxDB stores all timestamps as nanosecond values regardless of the write precision supplied.
@@ -217,7 +217,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## Single quoting and double quoting in queries
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 You can double quote identifiers even if they don't fall into one of those categories but it isn't necessary.
 
 Yes: `SELECT bikes_available FROM bikes WHERE station_id='9'`
@@ -323,7 +323,7 @@ So if two continuous queries write to different fields but also write to the sam
 For more on continuous queries, see [Continuous Queries](/influxdb/v0.9/query_language/continuous_queries/).
 
 ## Words and characters to avoid
-If you use any of the [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use any of the [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v0.9/troubleshooting/frequently_encountered_issues/#getting-the-expected-identifier-error-unexpectedly).
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 

--- a/content/influxdb/v1.0/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.0/concepts/schema_and_data_layout.md
@@ -40,7 +40,7 @@ In general, your queries should guide what gets stored as a tag and what gets st
 
 This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
 Identifiers are database names, [retention policy](/influxdb/v1.0/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v1.0/concepts/glossary/#user) names, [measurement](/influxdb/v1.0/concepts/glossary/#measurement) names, [tag keys](/influxdb/v1.0/concepts/glossary/#tag-key), and [field keys](/influxdb/v1.0/concepts/glossary/#field-key).
-See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influxql/README.md#keywords) for words to avoid.
+See [InfluxQL Keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) for words to avoid.
 
 Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 

--- a/content/influxdb/v1.0/query_language/data_exploration.md
+++ b/content/influxdb/v1.0/query_language/data_exploration.md
@@ -190,7 +190,7 @@ Other supported features:
 
 #### Quoting
 [Identifiers](/influxdb/v1.0/concepts/glossary/#identifiers) **must** be double quoted if they contain characters other than `[A-z,0-9,_]`, if they
-begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 While not always necessary, we recommend that you double quote identifiers.
 
 > **Note:** The quoting syntax for queries differs from the [line protocol](/influxdb/v1.0/concepts/glossary/#line-protocol).

--- a/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.0/troubleshooting/frequently-asked-questions.md
@@ -571,7 +571,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## When should I single quote and when should I double quote in queries?
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 Double quotes are not required for identifiers if they don't fall into one of
 those categories but we recommend double quoting them anyway.
 
@@ -912,7 +912,7 @@ InfluxDB's line protocol relies on line feed (`\n`, which is ASCII `0x0A`) to in
 Note that Windows uses carriage return and line feed (`\r\n`) as the newline character.
 
 ## What words and characters should I avoid when writing data to InfluxDB?
-If you use any of the [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use any of the [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v1.0/troubleshooting/errors/#error-parsing-query-found-expected-identifier-at-line-char).
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 

--- a/content/influxdb/v1.1/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.1/concepts/schema_and_data_layout.md
@@ -40,7 +40,7 @@ In general, your queries should guide what gets stored as a tag and what gets st
 
 This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
 Identifiers are database names, [retention policy](/influxdb/v1.1/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v1.1/concepts/glossary/#user) names, [measurement](/influxdb/v1.1/concepts/glossary/#measurement) names, [tag keys](/influxdb/v1.1/concepts/glossary/#tag-key), and [field keys](/influxdb/v1.1/concepts/glossary/#field-key).
-See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influxql/README.md#keywords) for words to avoid.
+See [InfluxQL Keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) for words to avoid.
 
 Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 

--- a/content/influxdb/v1.1/query_language/data_exploration.md
+++ b/content/influxdb/v1.1/query_language/data_exploration.md
@@ -196,7 +196,7 @@ Other supported features:
 
 #### Quoting
 [Identifiers](/influxdb/v1.1/concepts/glossary/#identifiers) **must** be double quoted if they contain characters other than `[A-z,0-9,_]`, if they
-begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 While not always necessary, we recommend that you double quote identifiers.
 
 > **Note:** The quoting syntax for queries differs from the [line protocol](/influxdb/v1.1/concepts/glossary/#line-protocol).

--- a/content/influxdb/v1.1/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.1/troubleshooting/frequently-asked-questions.md
@@ -613,7 +613,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## When should I single quote and when should I double quote in queries?
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 Double quotes are not required for identifiers if they don't fall into one of
 those categories but we recommend double quoting them anyway.
 
@@ -954,7 +954,7 @@ InfluxDB's line protocol relies on line feed (`\n`, which is ASCII `0x0A`) to in
 Note that Windows uses carriage return and line feed (`\r\n`) as the newline character.
 
 ## What words and characters should I avoid when writing data to InfluxDB?
-If you use any of the [InfluxQL keywords](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use any of the [InfluxQL keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v1.1/troubleshooting/errors/#error-parsing-query-found-expected-identifier-at-line-char).
 Identifiers are database names, retention policy names, user names, measurement names, tag keys, and field keys.
 

--- a/content/influxdb/v1.2/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.2/concepts/schema_and_data_layout.md
@@ -40,7 +40,7 @@ In general, your queries should guide what gets stored as a tag and what gets st
 
 This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
 Identifiers are database names, [retention policy](/influxdb/v1.2/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v1.2/concepts/glossary/#user) names, [measurement](/influxdb/v1.2/concepts/glossary/#measurement) names, [tag keys](/influxdb/v1.2/concepts/glossary/#tag-key), and [field keys](/influxdb/v1.2/concepts/glossary/#field-key).
-See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influxql/README.md#keywords) for words to avoid.
+See [InfluxQL Keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) for words to avoid.
 
 Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 

--- a/content/influxdb/v1.2/query_language/data_exploration.md
+++ b/content/influxdb/v1.2/query_language/data_exploration.md
@@ -209,7 +209,7 @@ Other supported features:
 
 #### Quoting
 [Identifiers](/influxdb/v1.2/concepts/glossary/#identifiers) **must** be double quoted if they contain characters other than `[A-z,0-9,_]`, if they
-begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 While not always necessary, we recommend that you double quote identifiers.
 
 > **Note:** The quoting syntax for queries differs from the [line protocol](/influxdb/v1.2/concepts/glossary/#line-protocol).

--- a/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.2/troubleshooting/frequently-asked-questions.md
@@ -674,7 +674,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## When should I single quote and when should I double quote in queries?
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 Double quotes are not required for identifiers if they don't fall into one of
 those categories but we recommend double quoting them anyway.
 
@@ -1019,7 +1019,7 @@ Note that Windows uses carriage return and line feed (`\r\n`) as the newline cha
 ## What words and characters should I avoid when writing data to InfluxDB?
 
 ### InfluxQL Keywords
-If you use an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v1.2/troubleshooting/errors/#error-parsing-query-found-expected-identifier-at-line-char).
 Identifiers are continuous query names, database names, field keys, measurement names, retention policy names, subscription names, tag keys, and user names.
 

--- a/content/influxdb/v1.3/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.3/concepts/schema_and_data_layout.md
@@ -40,7 +40,7 @@ In general, your queries should guide what gets stored as a tag and what gets st
 
 This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
 Identifiers are database names, [retention policy](/influxdb/v1.3/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v1.3/concepts/glossary/#user) names, [measurement](/influxdb/v1.3/concepts/glossary/#measurement) names, [tag keys](/influxdb/v1.3/concepts/glossary/#tag-key), and [field keys](/influxdb/v1.3/concepts/glossary/#field-key).
-See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influxql/README.md#keywords) for words to avoid.
+See [InfluxQL Keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) for words to avoid.
 
 Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 

--- a/content/influxdb/v1.3/query_language/data_exploration.md
+++ b/content/influxdb/v1.3/query_language/data_exploration.md
@@ -209,7 +209,7 @@ Other supported features:
 
 #### Quoting
 [Identifiers](/influxdb/v1.3/concepts/glossary/#identifiers) **must** be double quoted if they contain characters other than `[A-z,0-9,_]`, if they
-begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 While not always necessary, we recommend that you double quote identifiers.
 
 > **Note:** The quoting syntax for queries differs from the [line protocol](/influxdb/v1.3/concepts/glossary/#line-protocol).

--- a/content/influxdb/v1.3/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.3/troubleshooting/frequently-asked-questions.md
@@ -646,7 +646,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## When should I single quote and when should I double quote in queries?
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 Double quotes are not required for identifiers if they don't fall into one of
 those categories but we recommend double quoting them anyway.
 
@@ -994,7 +994,7 @@ Note that Windows uses carriage return and line feed (`\r\n`) as the newline cha
 ## What words and characters should I avoid when writing data to InfluxDB?
 
 ### InfluxQL Keywords
-If you use an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v1.3/troubleshooting/errors/#error-parsing-query-found-expected-identifier-at-line-char).
 Identifiers are continuous query names, database names, field keys, measurement names, retention policy names, subscription names, tag keys, and user names.
 

--- a/content/influxdb/v1.4/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.4/concepts/schema_and_data_layout.md
@@ -40,7 +40,7 @@ In general, your queries should guide what gets stored as a tag and what gets st
 
 This isn't necessary, but it simplifies writing queries; you won't have to wrap those identifiers in double quotes.
 Identifiers are database names, [retention policy](/influxdb/v1.4/concepts/glossary/#retention-policy-rp) names, [user](/influxdb/v1.4/concepts/glossary/#user) names, [measurement](/influxdb/v1.4/concepts/glossary/#measurement) names, [tag keys](/influxdb/v1.4/concepts/glossary/#tag-key), and [field keys](/influxdb/v1.4/concepts/glossary/#field-key).
-See [InfluxQL Keywords](https://github.com/influxdata/influxdb/blob/master/influxql/README.md#keywords) for words to avoid.
+See [InfluxQL Keywords](https://github.com/influxdata/influxql/blob/master/README.md#keywords) for words to avoid.
 
 Note that you will also need to wrap identifiers in double quotes in queries if they contain characters other than `[A-z,_]`.
 

--- a/content/influxdb/v1.4/query_language/data_exploration.md
+++ b/content/influxdb/v1.4/query_language/data_exploration.md
@@ -209,7 +209,7 @@ Other supported features:
 
 #### Quoting
 [Identifiers](/influxdb/v1.4/concepts/glossary/#identifiers) **must** be double quoted if they contain characters other than `[A-z,0-9,_]`, if they
-begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+begin with a digit, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 While not always necessary, we recommend that you double quote identifiers.
 
 > **Note:** The quoting syntax for queries differs from the [line protocol](/influxdb/v1.4/concepts/glossary/#line-protocol).

--- a/content/influxdb/v1.4/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.4/troubleshooting/frequently-asked-questions.md
@@ -651,7 +651,7 @@ time                  value	 precision_supplied  timestamp_supplied
 ## When should I single quote and when should I double quote in queries?
 Single quote string values (for example, tag values) but do not single quote identifiers (database names, retention policy names, user names, measurement names, tag keys, and field keys).
 
-Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords).
+Double quote identifiers if they start with a digit, contain characters other than `[A-z,0-9,_]`, or if they are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords).
 Double quotes are not required for identifiers if they don't fall into one of
 those categories but we recommend double quoting them anyway.
 
@@ -999,7 +999,7 @@ Note that Windows uses carriage return and line feed (`\r\n`) as the newline cha
 ## What words and characters should I avoid when writing data to InfluxDB?
 
 ### InfluxQL Keywords
-If you use an [InfluxQL keyword](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
+If you use an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords) as an identifier you will need to double quote that identifier in every query.
 This can lead to [non-intuitive errors](/influxdb/v1.4/troubleshooting/errors/#error-parsing-query-found-expected-identifier-at-line-char).
 Identifiers are continuous query names, database names, field keys, measurement names, retention policy names, subscription names, tag keys, and user names.
 

--- a/content/kapacitor/v0.10/introduction/getting_started.md
+++ b/content/kapacitor/v0.10/introduction/getting_started.md
@@ -112,7 +112,7 @@ Let's start the Kapacitor server:
 kapacitord -config kapacitor.conf
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 You should see some basic start up messages and something about listening on UDP port and starting subscriptions.
 At this point InfluxDB is streaming the data it is receiving from Telegraf to Kapacitor.

--- a/content/kapacitor/v0.11/introduction/getting_started.md
+++ b/content/kapacitor/v0.11/introduction/getting_started.md
@@ -112,7 +112,7 @@ Let's start the Kapacitor server:
 kapacitord -config kapacitor.conf
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 You should see some basic start up messages and something about listening on UDP port and starting subscriptions.
 At this point InfluxDB is streaming the data it is receiving from Telegraf to Kapacitor.

--- a/content/kapacitor/v0.12/introduction/getting_started.md
+++ b/content/kapacitor/v0.12/introduction/getting_started.md
@@ -112,7 +112,7 @@ Let's start the Kapacitor server:
 kapacitord -config kapacitor.conf
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 You should see some basic start up messages and something about listening on UDP port and starting subscriptions.
 At this point InfluxDB is streaming the data it is receiving from Telegraf to Kapacitor.

--- a/content/kapacitor/v0.13/introduction/getting_started.md
+++ b/content/kapacitor/v0.13/introduction/getting_started.md
@@ -112,7 +112,7 @@ Let's start the Kapacitor server:
 kapacitord -config kapacitor.conf
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 You should see some basic start up messages and something about listening on UDP port and starting subscriptions.
 At this point InfluxDB is streaming the data it is receiving from Telegraf to Kapacitor.

--- a/content/kapacitor/v0.2/introduction/getting_started.md
+++ b/content/kapacitor/v0.2/introduction/getting_started.md
@@ -119,7 +119,7 @@ Let's start the Kapacitor server:
 kapacitord -config kapacitor.conf
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 You should see some basic start up messages and something about listening on UDP port and starting subscriptions.
 At this point InfluxDB is streaming the data it is receiving from Telegraf to Kapacitor.

--- a/content/kapacitor/v1.0/introduction/getting_started.md
+++ b/content/kapacitor/v1.0/introduction/getting_started.md
@@ -112,7 +112,7 @@ Let's start the Kapacitor server:
 kapacitord -config kapacitor.conf
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 You should see some basic start up messages and something about listening on UDP port and starting subscriptions.
 At this point InfluxDB is streaming the data it is receiving from Telegraf to Kapacitor.

--- a/content/kapacitor/v1.1/introduction/getting_started.md
+++ b/content/kapacitor/v1.1/introduction/getting_started.md
@@ -112,7 +112,7 @@ Let's start the Kapacitor server:
 kapacitord -config kapacitor.conf
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 You should see some basic start up messages and something about listening on UDP port and starting subscriptions.
 At this point InfluxDB is streaming the data it is receiving from Telegraf to Kapacitor.

--- a/content/kapacitor/v1.2/introduction/getting_started.md
+++ b/content/kapacitor/v1.2/introduction/getting_started.md
@@ -112,7 +112,7 @@ Let's start the Kapacitor server:
 kapacitord -config kapacitor.conf
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 You should see some basic start up messages and something about listening on UDP port and starting subscriptions.
 At this point InfluxDB is streaming the data it is receiving from Telegraf to Kapacitor.

--- a/content/kapacitor/v1.3/introduction/getting_started.md
+++ b/content/kapacitor/v1.3/introduction/getting_started.md
@@ -247,7 +247,7 @@ zář 01 15:34:16 algonquin kapacitord[18526]: 2017/09/01 15:34:16 Using configu
 
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 
 For more log data check the log file in the traditional `/var/log/kapacitor` directory.

--- a/content/kapacitor/v1.4/introduction/getting_started.md
+++ b/content/kapacitor/v1.4/introduction/getting_started.md
@@ -247,7 +247,7 @@ zář 01 15:34:16 algonquin kapacitord[18526]: 2017/09/01 15:34:16 Using configu
 
 ```
 
-Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdb/influxdb/blob/master/influxql/README.md#create-subscription) on InfluxDB.
+Since InfluxDB is running on `http://localhost:8086` Kapacitor finds it during start up and creates several [subscriptions](https://github.com/influxdata/influxql/blob/master/README.md#create-subscription) on InfluxDB.
 These subscriptions tell InfluxDB to send all the data it receives to Kapacitor.
 
 For more log data check the log file in the traditional `/var/log/kapacitor` directory.


### PR DESCRIPTION
since the commit below in influxdata/influxdb influxql was moved out of the influxdb repo and into the newly formed influxdata/influxql repo

commit f3d45ba301d65eb63d26f85a0ae5b5bd0f4b18d3
Author: Stuart Carnie <stuart.carnie@gmail.com>
Date:   Mon Oct 30 14:40:26 2017 -0700

    influxdata/influxdb/influxql -> influxdata/influxql

the change I am proposing fixes all the links I could find which are currently broken

I noticed this when attempting to follow a link to subscriptions on the https://docs.influxdata.com/kapacitor/v1.4/introduction/getting_started/#installing-and-starting-kapacitor page