### PR TITLE
Fixes link to "Managing organizations"

### DIFF
--- a/content/chronograf/v1.4/administration/configuration.md
+++ b/content/chronograf/v1.4/administration/configuration.md
@@ -46,5 +46,5 @@ See [Managing security](/chronograf/latest/administration/managing-security) for
 
 After you configure OAuth 2.0 authentication in Chronograf, you can use the multi-organization and multi-user support described in detail here:
 
-* [Managing organizations](/chronograf/latest/administration/managing-organization)
+* [Managing organizations](/chronograf/latest/administration/managing-organizations)
 * [Managing Chronograf users](/chronograf/latest/administration/managing-chronograf-users)


### PR DESCRIPTION
The referenced link was missing the trailing, pluralizing "s" in "organizations".