### PR TITLE
Remove bogus merge hunk.

### DIFF
--- a/content/influxdb/v1.4/supported_protocols/prometheus.md
+++ b/content/influxdb/v1.4/supported_protocols/prometheus.md
@@ -11,16 +11,9 @@ menu:
 ## Prometheus remote read and write API support
 
 <dt>
-<<<<<<< HEAD
 InfluxDB support for the Prometheus remote read and write API is experimental for both Prometheus and InfluxDB.
 Prometheus documentation states that their remote_read and remote_write configuration settings are "experimental: breaking changes to configuration are likely in future releases."
 </dt>
-
-=======
-Prometheus remote read and write API is experimental for both Prometheus and InfluxDB.
->Prometheus configuration documentation states that their remote_read and remote_write configuration settings are "experimental: breaking changes to configuration are likely in future releases."
-</dt>
->>>>>>> 96434f37eafc91c5398aa2e6b3d189f815ac07f4
 
 InfluxDB support for the Prometheus remote read and write API adds the following two HTTP endpoints to the InfluxDB `httpd` handler:
 


### PR DESCRIPTION
Conflict markers were left in the documentation from the last rebase.