### PR TITLE
Fix redirect loop on index pages

### DIFF
--- a/content/chronograf/_index.md
+++ b/content/chronograf/_index.md
@@ -1,4 +1,3 @@
 ---
 type: chronograf
-layout: list
 ---

--- a/content/enterprise_influxdb/_index.md
+++ b/content/enterprise_influxdb/_index.md
@@ -1,4 +1,3 @@
 ---
 type: enterprise_influxdb
-layout: list
 ---

--- a/content/enterprise_kapacitor/_index.md
+++ b/content/enterprise_kapacitor/_index.md
@@ -1,4 +1,3 @@
 ---
 type: enterprise_kapacitor
-layout: list
 ---

--- a/content/influxdb/_index.md
+++ b/content/influxdb/_index.md
@@ -1,4 +1,3 @@
 ---
 type: influxdb
-layout: list
 ---

--- a/content/kapacitor/_index.md
+++ b/content/kapacitor/_index.md
@@ -1,4 +1,3 @@
 ---
 type: kapacitor
-layout: list
 ---

--- a/content/telegraf/_index.md
+++ b/content/telegraf/_index.md
@@ -1,4 +1,3 @@
 ---
 type: telegraf
-layout: list
 ---

--- a/layouts/chronograf/list.html
+++ b/layouts/chronograf/list.html
@@ -1,3 +1,0 @@
-<head>
-<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/chronograf/latest/" />
-</head>

--- a/layouts/chronograf/section.html
+++ b/layouts/chronograf/section.html
@@ -1,0 +1,19 @@
+{{ partial "header.html" . }}
+<article class="article">
+    {{ if .Title }}
+    <section class="article-section article-heading">
+        <div class="article-content">
+            <h1>{{ .Title }}</h1>
+        </div>
+    </section>
+    {{ end }}
+    <section class="article-section">
+        <div class="article-content">
+            {{ partial "chronograf/version.html" . }}
+            {{ .Content }}
+        </div>
+    </section>
+    {{ partial "chronograf/contribute.html" . }}
+</article>
+{{ partial "chronograf/sidebar.html" . }}
+{{ partial "footer.html" . }}

--- a/layouts/enterprise_influxdb/list.html
+++ b/layouts/enterprise_influxdb/list.html
@@ -1,3 +1,0 @@
-<head>
-<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/enterprise_influxdb/latest/" />
-</head>

--- a/layouts/enterprise_influxdb/section.html
+++ b/layouts/enterprise_influxdb/section.html
@@ -1,17 +1,19 @@
 {{ partial "header.html" . }}
 <article class="article">
+	{{ if .Title }}
 	<section class="article-section article-heading">
 		<div class="article-content">
-			<h1>{{ .Title }} Section</h1>
+			<h1>{{ .Title }}</h1>
 		</div>
 	</section>
+	{{ end }}
 	<section class="article-section">
 		<div class="article-content">
-			{{ range .Pages }}
-				{{ .Render "list"}}
-			{{ end }}
+			{{ partial "enterprise_influxdb/version.html" . }}
+			{{ .Content }}
 		</div>
 	</section>
+	{{ partial "enterprise_influxdb/contribute.html" . }}
 </article>
 {{ partial "enterprise_influxdb/sidebar.html" . }}
 {{ partial "footer.html" . }}

--- a/layouts/enterprise_kapacitor/list.html
+++ b/layouts/enterprise_kapacitor/list.html
@@ -1,3 +1,0 @@
-<head>
-<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/enterprise_kapacitor/latest/" />
-</head>

--- a/layouts/enterprise_kapacitor/section.html
+++ b/layouts/enterprise_kapacitor/section.html
@@ -1,17 +1,19 @@
 {{ partial "header.html" . }}
 <article class="article">
+	{{ if .Title }}
 	<section class="article-section article-heading">
 		<div class="article-content">
-			<h1>{{ .Title }} Section</h1>
+			<h1>{{ .Title }}</h1>
 		</div>
 	</section>
+	{{ end }}
 	<section class="article-section">
 		<div class="article-content">
-			{{ range .Pages }}
-				{{ .Render "list"}}
-			{{ end }}
+			{{ partial "enterprise_kapacitor/version.html" . }}
+			{{ .Content }}
 		</div>
 	</section>
+	{{ partial "enterprise_kapacitor/contribute.html" . }}
 </article>
 {{ partial "enterprise_kapacitor/sidebar.html" . }}
 {{ partial "footer.html" . }}

--- a/layouts/influxdb/list.html
+++ b/layouts/influxdb/list.html
@@ -1,3 +1,0 @@
-<head>
-<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/influxdb/latest/" />
-</head>

--- a/layouts/kapacitor/list.html
+++ b/layouts/kapacitor/list.html
@@ -1,3 +1,0 @@
-<head>
-<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/kapacitor/latest/" />
-</head>

--- a/layouts/kapacitor/section.html
+++ b/layouts/kapacitor/section.html
@@ -1,15 +1,19 @@
 {{ partial "header.html" . }}
 <article class="article">
-    <section class="article-section article-heading">
-	    <div class="article-content">
-	    	<h1>{{ .Title }} Section</h1>
-	    </div>
+	{{ if .Title }}
+	<section class="article-section article-heading">
+		<div class="article-content">
+			<h1>{{ .Title }}</h1>
+		</div>
 	</section>
+	{{ end }}
 	<section class="article-section">
 		<div class="article-content">
+			{{ partial "kapacitor/version.html" . }}
 			{{ .Content }}
 		</div>
 	</section>
+	{{ partial "kapacitor/contribute.html" . }}
 </article>
 {{ partial "kapacitor/sidebar.html" . }}
 {{ partial "footer.html" . }}

--- a/layouts/telegraf/list.html
+++ b/layouts/telegraf/list.html
@@ -1,3 +1,0 @@
-<head>
-<meta http-equiv="refresh" content="0; url=https://docs.influxdata.com/telegraf/latest/" />
-</head>

--- a/layouts/telegraf/section.html
+++ b/layouts/telegraf/section.html
@@ -9,11 +9,11 @@
 	{{ end }}
 	<section class="article-section">
 		<div class="article-content">
-			{{ partial "influxdb/version.html" . }}
+			{{ partial "telegraf/version.html" . }}
 			{{ .Content }}
 		</div>
 	</section>
-	{{ partial "influxdb/contribute.html" . }}
+	{{ partial "telegraf/contribute.html" . }}
 </article>
-{{ partial "influxdb/sidebar.html" . }}
+{{ partial "telegraf/sidebar.html" . }}
 {{ partial "footer.html" . }}


### PR DESCRIPTION
This switches all the section pages to use the same layouts as other pages. The infinite redirect is fixed since it removes the refresh meta tag that previously existed on all section pages.

Some template changes are required to make the templates work correctly on section pages.