### PR TITLE
updated version warning partial to fix bad links and automate detecti…

### DIFF
--- a/layouts/partials/chronograf/version.html
+++ b/layouts/partials/chronograf/version.html
@@ -1,7 +1,5 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.chronograf_semver) (eq .RelPermalink "/chronograf/")) }}
-{{ if or (in .RelPermalink "v0.4") (in .RelPermalink "v0.10") (in .RelPermalink "v0.11") (in .RelPermalink "v0.12") (in .RelPermalink "v0.13") ( in .RelPermalink "v1.0") ( in .RelPermalink "v1.3") }}
     <div class="old-version">
-    <strong>Warning!</strong> This page documents an old version of Chronograf, which is no longer actively developed. <a href="/chronograf/{{ .Site.Data.default_versions.chronograf_semver }}/introduction/getting-started/">Chronograf {{ .Site.Data.default_versions.chronograf_semver }}</a> is the most recent stable version of Chronograf.
+    <strong>Warning!</strong> This page documents an old version of Chronograf, which is no longer actively developed. <a href="/chronograf/{{ .Site.Data.default_versions.chronograf_semver }}{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">Chronograf {{ .Site.Data.default_versions.chronograf_semver }}</a> is the most recent stable version of Chronograf.
     </div>
-{{ end }}
 {{ end }}

--- a/layouts/partials/enterprise_influxdb/version.html
+++ b/layouts/partials/enterprise_influxdb/version.html
@@ -1,7 +1,5 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.enterprise_influxdb_semver) (eq .RelPermalink "/enterprise_influxdb/")) }}
 <div class="old-version">
-{{ if or (in .RelPermalink "v1.0") (in .RelPermalink "v1.1") (in .RelPermalink "v1.2") (in .RelPermalink "v1.3") }}
-    <strong>Warning!</strong> This page documents an old version of InfluxDB Enterprise, which is no longer actively developed. <a href="/enterprise_influxdb/{{ .Site.Data.default_versions.enterprise_influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 25 }}{{end}}">InfluxDB Enterprise {{ .Site.Data.default_versions.enterprise_influxdb_semver }}</a> is the most recent stable version of InfluxDB Enterprise.
-{{ end }}
+    <strong>Warning!</strong> This page documents an old version of InfluxDB Enterprise, which is no longer actively developed. <a href="/enterprise_influxdb/{{ .Site.Data.default_versions.enterprise_influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">InfluxDB Enterprise {{ .Site.Data.default_versions.enterprise_influxdb_semver }}</a> is the most recent stable version of InfluxDB Enterprise.
 </div>
 {{ end }}

--- a/layouts/partials/enterprise_influxdb/version.html
+++ b/layouts/partials/enterprise_influxdb/version.html
@@ -1,5 +1,5 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.enterprise_influxdb_semver) (eq .RelPermalink "/enterprise_influxdb/")) }}
 <div class="old-version">
-    <strong>Warning!</strong> This page documents an old version of InfluxDB Enterprise, which is no longer actively developed. <a href="/enterprise_influxdb/{{ .Site.Data.default_versions.enterprise_influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">InfluxDB Enterprise {{ .Site.Data.default_versions.enterprise_influxdb_semver }}</a> is the most recent stable version of InfluxDB Enterprise.
+    <strong>Warning!</strong> This page documents an earlier version of InfluxDB Enterprise, which is no longer actively developed. <a href="/enterprise_influxdb/{{ .Site.Data.default_versions.enterprise_influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">InfluxDB Enterprise {{ .Site.Data.default_versions.enterprise_influxdb_semver }}</a> is the most recent stable version of InfluxDB Enterprise.
 </div>
 {{ end }}

--- a/layouts/partials/enterprise_kapacitor/version.html
+++ b/layouts/partials/enterprise_kapacitor/version.html
@@ -1,7 +1,5 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.enterprise_kapacitor_semver) (eq .RelPermalink "/enterprise_kapacitor/")) }}
 <div class="old-version">
-{{ if or (in .RelPermalink "v1.0") (in .RelPermalink "v1.1") (in .RelPermalink "v1.2") (in .RelPermalink "v1.3") }}
-    <strong>Warning!</strong> This page documents an old version of Kapacitor Enterprise, which is no longer actively developed. <a href="/enterprise_kapacitor/{{ .Site.Data.default_versions.enterprise_kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 16 }}{{end}}">"Kapacitor Enterprise" {{ .Site.Data.default_versions.enterprise_kapacitor_semver }}</a> is the most recent stable version of Kapacitor Enterprise.
-{{ end }}
+    <strong>Warning!</strong> This page documents an old version of Kapacitor Enterprise, which is no longer actively developed. <a href="/enterprise_kapacitor/{{ .Site.Data.default_versions.enterprise_kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">"Kapacitor Enterprise" {{ .Site.Data.default_versions.enterprise_kapacitor_semver }}</a> is the most recent stable version of Kapacitor Enterprise.
 </div>
 {{ end }}

--- a/layouts/partials/enterprise_kapacitor/version.html
+++ b/layouts/partials/enterprise_kapacitor/version.html
@@ -1,5 +1,5 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.enterprise_kapacitor_semver) (eq .RelPermalink "/enterprise_kapacitor/")) }}
 <div class="old-version">
-    <strong>Warning!</strong> This page documents an old version of Kapacitor Enterprise, which is no longer actively developed. <a href="/enterprise_kapacitor/{{ .Site.Data.default_versions.enterprise_kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">"Kapacitor Enterprise" {{ .Site.Data.default_versions.enterprise_kapacitor_semver }}</a> is the most recent stable version of Kapacitor Enterprise.
+    <strong>Warning!</strong> This page documents an earlier version of Kapacitor Enterprise, which is no longer actively developed. <a href="/enterprise_kapacitor/{{ .Site.Data.default_versions.enterprise_kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">"Kapacitor Enterprise" {{ .Site.Data.default_versions.enterprise_kapacitor_semver }}</a> is the most recent stable version of Kapacitor Enterprise.
 </div>
 {{ end }}

--- a/layouts/partials/influxdb/version.html
+++ b/layouts/partials/influxdb/version.html
@@ -1,9 +1,9 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.influxdb_semver) (eq .RelPermalink "/influxdb/")) }}
 <div class="old-version">
   {{ if or (in .RelPermalink "v0.6") (in .RelPermalink "v0.7") (in .RelPermalink "v0.8") }}
-      <strong>Warning!</strong> This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent stable version of InfluxDB.
+      <strong>Warning!</strong> This page documents an earlier version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent stable version of InfluxDB.
   {{ else }}
-      <strong>Warning!</strong> This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent stable version of InfluxDB.
+      <strong>Warning!</strong> This page documents an earlier version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent stable version of InfluxDB.
   {{ end }}
 </div>
 {{ end }}

--- a/layouts/partials/influxdb/version.html
+++ b/layouts/partials/influxdb/version.html
@@ -1,13 +1,9 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.influxdb_semver) (eq .RelPermalink "/influxdb/")) }}
 <div class="old-version">
-{{ if or (in .RelPermalink "v0.10") (in .RelPermalink "v0.11") (in .RelPermalink "v0.12") (in .RelPermalink "v0.13") }}
-    <strong>Warning!</strong> This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 16 }}{{end}}">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent stable version of InfluxDB.
-{{ end }}
-{{ if or (in .RelPermalink "v0.9") (in .RelPermalink "v1.0")  (in .RelPermalink "v1.1") (in .RelPermalink "v1.2") (in .RelPermalink "v1.3") (in .RelPermalink "v1.4") }}
-    <strong>Warning!</strong> This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent stable version of InfluxDB.
-{{ end }}
-{{ if or (in .RelPermalink "v0.6") (in .RelPermalink "v0.7") (in .RelPermalink "v0.8") }}
-    <strong>Warning!</strong> This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent stable version of InfluxDB.
-{{ end }}
+  {{ if or (in .RelPermalink "v0.6") (in .RelPermalink "v0.7") (in .RelPermalink "v0.8") }}
+      <strong>Warning!</strong> This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent stable version of InfluxDB.
+  {{ else }}
+      <strong>Warning!</strong> This page documents an old version of InfluxDB, which is no longer actively developed. <a href="/influxdb/{{ .Site.Data.default_versions.influxdb_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">InfluxDB {{ .Site.Data.default_versions.influxdb_semver }}</a> is the most recent stable version of InfluxDB.
+  {{ end }}
 </div>
 {{ end }}

--- a/layouts/partials/kapacitor/version.html
+++ b/layouts/partials/kapacitor/version.html
@@ -1,10 +1,5 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.kapacitor_semver) (eq .RelPermalink "/kapacitor/")) }}
 <div class="old-version">
-{{ if or (in .RelPermalink "v0.10") (in .RelPermalink "v0.11") (in .RelPermalink "v0.12") (in .RelPermalink "v0.13") }}
-    <strong>Warning!</strong> This page documents an old version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 16 }}{{end}}">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent stable version of Kapacitor.
-{{ end }}
-{{ if or (in .RelPermalink "v0.2") (in .RelPermalink "v1.0") (in .RelPermalink "v1.1") (in .RelPermalink "v1.2") (in .RelPermalink "v1.3" ) }}
-    <strong>Warning!</strong> This page documents an old version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent stable version of Kapacitor.
-{{ end }}
+    <strong>Warning!</strong> This page documents an old version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent stable version of Kapacitor.
 </div>
 {{ end }}

--- a/layouts/partials/kapacitor/version.html
+++ b/layouts/partials/kapacitor/version.html
@@ -1,5 +1,5 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.kapacitor_semver) (eq .RelPermalink "/kapacitor/")) }}
 <div class="old-version">
-    <strong>Warning!</strong> This page documents an old version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent stable version of Kapacitor.
+    <strong>Warning!</strong> This page documents an earlier version of Kapacitor, which is no longer actively developed. <a href="/kapacitor/{{ .Site.Data.default_versions.kapacitor_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">Kapacitor {{ .Site.Data.default_versions.kapacitor_semver }}</a> is the most recent stable version of Kapacitor.
 </div>
 {{ end }}

--- a/layouts/partials/telegraf/version.html
+++ b/layouts/partials/telegraf/version.html
@@ -1,10 +1,5 @@
 {{ if not (or (in .RelPermalink .Site.Data.default_versions.telegraf_semver) (eq .RelPermalink "/telegraf/")) }}
 <div class="old-version">
-{{ if or (in .RelPermalink "v0.10") (in .RelPermalink "v0.11") (in .RelPermalink "v0.12") (in .RelPermalink "v0.13") }}
-    <strong>Warning!</strong> This page documents an earlier version of Telegraf, which is no longer actively developed. <a href="/telegraf/{{ .Site.Data.default_versions.telegraf_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 16 }}{{end}}">Telegraf {{ .Site.Data.default_versions.telegraf_semver }}</a> is the most recent stable version of Telegraf.
-{{ end }}
-{{ if or (in .RelPermalink "v0.2") (in .RelPermalink "v1.0") (in .RelPermalink "v1.1") (in .RelPermalink "v1.2") (in .RelPermalink "v1.3") (in .RelPermalink "v1.4")}}
-    <strong>Warning!</strong> This page documents an earlier version of Telegraf, which is no longer actively developed. <a href="/telegraf/{{ .Site.Data.default_versions.telegraf_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink 15 }}{{end}}">Telegraf {{ .Site.Data.default_versions.telegraf_semver }}</a> is the most recent stable version of Telegraf.
-{{ end }}
+    <strong>Warning!</strong> This page documents an earlier version of Telegraf, which is no longer actively developed. <a href="/telegraf/{{ .Site.Data.default_versions.telegraf_semver }}/{{ if isset .Params "newversionredirect" }}{{ .Params.newversionredirect }}{{else}}{{ substr .RelPermalink (len (index (findRE "^/.*?/+.*?/" .RelPermalink) 0)) }}{{end}}">Telegraf {{ .Site.Data.default_versions.telegraf_semver }}</a> is the most recent stable version of Telegraf.
 </div>
 {{ end }}


### PR DESCRIPTION
…on of version path length in the url, resolves #1469 

This was an interesting one. In my changes, I simplified some of the logic. Before it was using conditional logic to set the starting position for the string of the current doc's path. This starting position (character number) was manually being set for different version number lengths in each project.

Instead, I included functionality to automatically detect the starting point for the string by reading the relative permalink, regex'ing the first two directories (`/project/v.1.0/`), and detecting the length of that path. Now, no matter the length of the version number, the links should generate properly.