### PR TITLE
Update release-notes-changelog for InfluxEnterprise

### DIFF
--- a/content/enterprise_influxdb/v1.5/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.5/about-the-project/release-notes-changelog.md
@@ -17,6 +17,8 @@ menu:
 <br>
 <br>
 
+# Clustering
+
 ## v1.5.1 [2018-03-20]
 
 > ***Note:*** This release builds off of the 1.5.1 release of InfluxDB OSS. Please see the [InfluxDB OSS release
@@ -45,6 +47,13 @@ The default logging format has been changed. See [Logging and tracing in InfluxD
 * Update logging calls to take advantage of structured logging.
 * Use actual URL when logging anonymous stats start.
 * Fix auth failures on backup/restore.
+* Add support for passive nodes
+* Implement explain plan for remote nodes.
+* Add message pack format for query responses.
+* Teach show tag values to respect FGA
+* Address deadlock in meta server on 1.3.6
+* Add time support to `SHOW TAG VALUES`
+* Add distributed `SHOW TAG KEYS` with time support
 
 ### Bug fixes
 
@@ -56,51 +65,38 @@ The default logging format has been changed. See [Logging and tracing in InfluxD
 * Segfault in `digest.merge`
 * Meta Node CPU pegged on idle cluster.
 * Data race on `(meta.UserInfo).acl)`
+* Fix wildcard when one shard has no data for a measurement with partial replication.
+* Add `X-Influxdb-Build` to http response headers so users can identify if a response is from an InfluxDB OSS or InfluxDB Enterprise service.
+* Ensure that permissions cannot be set on non-existent databases.
+* Switch back to using `cluster-tracing` config option to enable meta HTTP request logging.
+* `influxd-ctl restore -newdb` can't restore data.
+* Close connection for remote iterators after EOF to avoid writer hanging indefinitely.
+* Data race reading `Len()` in connection pool.
+* Use InfluxData fork of `yamux`. This update reduces overall memory usage when streaming large amounts of data.
+* Fix group by marshaling in the IteratorOptions.
+* Meta service data race.
+* Read for the interrupt signal from the stream before creating the iterators.
+* Show retention policies requires the `createdatabase` permission
+* Handle UTF files with a byte order mark when reading the configuration files.
+* Remove the pidfile after the server has exited.
+* Resend authentication credentials on redirect.
+* Updated yamux resolves race condition when SYN is successfully sent and a write timeout occurs.
+* Fix no license message.
 
-## v1.4.2 [2017-11-15]
+## v1.3.9 [2018-01-19]
 
-### Bug fixes
+### Upgrading -- for users of the TSI preview
 
-- Fix wildcard when one shard has no data for a measurement with partial replication.
+If you have been using the TSI preview with 1.3.6 or earlier 1.3.x releases, you will need to follow the upgrade steps to continue using the TSI preview.  Unfortunately, these steps cannot be executed while the cluster is operating -- 
+so it will require downtime.
 
-## 1.4.1 [2017-11-13]
+### Bugfixes
 
-This release builds off of the InfluxDB OSS 1.4.1 release. Please see the [InfluxDB OSS release notes](/influxdb/v1.4/about_the_project/releasenotes-changelog/) for more information about the InfluxDB OSS release.
-
-## 1.4.0 [2017-11-13]
-
-This release builds off of the 1.4 release of InfluxDB OSS. Please see the [InfluxDB OSS release notes](https://docs.influxdata.com/influxdb/v1.4/about_the_project/releasenotes-changelog/) for more information about the InfluxDB OSS releases.
-
-### Features
-
-- Add support for passive nodes
-- Implement explain plan for remote nodes.
-- Add message pack format for query responses.
-- Teach show tag values to respect FGA
-- Deadlock(?) in meta server on 1.3.6
-- Add time support to `SHOW TAG VALUES`
-- Add distributed `SHOW TAG KEYS` with time support
-
-### Bug fixes
-
-- Add `X-Influxdb-Build` to http response headers so users can identify if a response is from an InfluxDB OSS or InfluxDB Enterprise service.
-- Ensure that permissions cannot be set on non-existent databases.
-- Switch back to using `cluster-tracing` config option to enable meta HTTP request logging.
-- `influxd-ctl restore -newdb` can't restore data.
-- Close connection for remote iterators after EOF to avoid writer hanging indefinitely.
-- Data race reading `Len()` in connection pool.
-- Use InfluxData fork of `yamux`. This update reduces overall memory usage when streaming large amounts of data.
-- Fix group by marshaling in the IteratorOptions.
-- Meta service data race.
-- Read for the interrupt signal from the stream before creating the iterators.
-- Show retention policies requires the `createdatabase` permission
-- Handle UTF files with a byte order mark when reading the configuration files.
-- Remove the pidfile after the server has exited.
-- Resend authentication credentials on redirect.
-- Updated yamux resolves race condition when SYN is successfully sent and a write timeout occurs.
-- Fix no license message.
-
-# Clustering
+* Elide "stream closed" error from logs and handle io.EOF as remote iterator interrupt.
+* Fix spurious "rpc error: i/o deadline exceeded" errors
+* Elide "stream closed" error from logs and handle io.EOF as remote iterator interrupt.
+* Discard remote iterators that label their type as unknown.
+* Do not queue `partial write` errors to hinted handoff.
 
 ## v1.3.8 [2017-12-04]
 

--- a/content/enterprise_influxdb/v1.5/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.5/about-the-project/release-notes-changelog.md
@@ -92,9 +92,8 @@ so it will require downtime.
 
 ### Bugfixes
 
-* Elide "stream closed" error from logs and handle io.EOF as remote iterator interrupt.
-* Fix spurious "rpc error: i/o deadline exceeded" errors
-* Elide "stream closed" error from logs and handle io.EOF as remote iterator interrupt.
+* Elide `stream closed` error from logs and handle `io.EOF` as remote iterator interrupt.
+* Fix spurious `rpc error: i/o deadline exceeded` errors
 * Discard remote iterators that label their type as unknown.
 * Do not queue `partial write` errors to hinted handoff.
 


### PR DESCRIPTION
Removed 1.4.x releases which didn't exist publicly. All feature additions and bug fixes added to the 1.5.0 release.
Also, re-added the 1.3.9 release, which seems to have been removed.