### PR TITLE
upgrading: Use whitespace to avoid accidental fractions

### DIFF
--- a/content/influxdb/v1.5/administration/upgrading.md
+++ b/content/influxdb/v1.5/administration/upgrading.md
@@ -8,12 +8,12 @@ menu:
     parent: administration
 ---
 
-* [Upgrading from 1.3/1.4 (no TSI Preview) to 1.5.x (TSI enabled)](#upgrading-from-13-14-no-tsi-preview-to-15-tsi-enabled)
+* [Upgrading from 1.3 / 1.4 (no TSI Preview) to 1.5.x (TSI enabled)](#upgrading-from-13-14-no-tsi-preview-to-15-tsi-enabled)
 * [Upgrading from 1.4 (TSI Preview enabled) to 1.5.x (TSI enabled)](#upgrading-from-13-14-tsi-preview-enabled-to-15-tsi-enabled)
 * [Upgrading from 1.3 to 1.5.x (TSI enabled)](#upgrading-from-13-to-15-tsi-enabled)
 * [Upgrading InfluxDB Enterprise clusters](#upgrading-influxdb-enterprise-clusters)
 
-## Upgrading from 1.3/1.4 (no TSI Preview) to 1.5.x (TSI enabled)
+## Upgrading from 1.3 / 1.4 (no TSI Preview) to 1.5.x (TSI enabled)
 
 Starting with the InfluxDB 1.5 release, enabling Time Series Index (TSI) is recommended for all customers. To learn more about TSI, see:
 


### PR DESCRIPTION
When referring to versions 1.3 and 1.4 together, writing "1.3/1.4"
tricks Hugo in to thinking that the "3/1" bit is a fraction, so then
it renders the whole thing as:

    1.<sup>3</sup>&frasl;<sub>1</sub>.4

which is clearly wrong.  Avoid the whole thing by sticking some spaces
in there and writing "1.3 / 1.4".