### PR TITLE
Fix http://localhost:1313 links

### DIFF
--- a/content/enterprise_influxdb/v1.5/guides/_index.md
+++ b/content/enterprise_influxdb/v1.5/guides/_index.md
@@ -11,5 +11,5 @@ menu:
 ## [Backing up and restoring in InfluxDB Enterprise](/enterprise_influxdb/v1.5/administration/backup-and-restore/)
 ## [Fine-grained authorization in InfluxDB Enterprise](/enterprise_influxdb/v1.5/guides/fine-grained-authorization/)
 ## [Migrating InfluxDB OSS instances to InfluxDB Enterprise clusters](/enterprise_influxdb/v1.5/guides/migration/)
-## [Rebalancing InfluxDB Enterprise clusters](http://localhost:1313/enterprise_influxdb/v1.5/guides/rebalance/)
+## [Rebalancing InfluxDB Enterprise clusters](/enterprise_influxdb/v1.5/guides/rebalance/)
 ## [SMTP server setup](/enterprise_influxdb/v1.5/guides/smtp-server/)

--- a/content/influxdb/v1.5/write_protocols/line_protocol_tutorial.md
+++ b/content/influxdb/v1.5/write_protocols/line_protocol_tutorial.md
@@ -11,7 +11,7 @@ menu:
 InfluxDB's Line Protocol is a text based format for writing points to the
 database.
 Points must be in Line Protocol format for InfluxDB to successfully parse and
-write points (unless you're using a [service plugin](http://localhost:1313/influxdb/v1.5/supported_protocols/)).
+write points (unless you're using a [service plugin](/influxdb/v1.5/supported_protocols/)).
 
 Using fictional temperature data, this page introduces Line Protocol.
 It covers:


### PR DESCRIPTION
A couple of links are rooted at "http://localhost:1313/" instead of "/",
which means they work with the local `hugo server`, but not when deployed
at https://docs.influxdata.com/