### PR TITLE
Fixing an open parenthesis in a link (line 322)

### DIFF
--- a/content/influxdb/v1.5/administration/config.md
+++ b/content/influxdb/v1.5/administration/config.md
@@ -319,7 +319,7 @@ Environment variable: `INFLUXDB_DATA_MAX_SERIES_PER_DATABASE`
 ### `max-values-per-tag = 100000`
 
 The maximum number of [tag values](/influxdb/v1.5/concepts/glossary/#tag-value)
-allowed per [tag key]((/influxdb/v1.5/concepts/glossary/#tag-key).
+allowed per [tag key](/influxdb/v1.5/concepts/glossary/#tag-key).
 The default setting is `100000`.
 Change the setting to `0` to allow an unlimited number of tag values per tag
 key.


### PR DESCRIPTION
<img width="1177" alt="link_broken_in_influxdata_documentation" src="https://user-images.githubusercontent.com/8016962/39236747-ddb693d6-4879-11e8-8564-147dd018e538.png">
