### PR TITLE
Add missing argument to backup_and_restore.md

### DIFF
--- a/content/influxdb/v1.5/administration/backup_and_restore.md
+++ b/content/influxdb/v1.5/administration/backup_and_restore.md
@@ -122,6 +122,7 @@ An online `restore` process is initiated by using the `restore` command with eit
 influxd restore [ -db <db_name> ]
     -portable | -online
     [ -host <host:port> ]
+    [ -newdb <newdb_name> ]
     [ -rp <rp_name> ]
     [ -newrp <newrp_name> ]
     [ -shard <shard_ID> ]


### PR DESCRIPTION
The `restore` example was missing the `[ -newdb <newdb_name> ]` optional argument from the usage example.