### PR TITLE
Fix Typo: meta node != data node - fix #1633

### DIFF
--- a/content/enterprise_influxdb/v1.5/guides/replacing-nodes.md
+++ b/content/enterprise_influxdb/v1.5/guides/replacing-nodes.md
@@ -249,7 +249,7 @@ influxd-ctl update-data enterprise-data-01:8088 enterprise-data-03:8088
 
 ### 3. Confirm the data node was added
 
-Confirm the new meta-node has been added by running:
+Confirm the new data node has been added by running:
 
 ```bash
 influxd-ctl show


### PR DESCRIPTION
The first line of text under the heading "Confirm the data node was added" is "Confirm the new meta-node has been added by running:" -- this should read "Confirm the new data node has been added by running:"

I expect the text was copied from section 2.4 and incompletely mutated.

Close issue #1633