### PR TITLE
Update GitHub Oauth instructions to use token-secret command line option

### DIFF
--- a/content/chronograf/v1.5/administration/managing-security.md
+++ b/content/chronograf/v1.5/administration/managing-security.md
@@ -149,7 +149,7 @@ The following steps will guide you in configuring Chronograf to support GitHub O
 
     * [`--github-client-id=`](/chronograf/v1.5/administration/configuration/#github-client-id)
     * [`--github-client-secret=`](/chronograf/v1.5/administration/configuration/#github-client-secret)
-    * [`--token_secret=`](/chronograf/v1.5/administration/config-options.md#--token-secret---t)
+    * [`--token-secret=`](/chronograf/v1.5/administration/config-options.md#--token-secret---t)
 
 #### Optional GitHub organizations
 


### PR DESCRIPTION
I found issue in the GitHub OAuth provider documentation:  the test case

a) . I configured using the variable `--token_secret` per documentation.  Was getting errors.

b).  Updated to follow convention with other variables ( `--token-secret`), and things seemed to work.

Test case (OS X from `brew install chronograf`):

```
    <string>homebrew.mxcl.chronograf</string>
    <key>ProgramArguments</key>
    <array>
      <string>/usr/local/opt/chronograf/bin/chronograf</string>
      <string>--public-url=http://localhost:8888</string>
      <string>--github-client-id=REDACT</string>
      <string>--github-client-secret=REDACT</string>
      <string>--token-secret=REDACT</string>
    </array>
```