### PR TITLE
Update to include deletetsm command.

### DIFF
--- a/content/influxdb/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.5/about_the_project/releasenotes-changelog.md
@@ -9,6 +9,10 @@ menu:
 
 ## v1.5.4 [2018-06-21]
 
+### Features
+
+* Add `influx_inspect deletetsm`.
+
 ### Bug fixes
 
 * Fix panic in readTombstoneV4.

--- a/content/influxdb/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.5/about_the_project/releasenotes-changelog.md
@@ -11,7 +11,7 @@ menu:
 
 ### Features
 
-* Add `influx_inspect deletetsm`.
+* Add `influx_inspect deletetsm` command for bulk deletes of measurements in raw TSM files.
 
 ### Bug fixes
 

--- a/content/influxdb/v1.5/tools/influx_inspect.md
+++ b/content/influxdb/v1.5/tools/influx_inspect.md
@@ -96,7 +96,7 @@ $ influx_inspect buildtsi -database stress -shard 1 -datadir ~/.influxdb/data -w
 
 ### `influx_inspect deletetsm`
 
-Bulk deletes a measurement from raw TSM files.
+Bulk deletes a measurement from a raw TSM file.
 
 #### Syntax
 
@@ -105,7 +105,7 @@ influx_inspect deletetsm -measurement <measurement_name> [ arguments ] <path>
 ````
 ##### `<path>`
 
-Path to the TSM files.
+Path to the `.tsm` file, located by default in the `data` directory.
 
 #### Arguments
 

--- a/content/influxdb/v1.5/tools/influx_inspect.md
+++ b/content/influxdb/v1.5/tools/influx_inspect.md
@@ -20,7 +20,7 @@ Influx Inspect is a disk shard utility that can be used to:
 The `influx_inspect` commands are:
 
 * [`buildtsi`](#influx-inspect-buildtsi): Converts in-memory (TSM-based) shards to TSI.
-* [`deletetsm`](#influx-inspect-deletetsm):
+* [`deletetsm`](#influx-inspect-deletetsm): Bulk deletes a measurement from raw TSM files.
 * [`dumptsi`](#influx-inspect-dumptsi): Dumps low-level details about TSI files.
 * [`dumptsm`](#influx-inspect-dumptsm): Dumps low-level details about TSM files.
 * [`export`](#influx-inspect-export): Exports raw data from a shard to Line Protocol format.
@@ -96,26 +96,30 @@ $ influx_inspect buildtsi -database stress -shard 1 -datadir ~/.influxdb/data -w
 
 ### `influx_inspect deletetsm`
 
+Bulk deletes a measurement from raw TSM files.
 
 #### Syntax
 
 ````
-influx_inspect deletetsm [ arguments ] <path>
+influx_inspect deletetsm -measurement <measurement_name> [ arguments ] <path>
 ````
+##### `<path>`
+
+Path to the TSM files.
 
 #### Arguments
 
 Optional arguments are in brackets.
 
-##### [ `-measurement` ]
+##### `-measurement`
 
-Name of the measurement to delete.
+The name of the measurement to delete from TSM files.
 
 ##### [ `-sanitize` ]
 
-Flag to remove all keys with non-printable Unicode.
+Flag to remove all keys containing non-printable Unicode characters.
 
-##### [ `-verbose` ]
+##### [ `-v` ]
 
 Flag to enable verbose logging.
 

--- a/content/influxdb/v1.5/tools/influx_inspect.md
+++ b/content/influxdb/v1.5/tools/influx_inspect.md
@@ -20,6 +20,7 @@ Influx Inspect is a disk shard utility that can be used to:
 The `influx_inspect` commands are:
 
 * [`buildtsi`](#influx-inspect-buildtsi): Converts in-memory (TSM-based) shards to TSI.
+* [`deletetsm`](#influx-inspect-deletetsm):
 * [`dumptsi`](#influx-inspect-dumptsi): Dumps low-level details about TSI files.
 * [`dumptsm`](#influx-inspect-dumptsm): Dumps low-level details about TSM files.
 * [`export`](#influx-inspect-export): Exports raw data from a shard to Line Protocol format.
@@ -92,6 +93,32 @@ $ influx_inspect buildtsi -database mydb -datadir ~/.influxdb/data -waldir ~/.in
 ```
 $ influx_inspect buildtsi -database stress -shard 1 -datadir ~/.influxdb/data -waldir ~/.influxdb/wal
 ```
+
+### `influx_inspect deletetsm`
+
+
+#### Syntax
+
+````
+influx_inspect deletetsm [ arguments ] <path>
+````
+
+#### Arguments
+
+Optional arguments are in brackets.
+
+##### [ `-measurement` ]
+
+Name of the measurement to delete.
+
+##### [ `-sanitize` ]
+
+Flag to remove all keys with non-printable Unicode.
+
+##### [ `-verbose` ]
+
+Flag to enable verbose logging.
+
 
 ### `influx_inspect dumptsi`
 


### PR DESCRIPTION
This update adds missing feature to release notes and influx_inspect utility documentation.

Is there anything I need to mention in docs about:
* time ranges
* TSM file or files?
* <path> - to a file or directory?

Content based on: [1.5] influx_inspect deletetsm #9960 and related issues.