### PR TITLE
Update homebrew start instructions

### DIFF
--- a/content/influxdb/v1.5/introduction/installation.md
+++ b/content/influxdb/v1.5/introduction/installation.md
@@ -169,16 +169,10 @@ brew update
 brew install influxdb
 ```
 
-To have `launchd` start InfluxDB at login, run:
+To have `launchd` start InfluxDB now and restart at login, run:
 
 ```bash
-ln -sfv /usr/local/opt/influxdb/*.plist ~/Library/LaunchAgents
-```
-
-And then to start InfluxDB now, run:
-
-```bash
-launchctl load ~/Library/LaunchAgents/homebrew.mxcl.influxdb.plist
+brew services start influxdb
 ```
 
 Or, if you don't want/need launchctl, in a separate terminal window you can just run:


### PR DESCRIPTION
Prior to this commit the homebrew startup instructions referenced the old launchctl/plist pattern.
This commit updates to the newer `brew services` method.
<img width="965" alt="screen shot 2018-06-26 at 4 31 07 pm" src="https://user-images.githubusercontent.com/818053/41944819-b8abd4b4-795e-11e8-9057-e8d95e4c3df5.png">
