### PR TITLE
Influxdb 1.6 deletetsm fix

### DIFF
--- a/content/influxdb/v1.5/tools/influx_inspect.md
+++ b/content/influxdb/v1.5/tools/influx_inspect.md
@@ -28,8 +28,9 @@ influx_inspect [ [ command ] [ options ] ]`
 The `influx_inspect` commands are summarized here, with links to detailed information on each of the commands.
 
 * [`buildtsi`](#buildtsi): Convert in-memory (TSM-based) shards to TSI
+* [`deletetsm`](#deletetsm): Bulk deletes a measurement from a raw TSM file.
 * [`dumptsi`](#dumptsi): Dump low-level details about TSI files.
-* [`dumptsm`](#dumptsm): Dump low-level details about TSM files. 
+* [`dumptsm`](#dumptsm): Dump low-level details about TSM files.
 * [`export`](#export): Export raw data from a shard in Line Protocol format.
 * [`help`](#help): Display this help message format.
 * [`report`](#report): Display a shard level report.

--- a/content/influxdb/v1.5/tools/influx_inspect.md
+++ b/content/influxdb/v1.5/tools/influx_inspect.md
@@ -123,6 +123,21 @@ influx_inspect deletetsm -measurement <measurement_name> [ arguments ] <path>
 
 Path to the `.tsm` file, located by default in the `data` directory.
 
+When specifying the path, wildcards (`*`) can replace one or more characters.
+
+###### Examples
+
+Single shard:
+
+```
+./influx_inspect deletetsm -sanitize /influxdb/data/location/autogen/1384/*.tsm
+```
+All shards in the database:
+
+```
+./influx_inspect deletetsm -sanitize /influxdb/data/location/autogen/*/*.tsm
+```
+
 #### Arguments
 
 Optional arguments are in brackets.

--- a/content/influxdb/v1.6/tools/influx_inspect.md
+++ b/content/influxdb/v1.6/tools/influx_inspect.md
@@ -124,6 +124,21 @@ influx_inspect deletetsm -measurement <measurement_name> [ arguments ] <path>
 
 Path to the `.tsm` file, located by default in the `data` directory.
 
+When specifying the path, wildcards (`*`) can replace one or more characters.
+
+###### Examples
+
+Single shard:
+
+```
+./influx_inspect deletetsm -sanitize /influxdb/data/location/autogen/1384/*.tsm
+```
+All shards in the database:
+
+```
+./influx_inspect deletetsm -sanitize /influxdb/data/location/autogen/*/*.tsm
+```
+
 #### Arguments
 
 Optional arguments are in brackets.

--- a/content/influxdb/v1.6/tools/influx_inspect.md
+++ b/content/influxdb/v1.6/tools/influx_inspect.md
@@ -27,7 +27,8 @@ influx_inspect [ [ command ] [ options ] ]`
 
 The `influx_inspect` commands are summarized here, with links to detailed information on each of the commands.
 
-* [`buildtsi`](#buildtsi): Convert in-memory (TSM-based) shards to TSI
+* [`buildtsi`](#buildtsi): Convert in-memory (TSM-based) shards to TSI.
+* [`deletetsm`](#deletetsm): Bulk deletes a measurement from a raw TSM file.
 * [`dumptsi`](#dumptsi): Dump low-level details about TSI files.
 * [`dumptsm`](#dumptsm): Dump low-level details about TSM files.
 * [`dumptsmwal`](#dumptsmwal): Dump all data from a WAL file.  
@@ -108,6 +109,38 @@ $ influx_inspect buildtsi -database mydb -datadir ~/.influxdb/data -waldir ~/.in
 $ influx_inspect buildtsi -database stress -shard 1 -datadir ~/.influxdb/data -waldir ~/.influxdb/wal
 ```
 
+### `deletetsm`
+
+Bulk deletes a measurement from a raw TSM file.
+
+<dt> **Warning:** Use the `deletetsm` command only when your InfluxDB instance is offline (`influxd` service is not running).</dt>
+
+#### Syntax
+
+````
+influx_inspect deletetsm -measurement <measurement_name> [ arguments ] <path>
+````
+##### `<path>`
+
+Path to the `.tsm` file, located by default in the `data` directory.
+
+#### Arguments
+
+Optional arguments are in brackets.
+
+##### `-measurement`
+
+The name of the measurement to delete from TSM files.
+
+##### [ `-sanitize` ]
+
+Flag to remove all keys containing non-printable Unicode characters.
+
+##### [ `-v` ]
+
+Flag to enable verbose logging.
+
+
 ### `dumptsi`
 
 Dumps low-level details about TSI files, including `.tsl` log files and `.tsi` index files.
@@ -177,7 +210,7 @@ $ influx_inspect dumptsi -series-file /path/to/db/_series /path/to/index/file0
 $ influx_inspect dumptsi -series-file /path/to/db/_series /path/to/index/file0 /path/to/index/file1 ...
 ```
 
-### `influx_inspect dumptsm`
+### `dumptsm`
 
 Dumps low-level details about [TSM](/influxdb/v1.6/concepts/glossary/#tsm-time-structured-merge-tree) files, including TSM (`.tsm`) files and WAL (`.wal`) files.
 


### PR DESCRIPTION
Adds missing deletetsm to 1.6, adds missing anchor link, and note about wildcards.