### PR TITLE
Updated Chronograf 1.6 changelog

### DIFF
--- a/content/chronograf/v1.6/about_the_project/release-notes-changelog.md
+++ b/content/chronograf/v1.6/about_the_project/release-notes-changelog.md
@@ -8,6 +8,44 @@ menu:
     parent: About the project
 ---
 
+## v1.6.0.0 [2018-07-18]
+
+### Features
+
+- Add support for template variables in cell titles.
+- Add ability to export and import dashboards.
+- Add ability to override template variables and time ranges via URL query.
+- Add pprof routes to Chronograf server.
+- Add API to get/update Log Viewer UI config.
+- Consume new Log Viewer config API in client to allow user to configure log viewer UI for their organization.
+- Add V2 Cells API.
+- Add V2 Dashboard API.
+
+### UI Improvements
+
+- Sort task table on Manage Alert page alphabetically.
+- Redesign icons in side navigation.
+- Remove Snip functionality in hover legend.
+- Upgrade Data Explorer query text field with syntax highlighting and partial multi-line support.
+- Truncate message preview in Alert Rules table.
+- Improve performance of graph crosshairs.
+- Hide dashboard cell menu until mouse over cell.
+- Auto-Scale single-stat text to match cell dimensions.
+
+### Bug Fixes
+
+- Ensure cell queries use constraints from Time Selector.
+- Fix Gauge color selection bug.
+- Fix erroneous icons in Date Picker widget.
+- Fix allowing hyphens in basepath.
+- Fix error in cell when tempVar returns no values.
+- Change arrows in table columns so that ascending sort points up and descending points down.
+- Fix crosshairs moving passed the edges of graphs.
+- Change y-axis options to have valid defaults.
+- Stop making requests for old sources after changing sources.
+- Fix health check status code creating FireFox error.
+- Change decimal places to enforce 2 places by default in cells.
+
 ## v1.5.0.1 [2018-06-04]
 
 ### Bug Fixes

--- a/content/chronograf/v1.6/about_the_project/release-notes-changelog.md
+++ b/content/chronograf/v1.6/about_the_project/release-notes-changelog.md
@@ -12,37 +12,37 @@ menu:
 
 ### Features
 
-- Add support for template variables in cell titles.
-- Add ability to export and import dashboards.
-- Add ability to override template variables and time ranges via URL query.
-- Add pprof routes to chronograf server.
-- Add API to get/update Log Viewer UI config.
-- Consume new Log Viewer config API in client to allow user to configure log viewer UI for their organization.
+* Add support for template variables in cell titles.
+* Add ability to export and import dashboards.
+* Add ability to override template variables and time ranges via URL query.
+* Add pprof routes to chronograf server.
+* Add API to get/update Log Viewer UI config.
+* Consume new Log Viewer config API in client to allow user to configure log viewer UI for their organization.
 
 ### UI Improvements
 
-- Sort task table on Manage Alert page alphabetically.
-- Redesign icons in side navigation.
-- Remove Snip functionality in hover legend.
-- Upgrade Data Explorer query text field with syntax highlighting and partial multi-line support.
-- Truncate message preview in Alert Rules table.
-- Improve performance of graph crosshairs.
-- Hide dashboard cell menu until mouse over cell.
-- Auto-Scale single-stat text to match cell dimensions.
+* Sort task table on Manage Alert page alphabetically.
+* Redesign icons in side navigation.
+* Remove Snip functionality in hover legend.
+* Upgrade Data Explorer query text field with syntax highlighting and partial multi-line support.
+* Truncate message preview in Alert Rules table.
+* Improve performance of graph crosshairs.
+* Hide dashboard cell menu until mouse over cell.
+* Auto-Scale single-stat text to match cell dimensions.
 
 ### Bug Fixes
 
-- Ensure cell queries use constraints from TimeSelector.
-- Fix Gauge color selection bug.
-- Fix erroneous icons in Date Picker widget.
-- Fix allowing hyphens in basepath.
-- Fix error in cell when tempVar returns no values.
-- Change arrows in table columns so that ascending sort points up and descending points down.
-- Fix crosshairs moving passed the edges of graphs.
-- Change y-axis options to have valid defaults.
-- Stop making requests for old sources after changing sources.
-- Fix health check status code creating FireFox error.
-- Change decimal places to enforce 2 places by default in cells.
+* Ensure cell queries use constraints from TimeSelector.
+* Fix Gauge color selection bug.
+* Fix erroneous icons in Date Picker widget.
+* Fix allowing hyphens in basepath.
+* Fix error in cell when tempVar returns no values.
+* Change arrows in table columns so that ascending sort points up and descending points down.
+* Fix crosshairs moving passed the edges of graphs.
+* Change y-axis options to have valid defaults.
+* Stop making requests for old sources after changing sources.
+* Fix health check status code creating FireFox error.
+* Change decimal places to enforce 2 places by default in cells.
 
 
 ## v1.5.0.1 [2018-06-04]

--- a/content/chronograf/v1.6/about_the_project/release-notes-changelog.md
+++ b/content/chronograf/v1.6/about_the_project/release-notes-changelog.md
@@ -8,7 +8,7 @@ menu:
     parent: About the project
 ---
 
-## v1.6.0.0 [2018-07-18]
+## v1.6.0 [2018-07-18]
 
 ### Features
 

--- a/content/chronograf/v1.6/about_the_project/release-notes-changelog.md
+++ b/content/chronograf/v1.6/about_the_project/release-notes-changelog.md
@@ -15,11 +15,9 @@ menu:
 - Add support for template variables in cell titles.
 - Add ability to export and import dashboards.
 - Add ability to override template variables and time ranges via URL query.
-- Add pprof routes to Chronograf server.
+- Add pprof routes to chronograf server.
 - Add API to get/update Log Viewer UI config.
 - Consume new Log Viewer config API in client to allow user to configure log viewer UI for their organization.
-- Add V2 Cells API.
-- Add V2 Dashboard API.
 
 ### UI Improvements
 
@@ -34,7 +32,7 @@ menu:
 
 ### Bug Fixes
 
-- Ensure cell queries use constraints from Time Selector.
+- Ensure cell queries use constraints from TimeSelector.
 - Fix Gauge color selection bug.
 - Fix erroneous icons in Date Picker widget.
 - Fix allowing hyphens in basepath.
@@ -45,6 +43,7 @@ menu:
 - Stop making requests for old sources after changing sources.
 - Fix health check status code creating FireFox error.
 - Change decimal places to enforce 2 places by default in cells.
+
 
 ## v1.5.0.1 [2018-06-04]
 


### PR DESCRIPTION
Note that there was a Flux Editor release note in the chronograf `master` changelog that I left out of this one since the Flux Editor is landing in 1.7.