### PR TITLE
Influxdb 1.6.1 oss fixes

### DIFF
--- a/content/influxdb/v1.5/administration/https_setup.md
+++ b/content/influxdb/v1.5/administration/https_setup.md
@@ -121,7 +121,7 @@ InfluxDB shell version: 1.x.x
 
 That's it! You've successfully set up HTTPS with InfluxDB.
 
-## Setup HTTPS with a Self-Signed Certificate
+## Setup HTTPS with a self-signed certificate
 
 #### Step 1: Generate a self-signed certificate
 
@@ -164,14 +164,14 @@ Enable HTTPS in InfluxDB's the `[http]` section of the configuration file (`/etc
   https-private-key = "/etc/ssl/influxdb-selfsigned.key"
 ```
 
-#### Step 3: Restart InfluxDB
+#### Step 3: Restart the InfluxDB service
 
-Restart the InfluxDB process for the configuration changes to take effect:
+Restart the InfluxDB service for the configuration changes to take effect:
 ```bash
 sudo systemctl restart influxdb
 ```
 
-#### Step 4: Verify the HTTPS Setup
+#### Step 4: Verify the HTTPS setup
 
 Verify that HTTPS is working by connecting to InfluxDB with the [CLI tool](/influxdb/v1.5/tools/shell/):
 ```bash
@@ -237,6 +237,7 @@ sudo openssl ca -infiles /etc/ssl/<client-certificate-file>.csr -out /etc/ssl/<c
 ```
 
 #### Step 2: Ensure file permissions
+
 Certificate files require read and write access by the `root` user.
 Ensure that you have the correct file permissions by running the following
 commands:

--- a/content/influxdb/v1.6/administration/config.md
+++ b/content/influxdb/v1.6/administration/config.md
@@ -334,6 +334,11 @@ will fail.
 
 Environment variable: `INFLUXDB_DATA_MAX_VALUES_PER_TAG`
 
+### `tsm-use-madv-willneed = false`
+
+If true, then the mmap advise value `MADV_WILLNEED` will be provided to the kernel with respect to TSM files. This setting has been found to be problematic on some kernels, and defaults to off. It might help users who have slow disks in some cases.
+
+
 ## Query management settings `[coordinator]`
 
 This section contains configuration settings for query management.

--- a/content/influxdb/v1.6/administration/config.md
+++ b/content/influxdb/v1.6/administration/config.md
@@ -13,6 +13,8 @@ The InfluxDB OSS configuration file contains configuration settings specific to 
 
 * [Configuration overview](#configuration-overview)
 * [Environment variables](#environment-variables)
+  * [InfluxDB environment variables (`INFLUXDB_*`)](#influxdb-environment-variables-influxdb)
+  * [`GOMAXPROCS` environment variable](#gomaxprocs-environment-variable)
 * [Using the configuration file](#using-the-configuration-file)
 * [Configuration file settings](#configuration-file-settings)
   * [Global settings](#global-settings)
@@ -59,12 +61,12 @@ If a configuration option is not specified in either the configuration file or i
 
 > ***Note:*** If an environment variable has already been set, the equivalent configuration setting in the configuration file is ignored.
 
-#### InfluxDB environment variables (`INFLUXDB_*`)
+### InfluxDB environment variables (`INFLUXDB_*`)
 
 The InfluxDB environment variables are documented below with the corresponding configuration file settings. All of the InfluxDB-specific environment variables are prefixed with `INFLUXDB_`.
 
 
-#### `GOMAXPROCS`
+### `GOMAXPROCS` environment variable
 
 > ***Note:*** The GOMAXPROCS environment variable cannot be set using the InfluxDB configuration file settings, like other environment variables.
 
@@ -291,7 +293,7 @@ Environment variable: `INFLUXDB_DATA_COMPACT_FULL_WRITE_COLD_DURATION`
 The maximum number of concurrent full and level [compactions](/influxdb/v1.6/concepts/storage_engine/#compactions) that can run at one time.
 A value of `0` results in `runtime.GOMAXPROCS(0)` being used at runtime — all processors are available.
 If explicitly set, the number of cores used for compaction is limited to the specified value.
-This setting does not apply to cache snapshotting.
+This setting does not apply to cache snapshotting. For more information on GOMAXPROCS environment variable, see the [`GOMAXPROCS` environment variable](#gomaxprocs-environment-variable) section on this page. 
 
 Environment variable: `INFLUXDB_DATA_MAX_CONCURRENT_COMPACTIONS`
 
@@ -335,7 +337,8 @@ Environment variable: `INFLUXDB_DATA_MAX_VALUES_PER_TAG`
 
 ### `tsm-use-madv-willneed = false`
 
-If `true`, then the MMap Advise value `MADV_WILLNEED` advises the kernel about how to handle the mapped memory region in terms of input/output paging and to expect access to the mapped memory region in the near future, with respect to TSM files. Because this setting has been problematic on some kernels, the default is `false`. Changing the value to `true` might help users who have slow disks in some cases.
+If `true`, then the MMap Advise value `MADV_WILLNEED` advises the kernel about how to handle the mapped memory region in terms of input/output paging and to expect access to the mapped memory region in the near future, with respect to TSM files. Because this setting has been problematic on some kernels, the default is `false`. 
+Changing the value to `true` might help users who have slow disks in some cases.
 
 Environment variable: `INFLUXDB_TSM_USE_MADV_WILLNEED`
 

--- a/content/influxdb/v1.6/administration/config.md
+++ b/content/influxdb/v1.6/administration/config.md
@@ -1035,10 +1035,16 @@ Global configuration settings for Transport Layer Security (TLS) in InfluxDB.
 
 Determines the available set of cipher suites. See the https://golang.org/pkg/crypto/tls/#pkg-constants for a list of available ciphers, which depends on the version of Go (use the query `SHOW DIAGNOSTICS` to see the version of Go used to build InfluxDB). If not specified, uses the default settings from the Go `crypto/tls` package.
 
+Environment variable: `INFLUXDB_TLS_CIPHERS`
+
 ### `min-version = "tls1.2"`
 
 Minimum version of the TLS protocol that will be negotiated. If not specified, uses the default settings from the Go `crypto/tls` package.
 
+Environment variable: `INFLUXDB_TLS_MIN_VERSION`
+
 ### `max-version = "tls1.2"`
 
 Maximum version of the TLS protocol that will be negotiated. If not specified, uses the default settings from the Go `crypto/tls` package.
+
+Environment variable: `INFLUXDB_TLS_MAX_VERSION`

--- a/content/influxdb/v1.6/administration/config.md
+++ b/content/influxdb/v1.6/administration/config.md
@@ -29,6 +29,7 @@ The InfluxDB OSS configuration file contains configuration settings specific to 
   * [OpenTSB settings `[[opentsdb]]`](#opentsdb-settings-opentsdb)
   * [UDP settings `[[udp]]`](#udp-settings-udp)
   * [Continuous queries settings `[continuous_queries]`](#continuous-queries-settings-continuous-queries)
+  * [Transport Layer Security (TLS) settings `[tls]`](#transport-layer-security-tls-settings-tls)
 
 ## Configuration overview
 
@@ -1024,3 +1025,20 @@ Environment variable: `INFLUXDB_CONTINUOUS_QUERIES_QUERY_STATS_ENABLED`
 The interval at which InfluxDB checks to see if a CQ needs to run. Set this option to the lowest interval at which your CQs run. For example, if your most frequent CQ runs every minute, set `run-interval` to `1m`.
 
 Environment variable: `INFLUXDB_CONTINUOUS_QUERIES_RUN_INTERVAL`
+
+
+## Transport Layer Security (TLS) settings `[tls]`
+
+Global configuration settings for Transport Layer Security (TLS) in InfluxDB.
+
+### `ciphers = [ "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", ]`
+
+Determines the available set of cipher suites. See the https://golang.org/pkg/crypto/tls/#pkg-constants for a list of available ciphers, which depends on the version of Go (use the query `SHOW DIAGNOSTICS` to see the version of Go used to build InfluxDB). If not specified, uses the default settings from the Go `crypto/tls` package.
+
+### `min-version = "tls1.2"`
+
+Minimum version of the TLS protocol that will be negotiated. If not specified, uses the default settings from the Go `crypto/tls` package.
+
+### `max-version = "tls1.2"`
+
+Maximum version of the TLS protocol that will be negotiated. If not specified, uses the default settings from the Go `crypto/tls` package.

--- a/content/influxdb/v1.6/administration/config.md
+++ b/content/influxdb/v1.6/administration/config.md
@@ -58,7 +58,6 @@ file.
 If a configuration option is not specified in either the configuration file or in an environment variable, InfluxDB uses its internal default configuration.
 
 > ***Note:*** If an environment variable has already been set, the equivalent configuration setting in the configuration file is ignored.
->
 
 #### InfluxDB environment variables (`INFLUXDB_*`)
 
@@ -67,8 +66,7 @@ The InfluxDB environment variables are documented below with the corresponding c
 
 #### `GOMAXPROCS`
 
-> ***Note:***
-> The GOMAXPROCS environment variable cannot be set using the InfluxDB configuration file settings, like other environment variables.
+> ***Note:*** The GOMAXPROCS environment variable cannot be set using the InfluxDB configuration file settings, like other environment variables.
 
 
 The `GOMAXPROCS` [Go language environment variable](https://golang.org/pkg/runtime/#hdr-Environment_Variables) can be used to set the maximum number of CPUs that can execute simultaneously.
@@ -291,7 +289,8 @@ Environment variable: `INFLUXDB_DATA_COMPACT_FULL_WRITE_COLD_DURATION`
 ### `max-concurrent-compactions = 0`
 
 The maximum number of concurrent full and level [compactions](/influxdb/v1.6/concepts/storage_engine/#compactions) that can run at one time.
-A value of `0` results in `runtime.GOMAXPROCS(0)` used at runtime -- which means use all processors.
+A value of `0` results in `runtime.GOMAXPROCS(0)` being used at runtime — all processors are available.
+If explicitly set, the number of cores used for compaction is limited to the specified value.
 This setting does not apply to cache snapshotting.
 
 Environment variable: `INFLUXDB_DATA_MAX_CONCURRENT_COMPACTIONS`
@@ -336,8 +335,9 @@ Environment variable: `INFLUXDB_DATA_MAX_VALUES_PER_TAG`
 
 ### `tsm-use-madv-willneed = false`
 
-If true, then the mmap advise value `MADV_WILLNEED` will be provided to the kernel with respect to TSM files. This setting has been found to be problematic on some kernels, and defaults to off. It might help users who have slow disks in some cases.
+If `true`, then the MMap Advise value `MADV_WILLNEED` advises the kernel about how to handle the mapped memory region in terms of input/output paging and to expect access to the mapped memory region in the near future, with respect to TSM files. Because this setting has been problematic on some kernels, the default is `false`. Changing the value to `true` might help users who have slow disks in some cases.
 
+Environment variable: `INFLUXDB_TSM_USE_MADV_WILLNEED`
 
 ## Query management settings `[coordinator]`
 

--- a/content/influxdb/v1.6/administration/config.md
+++ b/content/influxdb/v1.6/administration/config.md
@@ -1035,18 +1035,18 @@ The InfluxDB default values for TLS `ciphers`, `min-version`, and `max-version` 
 
 ### `ciphers = [ "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", ]`
 
-Specifies the set of cipher suite IDs to negotiate. If not specified, uses the list of values from the Go `crypto/tls` package.
+Specifies the set of cipher suite IDs to negotiate. If not specified, `ciphers` uses the list of values from the Go `crypto/tls` package. In this example, only the two specified cipher suite IDs would be supported.
 
 Environment variable: `INFLUXDB_TLS_CIPHERS`
 
 ### `min-version = "tls1.2"`
 
-Minimum version of the TLS protocol that will be negotiated. If not specified, uses the minimum TLS value specified in the Go `crypto/tls` package. In this example, `tls1.2` specifies the same version as the `max-version` example, which would result in support for only TLS 1.2.
+Minimum version of the TLS protocol that will be negotiated. If not specified, `min-version` uses the minimum TLS value specified in the Go `crypto/tls` package. In this example, `tls1.2` specifies the same version as the `max-version` example, which would result in support for only TLS 1.2.
 
 Environment variable: `INFLUXDB_TLS_MIN_VERSION`
 
 ### `max-version = "tls1.2"`
 
-Maximum version of the TLS protocol that will be negotiated. If not specified, uses the maximum TLS value specified in the Go `crypto/tls` package. In this example, `tls1.2` specifies the same version as the `min-version` example, which would result in support for only TLS 1.2.
+Maximum version of the TLS protocol that will be negotiated. If not specified, `max-version` uses the maximum TLS value specified in the Go `crypto/tls` package. In this example, `tls1.2` specifies the same version as the `min-version` example, which would result in support for only TLS 1.2.
 
 Environment variable: `INFLUXDB_TLS_MAX_VERSION`

--- a/content/influxdb/v1.6/administration/config.md
+++ b/content/influxdb/v1.6/administration/config.md
@@ -1029,22 +1029,24 @@ Environment variable: `INFLUXDB_CONTINUOUS_QUERIES_RUN_INTERVAL`
 
 ## Transport Layer Security (TLS) settings `[tls]`
 
-Global configuration settings for Transport Layer Security (TLS) in InfluxDB.
+Global configuration settings for Transport Layer Security (TLS) in InfluxDB.  
+
+The InfluxDB default values for TLS `ciphers`, `min-version`, and `max-version` are listed in the [Constants section of the Go `crypto/tls` package documentation](https://golang.org/pkg/crypto/tls/#pkg-constants) and depend on the version of Go. Use the `SHOW DIAGNOSTICS` command to see the version of Go used to build InfluxDB.
 
 ### `ciphers = [ "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", ]`
 
-Determines the available set of cipher suites. See the https://golang.org/pkg/crypto/tls/#pkg-constants for a list of available ciphers, which depends on the version of Go (use the query `SHOW DIAGNOSTICS` to see the version of Go used to build InfluxDB). If not specified, uses the default settings from the Go `crypto/tls` package.
+Specifies the set of cipher suite IDs to negotiate. If not specified, uses the list of values from the Go `crypto/tls` package.
 
 Environment variable: `INFLUXDB_TLS_CIPHERS`
 
 ### `min-version = "tls1.2"`
 
-Minimum version of the TLS protocol that will be negotiated. If not specified, uses the default settings from the Go `crypto/tls` package.
+Minimum version of the TLS protocol that will be negotiated. If not specified, uses the minimum TLS value specified in the Go `crypto/tls` package. In this example, `tls1.2` specifies the same version as the `max-version` example, which would result in support for only TLS 1.2.
 
 Environment variable: `INFLUXDB_TLS_MIN_VERSION`
 
 ### `max-version = "tls1.2"`
 
-Maximum version of the TLS protocol that will be negotiated. If not specified, uses the default settings from the Go `crypto/tls` package.
+Maximum version of the TLS protocol that will be negotiated. If not specified, uses the maximum TLS value specified in the Go `crypto/tls` package. In this example, `tls1.2` specifies the same version as the `min-version` example, which would result in support for only TLS 1.2.
 
 Environment variable: `INFLUXDB_TLS_MAX_VERSION`

--- a/content/influxdb/v1.6/administration/config.md
+++ b/content/influxdb/v1.6/administration/config.md
@@ -289,9 +289,8 @@ Environment variable: `INFLUXDB_DATA_COMPACT_FULL_WRITE_COLD_DURATION`
 
 ### `max-concurrent-compactions = 0`
 
-The maximum number of concurrent full and level compactions.
-The default value of `0` results in 50% of the CPU cores being used for compactions at runtime.
-With the default setting, at most 4 cores will be used. If explicitly set, the number of cores used for compaction is limited to the specified value.
+The maximum number of concurrent full and level [compactions](/influxdb/v1.6/concepts/storage_engine/#compactions) that can run at one time.
+A value of `0` results in `runtime.GOMAXPROCS(0)` used at runtime -- which means use all processors.
 This setting does not apply to cache snapshotting.
 
 Environment variable: `INFLUXDB_DATA_MAX_CONCURRENT_COMPACTIONS`
@@ -590,7 +589,7 @@ Environment variable: `INFLUXDB_HTTP_MAX_BODY_SIZE`
 
 ### `max-concurrent-write-limit = 0`
 
-The maximum number of writes processed concurrently. 
+The maximum number of writes processed concurrently.
 Setting this to `0` disables the limit.
 
 Environment variable: `INFLUXDB_HTTP_MAX_CONCURRRENT_WRITE_LIMIT`

--- a/content/influxdb/v1.6/administration/https_setup.md
+++ b/content/influxdb/v1.6/administration/https_setup.md
@@ -1,5 +1,6 @@
 ---
-title: Enabling HTTPS with InfluxDB
+title: Enabling HTTPS with
+description: Enable HTTPS and Transport Security Layer (TLS) secure communication between clients and your InfluxDB server.
 menu:
   influxdb_1_6:
     name: Enabling HTTPS
@@ -163,6 +164,9 @@ Enable HTTPS in InfluxDB's the `[http]` section of the configuration file (`/etc
   # Use a separate private key location.
   https-private-key = "/etc/ssl/influxdb-selfsigned.key"
 ```
+
+> If setting up HTTPS for [InfluxDB Enterprise](/enterprise_influxdb), you also need to configure insecure TLS connections between both meta and data nodes in your cluster.
+> Instructions are provided in the [InfluxDB Enterprise HTTPS Setup guide](/enterprise_influxdb/latest/guides/https_setup/#setup-https-with-a-self-signed-certificate).
 
 #### Step 3: Restart InfluxDB
 

--- a/content/influxdb/v1.6/administration/https_setup.md
+++ b/content/influxdb/v1.6/administration/https_setup.md
@@ -1,5 +1,5 @@
 ---
-title: Enabling HTTPS with
+title: Enabling HTTPS with InfluxDB
 description: Enable HTTPS and Transport Security Layer (TLS) secure communication between clients and your InfluxDB servers.
 menu:
   influxdb_1_6:
@@ -71,7 +71,8 @@ sudo chmod 600 /etc/ssl/<private-key-file>
 
 #### Step 3: Review the TLS configuration settings
 
-By default, InfluxDB supports the values for TLS `ciphers`, `min-version`, and `max-version` listed in the [Constants section of the Go `crypto/tls` package documentation](https://golang.org/pkg/crypto/tls/#pkg-constants) and depends on the version of Go used to build InfluxDB. You can configure InfluxDB to support a restricted list of TLS cipher suite IDs and versions. For more information, see [Transport Layer Security (TLS) settings `[tls]`](/influxdb/v1.6/administration/config#transport-layer-security-tls-settings-tls).
+By default, InfluxDB supports the values for TLS `ciphers`, `min-version`, and `max-version` listed in the [Constants section of the Go `crypto/tls` package documentation](https://golang.org/pkg/crypto/tls/#pkg-constants) and depends on the version of Go used to build InfluxDB. You can configure InfluxDB to support a restricted list of TLS cipher suite IDs and versions.
+For more information, see [Transport Layer Security (TLS) configuration settings](/influxdb/v1.6/administration/config#transport-layer-security-tls-settings-tls).
 
 
 #### Step 4: Enable HTTPS in the InfluxDB configuration file
@@ -185,7 +186,7 @@ Restart the InfluxDB process for the configuration changes to take effect:
 sudo systemctl restart influxdb
 ```
 
-#### Step 5: Verify the HTTPS Setup
+#### Step 5: Verify the HTTPS setup
 
 Verify that HTTPS is working by connecting to InfluxDB with the [CLI tool](/influxdb/v1.6/tools/shell/):
 ```

--- a/content/influxdb/v1.6/administration/https_setup.md
+++ b/content/influxdb/v1.6/administration/https_setup.md
@@ -1,6 +1,6 @@
 ---
 title: Enabling HTTPS with
-description: Enable HTTPS and Transport Security Layer (TLS) secure communication between clients and your InfluxDB server.
+description: Enable HTTPS and Transport Security Layer (TLS) secure communication between clients and your InfluxDB servers.
 menu:
   influxdb_1_6:
     name: Enabling HTTPS
@@ -69,7 +69,12 @@ sudo chmod 644 /etc/ssl/<certificate-file>
 sudo chmod 600 /etc/ssl/<private-key-file>
 ```
 
-#### Step 3: Enable HTTPS in the InfluxDB configuration file
+#### Step 3: Review the TLS configuration settings
+
+By default, InfluxDB supports the values for TLS `ciphers`, `min-version`, and `max-version` listed in the [Constants section of the Go `crypto/tls` package documentation](https://golang.org/pkg/crypto/tls/#pkg-constants) and depends on the version of Go used to build InfluxDB. You can configure InfluxDB to support a restricted list of TLS cipher suite IDs and versions. For more information, see [Transport Layer Security (TLS) settings `[tls]`](/influxdb/v1.6/administration/config#transport-layer-security-tls-settings-tls).
+
+
+#### Step 4: Enable HTTPS in the InfluxDB configuration file
 
 HTTPS is disabled by default.
 Enable HTTPS in InfluxDB's the `[http]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
@@ -99,14 +104,14 @@ Enable HTTPS in InfluxDB's the `[http]` section of the configuration file (`/etc
   https-private-key = "/etc/ssl/<private-key-file>.key"
 ```
 
-#### Step 4: Restart the InfluxDB service
+#### Step 5: Restart the InfluxDB service
 
 Restart the InfluxDB process for the configuration changes to take effect:
 ```
 sudo systemctl restart influxdb
 ```
 
-#### Step 5: Verify the HTTPS setup
+#### Step 6: Verify the HTTPS setup
 
 Verify that HTTPS is working by connecting to InfluxDB with the [CLI tool](/influxdb/v1.6/tools/shell/):
 ```
@@ -139,7 +144,12 @@ When you execute the command, it will prompt you for more information.
 You can choose to fill out that information or leave it blank;
 both actions generate valid certificate files.
 
-#### Step 2: Enable HTTPS in InfluxDB's configuration file
+#### Step 2: Review the TLS configuration settings
+
+By default, InfluxDB supports the values for TLS `ciphers`, `min-version`, and `max-version` listed in the [Constants section of the Go `crypto/tls` package documentation](https://golang.org/pkg/crypto/tls/#pkg-constants) and depends on the version of Go used to build InfluxDB. You can configure InfluxDB to support a restricted list of TLS cipher suite IDs and versions. For more information, see [Transport Layer Security (TLS) settings `[tls]`](/influxdb/v1.6/administration/config#transport-layer-security-tls-settings-tls).
+
+
+#### Step 3: Enable HTTPS in InfluxDB's configuration file
 
 HTTPS is disabled by default.
 Enable HTTPS in InfluxDB's the `[http]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
@@ -168,14 +178,14 @@ Enable HTTPS in InfluxDB's the `[http]` section of the configuration file (`/etc
 > If setting up HTTPS for [InfluxDB Enterprise](/enterprise_influxdb), you also need to configure insecure TLS connections between both meta and data nodes in your cluster.
 > Instructions are provided in the [InfluxDB Enterprise HTTPS Setup guide](/enterprise_influxdb/latest/guides/https_setup/#setup-https-with-a-self-signed-certificate).
 
-#### Step 3: Restart InfluxDB
+#### Step 4: Restart InfluxDB
 
 Restart the InfluxDB process for the configuration changes to take effect:
 ```
 sudo systemctl restart influxdb
 ```
 
-#### Step 4: Verify the HTTPS Setup
+#### Step 5: Verify the HTTPS Setup
 
 Verify that HTTPS is working by connecting to InfluxDB with the [CLI tool](/influxdb/v1.6/tools/shell/):
 ```
@@ -257,7 +267,7 @@ Note: The password is required, but will not be used for client certificate auth
 > GRANT WRITE ON "telegraf" to "testuser"
 ```
 
-#### Step 5: Verify the HTTPS setup
+#### Step 4: Verify the HTTPS setup
 
 Verify that client certificate authentication is working by connecting to InfluxDB with curl:
 ```

--- a/content/influxdb/v1.6/tools/influx_inspect.md
+++ b/content/influxdb/v1.6/tools/influx_inspect.md
@@ -393,13 +393,12 @@ Default value is `""`.
 The flag to report detailed cardinality estimates.
 Default value is `false`.
 
-### [ `-exact` ]
+#### [ `-exact` ]
 
 The flag to report exact cardinality counts instead of estimates.
 Default value is `false`.
 Note: This can use a lot of memory.
 
-Report
 
 ### `verify`
 


### PR DESCRIPTION
Added documentation for:

* TLS configuration settings in configuration page
* TLS steps in HTTPS setup page
* Adds `reporttsi` command to `influx_inspect`.
* Adds `tsm-use-madv-willneed` option to configuration.

Fixes #1739.
Fixes #1712.
Fixes #1738.