### PR TITLE
Removing merge conflict, fixing instructions

### DIFF
--- a/content/chronograf/v1.6/administration/import-export-dashboards.md
+++ b/content/chronograf/v1.6/administration/import-export-dashboards.md
@@ -39,7 +39,7 @@ The newly imported dashboard will be included in your list of dashboards.
 
 ### Reconciling unmatched sources
 If the data sources defined in the imported dashboard JSON file do not match any of your local sources,
-you will have to opportunity to reconcile each of the unmatched sources during the import process.
+you will have to reconcile each of the unmatched sources during the import process.
 
 ![Reconcile unmatched sources](/img/chronograf/v1.6/dashboard-import-reconcile.png)
 

--- a/content/chronograf/v1.6/guides/visualization-types.md
+++ b/content/chronograf/v1.6/guides/visualization-types.md
@@ -88,7 +88,6 @@ Use the **Stacked Graph Controls** to specify the following:
 
 ### Step-Plot Graph
 
-<<<<<<< HEAD
 The **Step-Plot Graph** view displays a time series in a staircase graph.
 
 ![Step-Plot Graph selector](/img/chronograf/chrono-viz-step-plot-graph-selector.png)


### PR DESCRIPTION
Removed a "<<<<< HEAD" in the Visualization Types section in Chronograf under the subsection "Step-Plot Graph"

Removed "to opportunity" from "you will have to opportunity to reconcile each of the unmatched sources" for the Importing and Exporting section in Chronograf.