### PR TITLE
Fixed typos in Kapacitor and Telegraf docs

### DIFF
--- a/content/kapacitor/v1.5/administration/configuration.md
+++ b/content/kapacitor/v1.5/administration/configuration.md
@@ -46,7 +46,7 @@ These include:
 * `-config`: Path to the configuration file.
 * `-hostname`: Hostname that will override the hostname specified in the configuration file.
 * `-pidfile`: File where the process ID will be written.
-* `-logfile`: File where logs will be written.
+* `-log-file`: File where logs will be written.
 * `-log-level`: Threshold for writing messages to the log file. Valid values include `debug, info, warn, error`.
 
 ### Systemd

--- a/content/telegraf/v1.7/concepts/data_formats_input.md
+++ b/content/telegraf/v1.7/concepts/data_formats_input.md
@@ -86,7 +86,7 @@ metrics are parsed directly into Telegraf metrics.
 
 The JSON data format flattens JSON into metric _fields_.
 NOTE: Only numerical values are converted to fields, and they are converted
-into a float. strings are ignored unless specified as a tag_key (see below).
+into a float. Strings are ignored unless specified as a tag_key (see below).
 
 So for example, this JSON:
 


### PR DESCRIPTION
For Kapacitor, the flag `log-file` was missing a hyphen.

For Telegraf, capitalized "string".