### PR TITLE
Prometheus yaml config have wrong syntax what causing error

### DIFF
--- a/content/influxdb/v1.6/supported_protocols/prometheus.md
+++ b/content/influxdb/v1.6/supported_protocols/prometheus.md
@@ -48,10 +48,10 @@ Also include the database name using the `db=` query parameter.
 _**Example endpoints in Prometheus configuration file**_  
 ```yaml
 remote_write:
-  url: "http://localhost:8086/api/v1/prom/write?db=prometheus"
+  - url: "http://localhost:8086/api/v1/prom/write?db=prometheus"
 
 remote_read:
-  url: "http://localhost:8086/api/v1/prom/read?db=prometheus"
+  - url: "http://localhost:8086/api/v1/prom/read?db=prometheus"
 ```
 
 #### Read and write URLs with authentication
@@ -62,10 +62,10 @@ using the `u=` and `p=` query parameters respectively.
 _**Example endpoints with authentication enabled**_  
 ```yaml
 remote_write:
-  url: "http://localhost:8086/api/v1/prom/write?db=prometheus&u=username&p=password"
+  - url: "http://localhost:8086/api/v1/prom/write?db=prometheus&u=username&p=password"
 
 remote_read:
-  url: "http://localhost:8086/api/v1/prom/read?db=prometheus&u=username&p=password"
+  - url: "http://localhost:8086/api/v1/prom/read?db=prometheus&u=username&p=password"
 ```
 
 > Including plain text passwords in your Prometheus configuration file is not ideal.


### PR DESCRIPTION
Prometheus yaml config have wrong syntax what causing error
./promtool check config ./prometheus.yml
Checking ./prometheus.yml
  FAILED: parsing YAML file ./prometheus.yml: yaml: unmarshal errors:
  line 15: cannot unmarshal !!map into []*config.RemoteWriteConfig
  line 17: cannot unmarshal !!map into []*config.RemoteReadConfig