### PR TITLE
Telegraf 1.8 fixes

### DIFF
--- a/content/telegraf/v1.8/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.8/about_the_project/release-notes-changelog.md
@@ -12,17 +12,17 @@ menu:
 
 ### New input plugins
 
-- [ActiveMQ (`activemq`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/activemq/) - Contributed by @mlabouardy
-- [Beanstalkd (`beanstalkd`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/beanstalkd/) - Contributed by @44px
-- [Filecount (`filecount`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/filecount/) - Contributed by @sometimesfood
-- [File (`file`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/file/) - Contributed by @maxunt
-- [Icinga2 (`icinga2`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/icinga2/) - Contributed by @mlabouardy
-- [Kibana (`kibana`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/icinga2/) - Contributed by @lpic10
-- [PgBouncer (`pgbouncer`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/pgbouncer/) - Contributed by @nerzhul
-- [Temp (`temp`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/temp/) - Contributed by @pytimer
-- [Tengine (`tengine`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/tengine/) - Contributed by @ertaoxu
-- [VMware vSphere (`vsphere`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/vsphere/) - Contributed by @prydin
-- [X509 Cert (`x509_cert`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/x509_cert/) - Contributed by @jtyr
+- [ActiveMQ (`activemq`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/activemq/README.md) - Contributed by @mlabouardy
+- [Beanstalkd (`beanstalkd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/beanstalkd/README.md) - Contributed by @44px
+- [File (`file`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/file/README.md) - Contributed by @maxunt
+- [Filecount (`filecount`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filecount/README.md) - Contributed by @sometimesfood
+- [Icinga2 (`icinga2`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/icinga2/README.md) - Contributed by @mlabouardy
+- [Kibana (`kibana`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kibana/README.md) - Contributed by @lpic10
+- [PgBouncer (`pgbouncer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pgbouncer/README.md) - Contributed by @nerzhul
+- [Temp (`temp`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/temp/README.md) - Contributed by @pytimer
+- [Tengine (`tengine`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tengine/README.md) - Contributed by @ertaoxu
+- [VMware vSphere (`vsphere`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere/README.md) - Contributed by @prydin
+- [X509 Cert (`x509_cert`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/x509_cert/README.md) - Contributed by @jtyr
 
 ### New processor plugins
 
@@ -33,7 +33,7 @@ menu:
 
 ### New aggregator plugins
 
-- [ValueCounter (`valuecounter`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/aggregators/valuecounter/) - Contributed by @piotr1212
+- [ValueCounter (`valuecounter`)](https://github.com/influxdata/telegraf/blob/master/plugins/aggregators/valuecounter/README.md) - Contributed by @piotr1212
 
 ### New output plugins
 

--- a/content/telegraf/v1.8/about_the_project/release-notes-changelog.md
+++ b/content/telegraf/v1.8/about_the_project/release-notes-changelog.md
@@ -26,19 +26,19 @@ menu:
 
 ### New processor plugins
 
-- [Enum (`enum`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/enum/) - Contributed by @KarstenSchnitter
-- [Parser (`parser`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/parser/) - Contributed by @Ayrdrie & @maxunt
-- [Rename (`rename`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/rename/) - Contributed by @goldibex
-- [Strings (`strings`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/strings/) - Contributed by @bsmaldon
+- [Enum (`enum`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/enum/README.md) - Contributed by @KarstenSchnitter
+- [Parser (`parser`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/parser/README.md) - Contributed by @Ayrdrie & @maxunt
+- [Rename (`rename`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/rename/README.md) - Contributed by @goldibex
+- [Strings (`strings`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/strings/README.md) - Contributed by @bsmaldon
 
 ### New aggregator plugins
 
-- [ValueCounter (`valuecounter`)](https://github.com/influxdata/telegraf/blob/master/plugins/aggregators/valuecounter/README.md) - Contributed by @piotr1212
+- [ValueCounter (`valuecounter`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/valuecounter/README.md) - Contributed by @piotr1212
 
 ### New output plugins
 
-- [Azure Monitor (`azure_monitor`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/azure_monitor/) - Contributed by @influxdata
-- [InfluxDB v2 (`influxdb_v2`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/influxdb_v2/) - Contributed by @influxdata
+- [Azure Monitor (`azure_monitor`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/azure_monitor/README.md) - Contributed by @influxdata
+- [InfluxDB v2 (`influxdb_v2`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb_v2/README.md) - Contributed by @influxdata
 
 ### New input data formats (parsers)
 

--- a/content/telegraf/v1.8/data_formats/input/_index.md
+++ b/content/telegraf/v1.8/data_formats/input/_index.md
@@ -13,17 +13,17 @@ using a configurable parser into [metrics][].  This allows, for example, the
 `kafka_consumer` input plugin to process messages in either InfluxDB Line
 Protocol or in JSON format. Telegraf supports the following input data formats:
 
-- [InfluxDB Line Protocol](/telegraf/v1.8/plugins/data_formats/input/influx/)
-- [collectd](/telegraf/v1.8/plugins/data_formats/input/collectd/)
-- [CSV](/telegraf/v1.8/plugins/data_formats/input/csv/)
-- [Dropwizard](/telegraf/v1.8/plugins/data_formats/input/dropwizard/)
-- [Graphite](/telegraf/v1.8/plugins/data_formats/input/graphite/)
-- [Grok](/telegraf/v1.8/plugins/data_formats/input/grok/)
-- [JSON](//telegraf/v1.8/plugins/data_formats/input/json/)
-- [logfmt](/telegraf/v1.8/plugins/data_formats/input/logfmt/)
-- [Nagios](/telegraf/v1.8/plugins/data_formats/input/nagios/)
-- [Value](/telegraf/v1.8/plugins/data_formats/input/value/), ie: 45 or "booyah"
-- [Wavefront](/telegraf/v1.8/plugins/data_formats/input/wavefront/)
+- [InfluxDB Line Protocol](/telegraf/v1.8/data_formats/input/influx/)
+- [collectd](/telegraf/v1.8/data_formats/input/collectd/)
+- [CSV](/telegraf/v1.8/data_formats/input/csv/)
+- [Dropwizard](/telegraf/v1.8/data_formats/input/dropwizard/)
+- [Graphite](/telegraf/v1.8/data_formats/input/graphite/)
+- [Grok](/telegraf/v1.8/data_formats/input/grok/)
+- [JSON](//telegraf/v1.8/data_formats/input/json/)
+- [logfmt](/telegraf/v1.8/data_formats/input/logfmt/)
+- [Nagios](/telegraf/v1.8/data_formats/input/nagios/)
+- [Value](/telegraf/v1.8/data_formats/input/value/), ie: 45 or "booyah"
+- [Wavefront](/telegraf/v1.8/data_formats/input/wavefront/)
 
 Any input plugin containing the `data_format` option can use it to select the
 desired parser:

--- a/content/telegraf/v1.8/data_formats/input/grok.md
+++ b/content/telegraf/v1.8/data_formats/input/grok.md
@@ -63,7 +63,7 @@ To match a comma decimal point you can use a period.  For example `%{TIMESTAMP:t
 To match a comma decimal point you can use a period in the pattern string.
 See https://golang.org/pkg/time/#Parse for more details.
 
-Telegraf has many of its own [built-in patterns](./grok/patterns/influx-patterns),
+Telegraf has many of its own [built-in patterns](https://github.com/influxdata/telegraf/blob/master/plugins/parsers/grok/influx_patterns.go),
 as well as support for most of
 [logstash's builtin patterns](https://github.com/logstash-plugins/logstash-patterns-core/blob/master/patterns/grok-patterns).
 _Golang regular expressions do not support lookahead or lookbehind.

--- a/content/telegraf/v1.8/data_formats/output/influx.md
+++ b/content/telegraf/v1.8/data_formats/output/influx.md
@@ -8,9 +8,7 @@ menu:
     parent: Output
 ---
 
-The `influx` output data format outputs metrics into [InfluxDB Line Protocol][line
-protocol].  InfluxData recommends this data format unless another format is required
-for interoperability.
+The `influx` output data format outputs metrics into [InfluxDB Line Protocol][line protocol]. InfluxData recommends this data format unless another format is required for interoperability.
 
 ## Configuration
 

--- a/content/telegraf/v1.8/plugins/aggregators.md
+++ b/content/telegraf/v1.8/plugins/aggregators.md
@@ -16,25 +16,25 @@ Aggregators emit new aggregate metrics based on the metrics collected by the inp
 ## Supported Telegraf aggregator plugins
 
 
-### [BasicStats (`basicstats`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/aggregators/basicstats)
+### [BasicStats (`basicstats`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/basicstats/README.md)
 
-The [BasicStats (`basicstats`) aggregator plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/aggregators/basicstats) gives count, max, min, mean, s2(variance), and stdev for a set of values, emitting the aggregate every period seconds.
+The [BasicStats (`basicstats`) aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/basicstats/README.md) gives count, max, min, mean, s2(variance), and stdev for a set of values, emitting the aggregate every period seconds.
 
-### [Histogram (`histogram`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/aggregators/histogram)
+### [Histogram (`histogram`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/histogram/README.md)
 
-The [Histogram (`histogram`) aggregator plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/aggregators/histogram) creates histograms containing the counts of field values within a range.
+The [Histogram (`histogram`) aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/histogram/README.md) creates histograms containing the counts of field values within a range.
 
 Values added to a bucket are also added to the larger buckets in the distribution. This creates a [cumulative histogram](https://en.wikipedia.org/wiki/Histogram#/media/File:Cumulative_vs_normal_histogram.svg).
 
 Like other Telegraf aggregators, the metric is emitted every period seconds. Bucket counts however are not reset between periods and will be non-strictly increasing while Telegraf is running.
 
-### [MinMax (`minmax`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/aggregators/minmax)
+### [MinMax (`minmax`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/minmax/README.md)
 
-The [MinMax (`minmax`) aggregator plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/aggregators/minmax) aggregates min and max values of each field it sees, emitting the aggegrate every period seconds.
+The [MinMax (`minmax`) aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/minmax/README.md) aggregates min and max values of each field it sees, emitting the aggegrate every period seconds.
 
-### [ValueCounter (`valuecounter`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/aggregators/valuecounter) -- NEW in v.1.8
+### [ValueCounter (`valuecounter`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/valuecounter/README.md) -- NEW in v.1.8
 
-The [MinMax (`valuecounter`) aggregator plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/aggregators/valuecounter) counts the occurrence of values in fields and emits the counter once every 'period' seconds.
+The [MinMax (`valuecounter`) aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/valuecounter/README.md) counts the occurrence of values in fields and emits the counter once every 'period' seconds.
 
 A use case for the ValueCounter aggregator plugin is when you are processing a HTTP access log (with the logparser input plugin) and want to count the HTTP status codes.
 

--- a/content/telegraf/v1.8/plugins/inputs.md
+++ b/content/telegraf/v1.8/plugins/inputs.md
@@ -46,6 +46,13 @@ server. The [ExtendedStatus](https://httpd.apache.org/docs/2.4/mod/core.html#ext
 to collect all available fields. For information about how to configure your server reference the
 [module documenation](https://httpd.apache.org/docs/2.4/mod/mod_status.html#enable).
 
+### [Apache Kafka Consumer (`kafka_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kafka_consumer/README.md)
+
+The [Apache Kafka Consumer (`kafka_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kafka_consumer/README.md) polls a specified Kafka topic and adds messages to InfluxDB.
+Messages are expected in the line protocol format.
+[Consumer Group](http://godoc.org/github.com/wvanbergen/kafka/consumergroup) is used to talk to the Kafka cluster so
+multiple instances of Telegraf can read from the same topic in parallel.
+
 ### [Apache Solr (`solr`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/solr/README.md)
 
 The [Apache Solr (`solr`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/solr/README.md) collects stats using the MBean Request Handler.
@@ -255,14 +262,6 @@ The [Jolokia2 Proxy (`jolokia2_proxy`) input plugin](https://github.com/influxda
 The [JTI OpenConfig Telemetry (`jti_openconfig_telemetry`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jti_openconfig_telemetry/README.md) reads Juniper Networks implementation of OpenConfig telemetry data from listed sensors using the Junos Telemetry Interface. Refer to
 [openconfig.net](http://openconfig.net/) for more details about OpenConfig and [Junos Telemetry Interface (JTI)](https://www.juniper.net/documentation/en_US/junos/topics/concept/junos-telemetry-interface-oveview.html).
 
-
-### [Kafka Consumer (`kafka_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kafka_consumer/README.md)
-
-The [Kafka Consumer (`kafka_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kafka_consumer/README.md) polls a specified Kafka topic and adds messages to InfluxDB.
-Messages are expected in the line protocol format.
-[Consumer Group](http://godoc.org/github.com/wvanbergen/kafka/consumergroup) is used to talk to the Kafka cluster so
-multiple instances of Telegraf can read from the same topic in parallel.
-
 ### [Kapacitor (`kapacitor`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kapacitor/README.md)
 
 The [Kapacitor (`kapacitor`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kapacitor/README.md) will collect metrics from the given Kapacitor instances.
@@ -313,7 +312,7 @@ The [Mailchimp (`mailchimp`) input plugin](https://github.com/influxdata/telegra
 
 ### [Mcrouter (`mcrouter`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mcrouter/README.md)
 
-The [mcrouter (`mcrouter`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mcrouter/README.md) gathers statistics data from a mcrouter instance. [Mcrouter](https://github.com/facebook/mcrouter) is a memcached protocol router, developed and maintained by Facebook, for scaling memcached (http://memcached.org/) deployments. It's a core component of cache infrastructure at Facebook and Instagram where mcrouter handles almost 5 billion requests per second at peak.
+The [Mcrouter (`mcrouter`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mcrouter/README.md) gathers statistics data from a mcrouter instance. [Mcrouter](https://github.com/facebook/mcrouter) is a memcached protocol router, developed and maintained by Facebook, for scaling memcached (http://memcached.org/) deployments. It's a core component of cache infrastructure at Facebook and Instagram where mcrouter handles almost 5 billion requests per second at peak.
 
 ### [Mem (`mem`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mem/README.md)
 

--- a/content/telegraf/v1.8/plugins/inputs.md
+++ b/content/telegraf/v1.8/plugins/inputs.md
@@ -20,68 +20,77 @@ View usage instructions for each service input by running `telegraf --usage <ser
 
 ## Supported Telegraf input plugins
 
-### [ActiveMQ (`activemq`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/activemq) -- NEW in v.1.8
+### [ActiveMQ (`activemq`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/activemq/README.md) -- NEW in v.1.8
 
-The [ActiveMQ (`activemq`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/activemq) gathers queues, topics, and subscriber metrics using the ActiveMQ Console API.
+The [ActiveMQ (`activemq`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/activemq/README.md) gathers queues, topics, and subscriber metrics using the ActiveMQ Console API.
 
-### [Aerospike (`aerospike`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/aerospike)
+### [Aerospike (`aerospike`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/aerospike/README.md)
 
-The [Aerospike (`aerospike`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/aerospike) queries Aerospike servers and gets node statistics and  statistics for all configured namespaces.
+The [Aerospike (`aerospike`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/aerospike/README.md) queries Aerospike servers and gets node statistics and  statistics for all configured namespaces.
 
-### [AMQP Consumer (`amqp_consumer`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/amqp_consumer)
+### [Amazon CloudWatch Statistics (`cloudwatch`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cloudwatch/README.md)
 
-The [AMQP Consumer (`amqp_consumer`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/amqp_consumer) provides a consumer for use with AMQP 0-9-1, a prominent implementation of this protocol
+The [Amazon CloudWatch Statistics (`cloudwatch`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cloudwatch/README.md) pulls metric statistics from Amazon CloudWatch.
+
+### [AMQP Consumer (`amqp_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/amqp_consumer/README.md)
+
+The [AMQP Consumer (`amqp_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/amqp_consumer/README.md) provides a consumer for use with AMQP 0-9-1, a prominent implementation of this protocol
 being RabbitMQ.
 
-### [Apache (`apache`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/apache)
+### [Apache HTTP Server  (`apache`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/apache/README.md)
 
-The [Apache (`apache`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/apache) collects server performance information using the `mod_status` module of the Apache HTTP Server.
+The [Apache HTTP Server (`apache`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/apache/README.md) collects server performance information using the `mod_status` module of the Apache HTTP Server.
 
 Typically, the `mod_status` module is configured to expose a page at the `/server-status?auto` location of the Apache
 server. The [ExtendedStatus](https://httpd.apache.org/docs/2.4/mod/core.html#extendedstatus) option must be enabled in order
 to collect all available fields. For information about how to configure your server reference the
 [module documenation](https://httpd.apache.org/docs/2.4/mod/mod_status.html#enable).
 
-### [Aurora (`aurora`)](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/aurora)
+### [Apache Solr (`solr`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/solr/README.md)
 
-The [Aurora input plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/aurora) gathers metrics from [Apache Aurora](https://aurora.apache.org/) schedulers. For monitoring recommendations, see [Monitoring your Aurora cluster](https://aurora.apache.org/documentation/latest/operations/monitoring/).
+The [Apache Solr (`solr`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/solr/README.md) collects stats using the MBean Request Handler.
 
-### [Bcache (`bcache`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/bcache)
+### [Apache Tomcat (`tomcat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tomcat/README.md)
 
-The [Bcache (`bcache`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/bcache) gets bcache statistics from the `stats_total` directory and `dirty_data` file.
+The [Apache Tomcat (`tomcat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tomcat/README.md) collects statistics available from the Apache Tomcat manager status page (`http://<host>/manager/status/all?XML=true`). Using `XML=true` returns XML data).
+See the [Apache Tomcat documentation](https://tomcat.apache.org/tomcat-9.0-doc/manager-howto.html#Server_Status) for details on these statistics.
 
-### [Beanstalkd (`beanstalkd`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/beanstalkd) -- NEW in v.1.8
+### [Aurora (`aurora`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/aurora/README.md)
 
-The [Beanstalkd (`beanstalkd`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/beanstalkd) collects server stats as well as tube stats (reported by `stats` and `stats-tube` commands respectively).
+The [Aurora input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/aurora/README.md) gathers metrics from [Apache Aurora](https://aurora.apache.org/) schedulers. For monitoring recommendations, see [Monitoring your Aurora cluster](https://aurora.apache.org/documentation/latest/operations/monitoring/).
 
-### [Bond (`bond`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/bond)
+### [Bcache (`bcache`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bcache/README.md)
 
-The [Bond (`bond`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/bond) collects network bond interface status, bond's slaves interfaces status and failures count of
+The [Bcache (`bcache`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bcache/README.md) gets bcache statistics from the `stats_total` directory and `dirty_data` file.
+
+### [Beanstalkd (`beanstalkd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/beanstalkd/README.md) -- NEW in v.1.8
+
+The [Beanstalkd (`beanstalkd`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/beanstalkd/README.md) collects server stats as well as tube stats (reported by `stats` and `stats-tube` commands respectively).
+
+### [Bond (`bond`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bond/README.md)
+
+The [Bond (`bond`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bond/README.md) collects network bond interface status, bond's slaves interfaces status and failures count of
 bond's slaves interfaces. The plugin collects these metrics from `/proc/net/bonding/*` files.
 
-### [Burrow (`burrow`)](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/burrow)
+### [Burrow (`burrow`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/burrow/README.md)
 
-The [Burrow (`burrow` input plugin)](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/burrow) collects Apache Kafka topic, consumer, and partition status using the [Burrow](https://github.com/linkedin/Burrow) HTTP [HTTP Endpoint](https://github.com/linkedin/Burrow/wiki/HTTP-Endpoint).
+The [Burrow (`burrow` input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/burrow/README.md) collects Apache Kafka topic, consumer, and partition status using the [Burrow](https://github.com/linkedin/Burrow) HTTP [HTTP Endpoint](https://github.com/linkedin/Burrow/wiki/HTTP-Endpoint).
 
-### [Ceph Storage (`ceph`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/ceph)
+### [Ceph Storage (`ceph`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ceph/README.md)
 
-The [Ceph Storage (`ceph`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/ceph) collects performance metrics from the MON and OSD nodes in a Ceph storage cluster.
+The [Ceph Storage (`ceph`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ceph/README.md) collects performance metrics from the MON and OSD nodes in a Ceph storage cluster.
 
-### [CGroup (`cgroup`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/cgroup)
+### [CGroup (`cgroup`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cgroup/README.md)
 
-The [CGroup (`cgroup`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/cgroup) captures specific statistics per cgroup.
+The [CGroup (`cgroup`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cgroup/README.md) captures specific statistics per cgroup.
 
-### [Chrony (`chrony`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/chrony)
+### [Chrony (`chrony`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/chrony/README.md)
 
-The [Chrony (`chrony`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/chrony) gets standard chrony metrics, requires chronyc executable.
+The [Chrony (`chrony`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/chrony/README.md) gets standard chrony metrics, requires chronyc executable.
 
-### [CloudWatch (`cloudwatch`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/cloudwatch)
+### [Conntrack (`conntrack`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/conntrack/README.md)
 
-The [CloudWatch (`cloudwatch`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/cloudwatch) pulls metric statistics from Amazon CloudWatch.
-
-### [Conntrack (`conntrack`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/conntrack)
-
-The [Conntrack (`conntrack`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/conntrack) collects stats from Netfilter's conntrack-tools.
+The [Conntrack (`conntrack`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/conntrack/README.md) collects stats from Netfilter's conntrack-tools.
 
 The conntrack-tools provide a mechanism for tracking various aspects of network connections as they are processed by
 netfilter. At runtime, conntrack exposes many of those connection statistics within `/proc/sys/net`. Depending on your
@@ -89,126 +98,122 @@ kernel version, these files can be found in either `/proc/sys/net/ipv4/netfilter
 prefixed with either `ip_` or `nf_`. This plugin reads the files specified in its configuration and publishes each one as
 a field, with the prefix normalized to `ip_`.
 
-### [Consul (`consul`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/consul)
+### [Consul (`consul`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/consul/README.md)
 
-The [Consul (`consul`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/consul) will collect statistics about all health checks registered in the Consul.
+The [Consul (`consul`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/consul/README.md) will collect statistics about all health checks registered in the Consul.
 It uses Consul API to query the data.
 It will not report the telemetry but Consul can report those stats already using StatsD protocol, if needed.
 
-### [Couchbase (`couchbase`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/couchbase)
+### [Couchbase (`couchbase`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchbase/README.md)
 
-The [Couchbase (`couchbase`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/couchbase) reads per-node and per-bucket metrics from Couchbase.
+The [Couchbase (`couchbase`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchbase/README.md) reads per-node and per-bucket metrics from Couchbase.
 
-### [CouchDB (`couchdb`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/couchdb)
+### [CouchDB (`couchdb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchdb/README.md)
 
-The [CouchDB (`couchdb`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/couchdb) gathers metrics of CouchDB using `_stats` endpoint.
+The [CouchDB (`couchdb`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchdb/README.md) gathers metrics of CouchDB using `_stats` endpoint.
 
-### [CPU (`cpu`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/CPU_README.md)
+### [CPU (`cpu`)](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cpu/README.md)
 
-The [CPU (`cpu`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/CPU_README.md) gathers metrics about cpu usage.
+The [CPU (`cpu`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cpu/README.md) gathers metrics about cpu usage.
 
-### [Mesosphere DC/OS (`dcos`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dcos)
+### [Disk (`disk`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/disk/README.md)
 
-The [Mesosphere DC/OS (`dcos`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dcos) gathers metrics from a DC/OS cluster's [metrics component](https://docs.mesosphere.com/1.10/metrics/).
+The [Disk (`disk`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/disk/README.md) gathers metrics about disk usage by mount point.
 
-### [Disk (`disk`)](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/DISK_README.md)
+### [DiskIO (`diskio`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/diskio/README.md)
 
-The [Disk (`disk`) input plugin](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/DISK_README.md) gathers metrics about disk usage by mount point.
-
-### [DiskIO (`diskio`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/DISKIO_README.md)
-
-The [DiskIO (`diskio`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/DISKIO_README.md) gathers metrics about disk IO by device.
+The [DiskIO (`diskio`) input plugin](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/diskio/README.md) gathers metrics about disk IO by device.
 
 ### [Disque (`disque`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/disque)
 
 The [Disque (`disque`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/disque) gathers metrics from one or more [Disque](https://github.com/antirez/disque) servers.
 
-### [DMCache (`dmcache`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache)
+### [DMCache (`dmcache`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dmcache/README.md)
 
-The [DMCache (`dmcache`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dmcache) provides a native collection for dmsetup-based statistics for dm-cache.
+The [DMCache (`dmcache`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dmcache/README.md) provides a native collection for dmsetup-based statistics for dm-cache.
 
-### [DNS query time (`dns_query_time`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dns_query)
+### [DNS Query (`dns_query`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dns_query/README.md)
 
-The [DNS query time (`dns_query_time`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dns_query) gathers dns query times in milliseconds - like [Dig](https://en.wikipedia.org/wiki/Dig_(command)).
+The [DNS Query (`dns_query`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dns_query/README.md) gathers DNS query times in milliseconds - like [Dig](https://en.wikipedia.org/wiki/Dig_(command)).
 
-### [Docker (`docker`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/docker)
+### [Docker (`docker`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/docker/README.md)
 
-The [Docker (`docker`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/docker) uses the Docker Engine API to gather metrics on running Docker containers. The Docker plugin
+The [Docker (`docker`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/docker/README.md) uses the Docker Engine API to gather metrics on running Docker containers. The Docker plugin
 uses the [Official Docker Client](https://github.com/moby/moby/tree/master/client) to gather stats from the
 [Engine API](https://docs.docker.com/engine/api/v1.20/) library documentation.
 
-### [Dovecot (`dovecot`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dovecot)
+### [Dovecot (`dovecot`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dovecot/README.md)
 
-The [Dovecot (`dovecot`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/dovecot) uses the dovecot Stats protocol to gather metrics on configured domains. For more information,
+The [Dovecot (`dovecot`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dovecot/README.md) uses the dovecot Stats protocol to gather metrics on configured domains. For more information,
 see the [Dovecot documentation](http://wiki2.dovecot.org/Statistics).
 
-### [Elasticsearch (`elasticsearch`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/elasticsearch)
+### [Elasticsearch (`elasticsearch`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/elasticsearch/README.md)
 
-The [Elasticsearch (`elasticsearch`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/elasticsearch) queries endpoints to obtain [node](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html)
+The [Elasticsearch (`elasticsearch`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/elasticsearch/README.md) queries endpoints to obtain [node](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html)
 and optionally [cluster-health](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html)
 or [cluster-stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-stats.html) metrics.
 
-### [Exec (`exec`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/exec)
+### [Exec (`exec`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/exec/README.md)
 
-The [Exec (`exec`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/exec) parses supported [Telegraf input data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md) (InfluxDB Line Protocol, JSON, Graphite, Value, Nagios, Collectd, and Dropwizard into metrics. Each Telegraf metric includes the measurement name, tags, fields, and timesamp. See [Telegraf input data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md) for details on the supported data formats.
+The [Exec (`exec`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/exec/README.md) parses supported [Telegraf input data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md) (InfluxDB Line Protocol, JSON, Graphite, Value, Nagios, Collectd, and Dropwizard into metrics. Each Telegraf metric includes the measurement name, tags, fields, and timesamp. See [Telegraf input data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md) for details on the supported data formats.
 
-### [Fail2ban (`fail2ban`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/fail2ban)
+### [Fail2ban (`fail2ban`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fail2ban/README.md)
 
-The [Fail2ban (`fail2ban`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/fail2ban) gathers the count of failed and banned ip addresses using [fail2ban](https://www.fail2ban.org/).
+The [Fail2ban (`fail2ban`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fail2ban/README.md) gathers the count of failed and banned ip addresses using [fail2ban](https://www.fail2ban.org/).
 
-### [Fibaro (`fibaro`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/fibaro)
+### [Fibaro (`fibaro`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fibaro/README.md)
 
-The [Fibaro (`fibaro`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/fibaro) makes HTTP calls to the Fibaro controller API to gather values of hooked devices. Those values could be true (`1`) or false (`0`) for switches, percentage for dimmers, temperature, etc.
+The [Fibaro (`fibaro`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fibaro/README.md) makes HTTP calls to the Fibaro controller API to gather values of hooked devices. Those values could be true (`1`) or false (`0`) for switches, percentage for dimmers, temperature, etc.
 
-### [File (`file`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/file) -- NEW in v.1.8
+### [File (`file`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/file/README.md) -- NEW in v.1.8
 
-The [File (`file`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/file) updates a list of files every interval and parses the contents using the selected input data format.
+The [File (`file`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/file/README.md) updates a list of files every interval and parses the contents using the selected input data format.
 
 Files will always be read in their entirety, if you wish to tail/follow a file use the [tail input plugin](#tail-tail) instead.
 
-### [Filecount (`filecount`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/filecount) -- NEW in v.1.8
+### [Filecount (`filecount`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filecount/README.md) -- NEW in v.1.8
 
-The [Filecount (`filecount`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/filecount) counts files in directories that match certain criteria.
+The [Filecount (`filecount`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filecount/README.md) counts files in directories that match certain criteria.
 
-### [Filestat (`filestat`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/filestat)
+### [Filestat (`filestat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filestat/README.md)
 
-The [Filestat (`filestat`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/filestat) gathers metrics about file existence, size, and other stats.
+The [Filestat (`filestat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filestat/README.md) gathers metrics about file existence, size, and other stats.
 
-### [Fluentd (`fluentd`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/fluentd)
+### [Fluentd (`fluentd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fluentd/README.md)
 
-The [Fluentd (`fluentd`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/fluentd) gathers metrics from plugin endpoint provided by in_monitor plugin. This plugin understands
+The [Fluentd (`fluentd`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fluentd/README.md) gathers metrics from plugin endpoint provided by in_monitor plugin. This plugin understands
 data provided by `/api/plugin.json` resource (`/api/config.json` is not covered).
 
-### [Graylog (`graylog`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/graylog)
+### [Graylog (`graylog`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/graylog/README.md)
 
-The [Graylog (`graylog`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/graylog) can collect data from remote Graylog service URLs. This plugin currently supports two
+The [Graylog (`graylog`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/graylog/README.md) can collect data from remote Graylog service URLs. This plugin currently supports two
 types of endpoints:
 
 * multiple (e.g., `http://[graylog-server-ip]:12900/system/metrics/multiple`)
 * namespace (e.g., `http://[graylog-server-ip]:12900/system/metrics/namespace/{namespace}`)
 
-### [HAproxy (`haproxy`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/haproxy)
+### [HAproxy (`haproxy`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/haproxy/README.md)
 
-The [HAproxy (`haproxy`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/haproxy) gathers metrics directly from any running HAproxy instance. It can do so by using CSV
+The [HAproxy (`haproxy`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/haproxy/README.md) gathers metrics directly from any running HAproxy instance. It can do so by using CSV
 generated by HAproxy status page or from admin sockets.
 
-### [Hddtemp (`hddtemp`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/hddtemp)
+### [Hddtemp (`hddtemp`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/hddtemp/README.md)
 
-The [Hddtemp (`hddtemp`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/hddtemp) reads data from `hddtemp` daemons.
+The [Hddtemp (`hddtemp`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/hddtemp/README.md) reads data from `hddtemp` daemons.
 
-### [HTTP (`http`)](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/http)
+### [HTTP (`http`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http/README.md)
 
-The [HTTP (`http`) input plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/http) collects metrics from one or more HTTP (or HTTPS) endpoints. The endpoint should have metrics formatted in one of the supported input data formats. Each data format has its own unique set of configuration options which can be added to the input configuration.
+The [HTTP (`http`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http/README.md) collects metrics from one or more HTTP (or HTTPS) endpoints. The endpoint should have metrics formatted in one of the supported input data formats. Each data format has its own unique set of configuration options which can be added to the input configuration.
 
-### [HTTP Listener (`http_listener`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener)
+### [HTTP Listener (`http_listener`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md)
 
-The [HTTP Listener (`http_listener`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_listener) listens for messages sent via HTTP POST. Messages are expected in the InfluxDB
+The [HTTP Listener (`http_listener`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md) listens for messages sent via HTTP POST. Messages are expected in the InfluxDB
 line protocol format ONLY (other Telegraf input data formats are not supported). The plugin allows Telegraf to serve
 as a proxy/router for the `/write` endpoint of the InfluxDB HTTP API.
 
-### [HTTP Response (`http_response`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_response)
+### [HTTP Response (`http_response`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_response/README.md)
 
-The [HTTP Response (`http_response`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/http_response) gathers metrics for HTTP responses. The measurements and fields include `response_time`, `http_response_code`, and `result_type`. Tags for measurements include `server` and `method`.
+The [HTTP Response (`http_response`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_response/README.md) gathers metrics for HTTP responses. The measurements and fields include `response_time`, `http_response_code`, and `result_type`. Tags for measurements include `server` and `method`.
 
 ### [Icinga2 (`icinga2`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/incinga2) -- NEW in v.1.8
 
@@ -236,65 +241,65 @@ The [Ipset (`ipset`) input plugin](https://github.com/influxdata/telegraf/tree/m
 
 The [IPtables (`iptables`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/iptables) gathers packets and bytes counters for rules within a set of table and chain from the Linux's iptables firewall.
 
-### [Jolokia2 Agent (`jolokia2_agent`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jolokia2/README.md)
+### [Jolokia2 Agent (`jolokia2_agent`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jolokia2/README.md)
 
-The [Jolokia2 Agent (`jolokia2_agent`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jolokia2/README.md) reads JMX metrics from one or more [Jolokia](https://jolokia.org/) agent REST endpoints using the
+The [Jolokia2 Agent (`jolokia2_agent`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jolokia2/README.md) reads JMX metrics from one or more [Jolokia](https://jolokia.org/) agent REST endpoints using the
  [JSON-over-HTTP protocol](https://jolokia.org/reference/html/protocol.html).
 
 ### [Jolokia2 Proxy (`jolokia2_proxy`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jolokia2/README.md)
 
 The [Jolokia2 Proxy (`jolokia2_proxy`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jolokia2/README.md) eads JMX metrics from one or more targets by interacting with a [Jolokia](https://jolokia.org/) proxy REST endpoint using the [Jolokia](https://jolokia.org/) [JSON-over-HTTP protocol](https://jolokia.org/reference/html/protocol.html).
 
-### [JTI OpenConfig Telemetry](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jti_openconfig_telemetry)
+### [JTI OpenConfig Telemetry (`jti_openconfig_telemetry`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jti_openconfig_telemetry/README.md)
 
-The [JTI OpenConfig Telemetry (`jti_openconfig_telemetry`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jti_openconfig_telemetry) reads Juniper Networks implementation of OpenConfig telemetry data from listed sensors using the Junos Telemetry Interface. Refer to
+The [JTI OpenConfig Telemetry (`jti_openconfig_telemetry`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jti_openconfig_telemetry/README.md) reads Juniper Networks implementation of OpenConfig telemetry data from listed sensors using the Junos Telemetry Interface. Refer to
 [openconfig.net](http://openconfig.net/) for more details about OpenConfig and [Junos Telemetry Interface (JTI)](https://www.juniper.net/documentation/en_US/junos/topics/concept/junos-telemetry-interface-oveview.html).
 
 
-### [Kafka Consumer (`kafka_consumer`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer)
+### [Kafka Consumer (`kafka_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kafka_consumer/README.md)
 
-The [Kafka Consumer (`kafka_consumer`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kafka_consumer) polls a specified Kafka topic and adds messages to InfluxDB.
+The [Kafka Consumer (`kafka_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kafka_consumer/README.md) polls a specified Kafka topic and adds messages to InfluxDB.
 Messages are expected in the line protocol format.
 [Consumer Group](http://godoc.org/github.com/wvanbergen/kafka/consumergroup) is used to talk to the Kafka cluster so
 multiple instances of Telegraf can read from the same topic in parallel.
 
-### [Kapacitor (`kapacitor`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kapacitor)
+### [Kapacitor (`kapacitor`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kapacitor/README.md)
 
-The [Kapacitor (`kapacitor`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kapacitor) will collect metrics from the given Kapacitor instances.
+The [Kapacitor (`kapacitor`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kapacitor/README.md) will collect metrics from the given Kapacitor instances.
 
-### [Kernel (`kernel`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/KERNEL_README.md)
+### [Kernel (`kernel`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kernel/README.md)
 
-The [Kernel (`kernel`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/KERNEL_README.md) gathers kernel statistics from `/proc/stat`.
+The [Kernel (`kernel`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kernel/README.md) gathers kernel statistics from `/proc/stat`.
 
-### [Kernel VMStat (`kernel_vmstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/KERNEL_VMSTAT_README.md)
+### [Kernel VMStat (`kernel_vmstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kernel_vmstat/README.md)
 
-The [Kernel VMStat input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/KERNEL_VMSTAT_README.md) gathers kernel statistics from `/proc/vmstat`.
+The [Kernel VMStat input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kernel_vmstat/README.md) gathers kernel statistics from `/proc/vmstat`.
 
-### [Kibana (`kibana`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kibana) -- NEW in v.1.8
+### [Kibana (`kibana`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kibana/README.md) -- NEW in v.1.8
 
-The [Kibana (`kibana`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kibana) queries the Kibana status API to obtain the health status of Kibana and some useful metrics.
+The [Kibana (`kibana`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kibana/README.md) queries the Kibana status API to obtain the health status of Kibana and some useful metrics.
 
-### [Kubernetes (`kubernetes`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kubernetes)
+### [Kubernetes (`kubernetes`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kubernetes/README.md)
 
 >***Note:*** The Kubernetes input plugin is experimental and may cause high cardinality issues with moderate to
 large Kubernetes deployments.
 
-The [Kubernetes (`kubernetes`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/kubernetes) talks to the kubelet API using the `/stats/summary` endpoint to gather metrics about the running pods
+The [Kubernetes (`kubernetes`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kubernetes/README.md) talks to the kubelet API using the `/stats/summary` endpoint to gather metrics about the running pods
 and containers for a single host. It is assumed that this plugin is running as part of a daemonset within a
 Kubernetes installation. This means that Telegraf is running on every node within the cluster. Therefore, you
 should configure this plugin to talk to its locally running kubelet.
 
-### [LeoFS (`leofs`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/leofs)
+### [LeoFS (`leofs`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/leofs/README.md)
 
-The [LeoFS (`leofs`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/leofs) gathers metrics of LeoGateway, LeoManager, and LeoStorage using SNMP. See [System monitoring](https://leo-project.net/leofs/docs/admin/system_admin/monitoring/) in the [LeoFS documentation](https://leo-project.net/leofs/docs/) for more information.
+The [LeoFS (`leofs`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/leofs/README.md) gathers metrics of LeoGateway, LeoManager, and LeoStorage using SNMP. See [System monitoring](https://leo-project.net/leofs/docs/admin/system_admin/monitoring/) in the [LeoFS documentation](https://leo-project.net/leofs/docs/) for more information.
 
-### [Linux Sysctl FS (`linux_sysctl_fs`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/LINUX_SYSCTL_FS_README.md)
+### [Linux Sysctl FS (`linux_sysctl_fs`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/linux_sysctl_fs/README.md)
 
-The [Linux Sysctl FS input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/LINUX_SYSCTL_FS_README.md) provides Linux system level file (`sysctl fs`) metrics. The documentation on these fields can be found at https://www.kernel.org/doc/Documentation/sysctl/fs.txt.
+The [Linux Sysctl FS input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/linux_sysctl_fs/README.md) provides Linux system level file (`sysctl fs`) metrics. The documentation on these fields can be found at https://www.kernel.org/doc/Documentation/sysctl/fs.txt.
 
-### [Logparser (`logparser`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/logparser)
+### [Logparser (`logparser`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/logparser/README.md)
 
-The [Logparser (`logparser`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/logparser) streams and parses the given log files. Currently, it has the capability of parsing "grok" patterns
+The [Logparser (`logparser`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/logparser/README.md) streams and parses the given log files. Currently, it has the capability of parsing "grok" patterns
 from log files, which also supports regular expression (regex) patterns.
 
 ### [Lustre2 (`lustre2`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/lustre2)
@@ -306,185 +311,187 @@ The [Lustre2 (`lustre2`) input plugin](https://github.com/influxdata/telegraf/tr
 
 The [Mailchimp (`mailchimp`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mailchimp) gathers metrics from the `/3.0/reports` MailChimp API.
 
-### [Mcrouter (`mcrouter`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mcrouter)
+### [Mcrouter (`mcrouter`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mcrouter/README.md)
 
-The [mcrouter (`mcrouter`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mcrouter) gathers statistics data from a mcrouter instance. [Mcrouter](https://github.com/facebook/mcrouter) is a memcached protocol router, developed and maintained by Facebook, for scaling memcached (http://memcached.org/) deployments. It's a core component of cache infrastructure at Facebook and Instagram where mcrouter handles almost 5 billion requests per second at peak.
+The [mcrouter (`mcrouter`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mcrouter/README.md) gathers statistics data from a mcrouter instance. [Mcrouter](https://github.com/facebook/mcrouter) is a memcached protocol router, developed and maintained by Facebook, for scaling memcached (http://memcached.org/) deployments. It's a core component of cache infrastructure at Facebook and Instagram where mcrouter handles almost 5 billion requests per second at peak.
 
-### [Mem (`mem`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/MEM_README.md)
+### [Mem (`mem`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mem/README.md)
 
-The [Mem (`mem`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/MEM_README.md) collects system memory metrics. For a more complete explanation of the difference between used and actual_used RAM, see [Linux ate my ram](https://www.linuxatemyram.com/).
+The [Mem (`mem`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mem/README.md) collects system memory metrics. For a more complete explanation of the difference between used and actual_used RAM, see [Linux ate my ram](https://www.linuxatemyram.com/).
 
+### [Memcached (`memcached`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/memcached/README.md)
 
-### [Memcached (`memcached`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/memcached)
+The [Memcached (`memcached`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/memcached/README.md) gathers statistics data from a Memcached server.
 
-The [Memcached (`memcached`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/memcached) gathers statistics data from a Memcached server.
+### [Mesos (`mesos`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mesos/README.md)
 
-### [Mesos (`mesos`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mesos)
-
-The [Mesos (`mesos`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mesos) gathers metrics from Mesos. For more information, please check the
+The [Mesos (`mesos`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mesos/README.md) gathers metrics from Mesos. For more information, please check the
 [Mesos Observability Metrics](http://mesos.apache.org/documentation/latest/monitoring/) page.
 
-### [Minecraft (`minecraft`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/minecraft)
+### [Mesosphere DC/OS (`dcos`)](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dcos/README.md)
 
-The [Minecraft (`minecraft`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/minecraft) uses the RCON protocol to collect statistics from a scoreboard on a Minecraft server.
+The [Mesosphere DC/OS (`dcos`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dcos/README.md) gathers metrics from a DC/OS cluster's [metrics component](https://docs.mesosphere.com/1.10/metrics/).
 
-### [MongoDB (`mongodb`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mongodb)
+### [Microsoft SQL Server (`sqlserver`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sqlserver/README.md)
 
-The [MongoDB (`mongodb`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mongodb) collects mongodb stats exposed by serverStatus and few more and create a single
+The [Microsoft SQL Server (`sqlserver`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sqlserver/README.md) provides metrics for your Microsoft SQL Server instance. It currently works with SQL Server
+versions 2008+. Recorded metrics are lightweight and use Dynamic Management Views supplied by SQL Server.
+
+### [Minecraft (`minecraft`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/minecraft/README.md)
+
+The [Minecraft (`minecraft`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/minecraft/README.md) uses the RCON protocol to collect statistics from a scoreboard on a Minecraft server.
+
+### [MongoDB (`mongodb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mongodb/README.md)
+
+The [MongoDB (`mongodb`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mongodb/README.md) collects MongoDB stats exposed by `serverStatus` and few more and create a single
 measurement containing values.
 
-### [MQTT Consumer (`mqtt_consumer`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mqtt_consumer)
+### [MQTT Consumer (`mqtt_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mqtt_consumer/README.md)
 
-The [MQTT Consumer (`mqtt_consumer`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mqtt_consumer) reads from specified MQTT topics and adds messages to InfluxDB. Messages are in the
+The [MQTT Consumer (`mqtt_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mqtt_consumer/README.md) reads from specified MQTT topics and adds messages to InfluxDB. Messages are in the
 Telegraf Input Data Formats.
 
-### [MySQL `(mysql`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mysql)
+### [MySQL `(mysql`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mysql/README.md)
 
-The [MySQL (`mysql`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mysql) gathers the statistics data from MySQL servers.
+The [MySQL (`mysql`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mysql/README.md) gathers the statistics data from MySQL servers.
 
-### [NATS Server Monitoring (`nats`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nats)
+### [NATS Consumer (`nats_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats_consumer/README.md)
 
-The [NATS Server Monitoring (`nats`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nats) gathers metrics when using the [NATS Server monitoring server](https://www.nats.io/documentation/server/gnatsd-monitoring/).
+The [NATS Consumer (`nats_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats_consumer/README.md) reads from specified NATS subjects and adds messages to InfluxDB. Messages are expected in the Telegraf Input Data Formats. A Queue Group is used when subscribing to subjects so multiple instances of Telegraf can read from a NATS cluster in parallel.
 
-### [NATS Consumer (`nats_consumer`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nats_consumer)
+### [NATS Server Monitoring (`nats`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats/README.md)
 
-The [NATS Consumer (`nats_consumer`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nats_consumer) reads from specified NATS subjects and adds messages to InfluxDB. Messages are expected in the Telegraf Input Data Formats. A Queue Group is used when subscribing to subjects so multiple instances of Telegraf can read from a NATS cluster in parallel.
+The [NATS Server Monitoring (`nats`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats/README.md) gathers metrics when using the [NATS Server monitoring server](https://www.nats.io/documentation/server/gnatsd-monitoring/).
 
-### [Net (`net`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/NET_README.md)
+### [Net (`net`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NET_README.md)
 
-The [Net (`net`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/NET_README.md) gathers metrics about network interface usage (Linux only).
+The [Net (`net`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NET_README.md) gathers metrics about network interface usage (Linux only).
 
-### [Network Response (`net_response`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/net_response)
+### [Netstat (`netstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NETSTAT_README.md)
 
-The [Network Response (`net_response`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/net_response) tests UDP and TCP connection response time. It can also check response text.
+The [Netstat (`netstat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NETSTAT_README.md) gathers TCP metrics such as established, time-wait and sockets counts by using `lsof`.
 
-### [Netstat (`netstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/NETSTAT_README.md)
+### [Network Response (`net_response`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net_response/README.md)
 
-The [Netstat (`netstat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/NETSTAT_README.md) gathers TCP metrics such as established, time-wait and sockets counts by using `lsof`.
+The [Network Response (`net_response`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net_response/README.md) tests UDP and TCP connection response time. It can also check response text.
 
-### [NGINX (`nginx`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nginx)
+### [NGINX (`nginx`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx/README.md)
 
-The [NGINX (nginx) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nginx) reads NGINX basic status information (`ngx_http_stub_status_module`).
+The [NGINX (nginx) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx/README.md) reads NGINX basic status information (`ngx_http_stub_status_module`).
 
-### [NGINX Plus (`nginx_plus`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nginx_plus/README.md)
+### [NGINX Plus (`nginx_plus`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx_plus/README.md)
 
-The [NGINX Plus (`nginx_plus`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nginx_plus/README.md) is for NGINX Plus, the commercial version of the open source web server NGINX. To use this plugin you will need a license.
+The [NGINX Plus (`nginx_plus`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx_plus/README.md) is for NGINX Plus, the commercial version of the open source web server NGINX. To use this plugin you will need a license.
 For more information, see [What’s the Difference between Open Source NGINX and NGINX Plus?](https://www.nginx.com/blog/whats-difference-nginx-foss-nginx-plus/).
 
 Structures for NGINX Plus have been built based on history of [status module documentation](http://nginx.org/en/docs/http/ngx_http_status_module.html).
 
 ### [NSQ (`nsq`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nsq)
 
+### [NSQ Consumer (`nsq_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nsq_consumer/README.md)
 
-### [NSQ Consumer (`nsq_consumer`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nsq_consumer)
+The [NSQ Consumer (`nsq_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nsq_consumer/README.md) polls a specified NSQD topic and adds messages to InfluxDB. This plugin allows a message to be in any of the supported data_format types.
 
-The [NSQ Consumer (`nsq_consumer`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nsq_consumer) polls a specified NSQD topic and adds messages to InfluxDB. This plugin allows a message to be in any of the supported data_format types.
+### [Nstat (`nstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nstat/README.md)
 
-### [Nstat (`nstat`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nstat)
+The [Nstat (`nstat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nstat/README.md) collects network metrics from `/proc/net/netstat`, `/proc/net/snmp`, and `/proc/net/snmp6` files.
 
-The [Nstat (`nstat`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nstat) collects network metrics from `/proc/net/netstat`, `/proc/net/snmp`, and `/proc/net/snmp6` files.
+### [NTPq (`ntpq`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ntpq/README.md)
 
-### [NTPq (`ntpq`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/ntpq)
+The [NTPq (`ntpq`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ntpq/README.md) gets standard NTP query metrics, requires ntpq executable.
 
-The [NTPq (`ntpq`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/ntpq) gets standard NTP query metrics, requires ntpq executable.
+### [NVIDIA SMI (`nvidia-smi`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nvidia_smi/README.md)
 
-### [NVIDIA SMI (`nvidia-smi`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nvidia_smi)
+The [NVIDIA SMI (`nvidia-smi`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nvidia_smi/README.md) uses a query on the [NVIDIA System Management Interface (`nvidia-smi`)](https://developer.nvidia.com/nvidia-system-management-interface) binary to pull GPU stats including memory and GPU usage, temp and other.
 
-The [NVIDIA SMI (`nvidia-smi`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nvidia_smi) uses a query on the [NVIDIA System Management Interface (`nvidia-smi`)](https://developer.nvidia.com/nvidia-system-management-interface) binary to pull GPU stats including memory and GPU usage, temp and other.
+### [OpenLDAP (`openldap`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/openldap/README.md)
 
-### [OpenLDAP (`openldap`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/openldap)
+The [OpenLDAP (`openldap`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/openldap/README.md) gathers metrics from OpenLDAP's `cn=Monitor` backend.
 
-The [OpenLDAP (`openldap`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/openldap) gathers metrics from OpenLDAP's `cn=Monitor` backend.
+### [OpenSMTPD (`opensmtpd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/opensmtpd/README.md)
 
-### [OpenSMTPD (`opensmtpd`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/opensmtpd/README.md)
+The [OpenSMTPD (`opensmtpd`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/opensmtpd/README.md) gathers stats from [OpenSMTPD](https://www.opensmtpd.org/), a free implementation of the server-side SMTP protocol.
 
-The [OpenSMTPD (`opensmtpd`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/opensmtpd/README.md) gathers stats from OpenSMTPD, a free implementation of the server-side SMTP protocol.
+### [PF (`pf`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pf/README.md)
 
-### [Particle.io Webhooks (`particle`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/particle/README.md)
-
-The [Particle.io Webhooks (`particle`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/particle/README.md) enables [Particle webhooks](https://docs.particle.io/guide/tools-and-features/webhooks/) to gather Particle device data which gets routed through the Particle Device Cloud into InfluxDB. For more information on the Particle webhook integration, see [InfluxData Integration](https://docs.particle.io/tutorials/integrations/influxdata/core/).
-
-### [Passenger (`passenger`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/passenger)
-
-The [Passenger (`passenger`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/passenger) gets phusion passenger statistics using their command line utility `passenger-status`.
-
-### [PF (`pf`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/pf/README.md)
-
-The [PF (`pf`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/pf/README.md) gathers information from the FreeBSD/OpenBSD pf firewall. Currently it can retrive information about
+The [PF (`pf`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pf/README.md) gathers information from the FreeBSD/OpenBSD pf firewall. Currently it can retrive information about
 the state table: the number of current entries in the table, and counters for the number of searches, inserts, and
 removals to the table. The pf plugin retrieves this information by invoking the `pfstat` command.
 
-### [PgBouncer (`pgbouncer`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/pgbouncer) -- NEW in v.1.8
+### [PgBouncer (`pgbouncer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pgbouncer/README.md) -- NEW in v.1.8
 
-The [PgBouncer (`pgbouncer`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/pgbuncer) provides metrics for your PgBouncer load balancer. For information about the metrics, see the [PgBouncer documentation](https://pgbouncer.github.io/usage.html).
+The [PgBouncer (`pgbouncer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pgbouncer/README.md) provides metrics for your PgBouncer load balancer. For information about the metrics, see the [PgBouncer documentation](https://pgbouncer.github.io/usage.html).
 
-### [PHP FPM (`phpfpm`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/phpfpm)
+### [Phfusion Passenger (`passenger`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/passenger/README.md)
 
-The [PHP FPM (`phpfpm`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/phpfpm) gets phpfpm statistics using either HTTP status page or fpm socket.
+The [Phfusion 0Passenger (`passenger`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/passenger/README.md) gets Phusion Passenger statistics using their command line utility `passenger-status`.
 
-### [Ping (`ping`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/ping)
+### [PHP FPM (`phpfpm`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/phpfpm/README.md)
 
-The [Ping (`ping`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/ping) measures the round-trip for ping commands, response time, and other packet statistics.
+The [PHP FPM (`phpfpm`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/phpfpm/README.md) gets phpfpm statistics using either HTTP status page or fpm socket.
 
-### [Postfix (`postfix`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/postfix/README.md)
+### [Ping (`ping`)](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ping/README.md)
 
-The [Postfix (`postfix`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/postfix/README.md) reports metrics on the postfix queues. For each of the active, hold, incoming, maildrop, and
+The [Ping (`ping`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ping/README.md) measures the round-trip for ping commands, response time, and other packet statistics.
+
+### [Postfix (`postfix`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postfix/README.md)
+
+The [Postfix (`postfix`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postfix/README.md) reports metrics on the postfix queues. For each of the active, hold, incoming, maildrop, and
 deferred [queues](http://www.postfix.org/QSHAPE_README.html#queues), it will report the queue length (number of items),
 size (bytes used by items), and age (age of oldest item in seconds).
 
-### [PostgreSQL (`postgresql`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/postgresql)
+### [PostgreSQL (`postgresql`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postgresql/README.md)
 
-The [PostgreSQL (`postgresql`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/postgresql) provides metrics for your PostgreSQL database. It currently works with PostgreSQL versions 8.1+.
+The [PostgreSQL (`postgresql`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postgresql/README.md) provides metrics for your PostgreSQL database. It currently works with PostgreSQL versions 8.1+.
 It uses data from the built in `pg_stat_database` and `pg_stat_bgwriter` views. The metrics recorded depend on your
 version of postgres.
 
-### [PostgreSQL Extensible (`postgresql_extensible`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/postgresql_extensible)
+### [PostgreSQL Extensible (`postgresql_extensible`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postgresql_extensible/README.md)
 
-This [PostgreSQL Extensible (`postgresql_extensible`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/postgresql_extensible) provides metrics for your postgres database. It has been designed to parse
-SQL queries in the plugin section of `telegraf.conf` files.
+This [PostgreSQL Extensible (`postgresql_extensible`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/postgresql_extensible) provides metrics for your Postgres database. It has been designed to parse SQL queries in the plugin section of `telegraf.conf` files.
 
-### [PowerDNS (`powerdns`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/powerdns)
+### [PowerDNS (`powerdns`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/powerdns/README.md)
 
-The [PowerDNS (`powerdns`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/powerdns) gathers metrics about PowerDNS using UNIX sockets.
+The [PowerDNS (`powerdns`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/powerdns/README.md) gathers metrics about PowerDNS using UNIX sockets.
 
-### [Processes (`processes`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/PROCESSES_README.md)
+### [Processes (`processes`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/processes/README.md)
 
-The [Processes (`processes`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/PROCESSES_README.md)
+The [Processes (`processes`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/processes/README.md)
 gathers info about the total number of processes and groups them by status (zombie, sleeping, running, etc.). On Linux, this plugin requires access to `procfs` (`/proc`); on other operating systems, it requires access to execute `ps`.
 
-### [Procstat (`procstat`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/procstat)
+### [Procstat (`procstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/procstat/README.md)
 
-The [Procstat (`procstat`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/procstat) can be used to monitor system resource usage by an individual process using their `/proc` data.
+The [Procstat (`procstat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/procstat/README.md) can be used to monitor system resource usage by an individual process using their `/proc` data.
 
 Processes can be specified either by `pid` file, by executable name, by command line pattern matching, by username,
 by systemd unit name, or by cgroup name/path (in this order or priority). This plugin uses `pgrep` when an executable
 name is provided to obtain the `pid`. The Procstat plugin transmits IO, memory, cpu, file descriptor-related
 measurements for every process specified. A prefix can be set to isolate individual process specific measurements.
 
-The plugin will tag processes according to how they are specified in the configuration. If a pid file is used, a
+The Procstat input plugin will tag processes according to how they are specified in the configuration. If a pid file is used, a
 "pidfile" tag will be generated. On the other hand, if an executable is used an "exe" tag will be generated.
 
-### [Prometheus (`prometheus`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/prometheus)
+### [Prometheus Format  (`prometheus`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/prometheus/README.md)
 
-The [Prometheus (`prometheus`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/prometheus) input plugin gathers metrics from HTTP servers exposing metrics in Prometheus format.
+The [Prometheus Format (`prometheus`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/prometheus/README.md) input plugin gathers metrics from HTTP servers exposing metrics in Prometheus format.
 
-### [PuppetAgent (`puppetagent`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/puppetagent)
+### [Puppet Agent (`puppetagent`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/puppetagent)
 
-The [PuppetAgent (`puppetagent`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/puppetagent) collects variables outputted from the `last_run_summary.yaml` file usually
-located in `/var/lib/puppet/state/` PuppetAgent Runs.
+The [Puppet Agent (`puppetagent`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/puppetagent) collects variables outputted from the `last_run_summary.yaml` file usually
+located in `/var/lib/puppet/state/` Puppet Agent Runs. For more information, see [Puppet Monitoring: How  to Monitor the Success or Failure of Puppet Runs](https://puppet.com/blog/puppet-monitoring-how-to-monitor-success-or-failure-of-puppet-runs)
 
-### [RabbitMQ (`rabbitmq`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/rabbitmq)
+### [RabbitMQ (`rabbitmq`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/rabbitmq/README.md)
 
-The [RabbitMQ (`rabbitmq`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/rabbitmq) reads metrics from RabbitMQ servers via the [Management Plugin](https://www.rabbitmq.com/management.html).
+The [RabbitMQ (`rabbitmq`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/rabbitmq/README.md) reads metrics from RabbitMQ servers via the [Management Plugin](https://www.rabbitmq.com/management.html).
 
-### [Raindrops (`raindrops`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/raindrops)
+### [Raindrops Middleware (`raindrops`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/raindrops/README.md)
 
-The [Raindrops (`raindrops`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/raindrops) reads from specified Raindops [middleware](http://raindrops.bogomips.org/Raindrops/Middleware.html)
+The [Raindrops Middleware (`raindrops`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/raindrops/README.md) reads from the specified [Raindrops middleware](http://raindrops.bogomips.org/Raindrops/Middleware.html)
 URI and adds the statistics to InfluxDB.
 
-### [Redis (`redis`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/redis)
+### [Redis (`redis`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/redis/README.md)
 
-The [Redis (`redis`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/redis) gathers the results of the INFO Redis command. There are two separate measurements: `redis`
+The [Redis (`redis`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/redis/README.md) gathers the results of the INFO Redis command. There are two separate measurements: `redis`
 and `redis_keyspace`, the latter is used for gathering database-related statistics.
 
 Additionally the plugin also calculates the hit/miss ratio (`keyspace_hitrate`) and the elapsed time since the last RDB
@@ -495,58 +502,49 @@ save (`rdb_last_save_time_elapsed`).
 The [RethinkDB (`rethinkdb`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/rethinkdb) works with RethinkDB 2.3.5+ databases that requires username, password authorization,
 and Handshake protocol v1.0.
 
-### [Riak (`riak`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/riak)
+### [Riak (`riak`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/riak/README.md)
 
-The [Riak (`riak`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/riak) gathers metrics from one or more Riak instances.
+The [Riak (`riak`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/riak/README.md) gathers metrics from one or more Riak instances.
 
-### [Salesforce (`salesforce`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/salesforce)
+### [Salesforce (`salesforce`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/salesforce/README.md)
 
-The [Salesforce (`salesforce`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/salesforce) gathers metrics about the limits in your Salesforce organization and the remaining usage.
+The [Salesforce (`salesforce`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/salesforce/README.md) gathers metrics about the limits in your Salesforce organization and the remaining usage.
 It fetches its data from the limits endpoint of the Salesforce REST API.
 
-### [Sensors (`sensors`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/sensors)
+### [Sensors (`sensors`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sensors/README.md)
 
-The [Sensors (`sensors`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/sensors) collects collects sensor metrics with the sensors executable from the `lm-sensor` package.
+The [Sensors (`sensors`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sensors/README.md) collects collects sensor metrics with the sensors executable from the `lm-sensor` package.
 
-### [SMART (`smart`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/smart/README.md)
+### [SMART (`smart`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/smart/README.md)
 
-The [SMART (`smart`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/smart/README.md) gets metrics using the command line utility `smartctl` for S.M.A.R.T. (Self-Monitoring, Analysis
+The [SMART (`smart`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/smart/README.md) gets metrics using the command line utility `smartctl` for SMART (Self-Monitoring, Analysis
 and Reporting Technology) storage devices. SMART is a monitoring system included in computer hard disk drives (HDDs)
 and solid-state drives (SSDs), which include most modern ATA/SATA, SCSI/SAS and NVMe disks. The plugin detects and
 reports on various indicators of drive reliability, with the intent of enabling the anticipation of hardware failures.
 See [smartmontools](https://www.smartmontools.org/).
 
-### [SNMP (`snmp`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/snmp)
+### [SNMP (`snmp`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp/README.md)
 
-The [SNMP (`snmp`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/snmp) gathers metrics from SNMP agents.
+The [SNMP (`snmp`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp/README.md) gathers metrics from SNMP agents.
 
-### [Socket Listener (`socket_listener`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/socket_listener)
+### [Socket Listener (`socket_listener`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/socket_listener/README.md)
 
-The [Socket Listener (`socket_listener`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/socket_listener) listens for messages from streaming (tcp, unix) or datagram
+The [Socket Listener (`socket_listener`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/socket_listener/README.md) listens for messages from streaming (tcp, unix) or datagram
 (UDP, unixgram) protocols. Messages are expected in the
 [Telegraf Input Data Formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md).
 
-### [Solr (`solr`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/solr/README.md)
+### [StatsD (`statsd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/statsd/README.md)
 
-The [Solr (`solr`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/solr/README.md) collects stats using the MBean Request Handler.
-
-### [SQL Server (`sqlserver`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/sqlserver)
-
-The [SQL Server (`sqlserver`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/sqlserver) provides metrics for your Microsoft SQL Server instance. It currently works with SQL Server
-versions 2008+. Recorded metrics are lightweight and use Dynamic Management Views supplied by SQL Server.
-
-### [StatsD (`statsd`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/statsd)
-
-The [StatsD (`statsd`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/statsd) is a special type of plugin which runs a backgrounded `statsd` listener service while Telegraf is running.
+The [StatsD (`statsd`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/statsd/README.md) is a special type of plugin which runs a backgrounded `statsd` listener service while Telegraf is running.
 StatsD messages are formatted as described in the original [etsy statsd](https://github.com/etsy/statsd/blob/master/docs/metric_types.md) implementation.
 
-### [Swap (`swap`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/SWAP_README.md)
+### [Swap (`swap`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/swap/README.md)
 
-The [Swap (`swap`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/SWAP_README.md) gathers metrics about swap memory usage. For more information about Linux swap spaces, see [All about Linux swap space](https://www.linux.com/news/all-about-linux-swap-space)
+The [Swap (`swap`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/swap/README.md) gathers metrics about swap memory usage. For more information about Linux swap spaces, see [All about Linux swap space](https://www.linux.com/news/all-about-linux-swap-space)
 
-### [Syslog (`syslog`)](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/syslog)
+### [Syslog (`syslog`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/syslog/README.md)
 
-The [Syslog (`syslog`) input plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/syslog) listens for syslog messages transmitted over
+The [Syslog (`syslog`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/syslog/README.md) listens for syslog messages transmitted over
 [UDP](https://tools.ietf.org/html/rfc5426) or [TCP](https://tools.ietf.org/html/rfc5425). Syslog messages should be formatted according to [RFC 5424](https://tools.ietf.org/html/rfc5424).
 
 ### [Sysstat (`sysstat`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/sysstat)
@@ -554,37 +552,30 @@ The [Syslog (`syslog`) input plugin](https://github.com/influxdata/telegraf/tree
 The [Sysstat (`sysstat`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/sysstat) collects [sysstat](https://github.com/sysstat/sysstat) system metrics with the sysstat
 collector utility `sadc` and parses the created binary data file with the `sadf` utility.
 
-### [System (`system`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/SYSTEM_README.md)
+### [System (`system`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/README.md)
 
-The [System (`system`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/SYSTEM_README.md) gathers general stats on system load, uptime, and number of users logged in. It is basically equivalent to the UNIX `uptime` command.
+The [System (`system`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/README.md) gathers general stats on system load, uptime, and number of users logged in. It is basically equivalent to the UNIX `uptime` command.
 
-### [Tail (`tail`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/tail)
+### [Tail (`tail`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tail/README.md)
 
-The [Tail (`tail`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/tail) "tails" a logfile and parses each log message.
+The [Tail (`tail`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tail/README.md) "tails" a log file and parses each log message.
 
-### [Teamspeak 3 (`teamspeak`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/teamspeak/README.md)
+### [Teamspeak 3 (`teamspeak`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/teamspeak/README.md)
 
-The [Teamspeak 3 (`teamspeak`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/teamspeak/README.md) uses the Teamspeak 3 ServerQuery interface of the Teamspeak server to collect statistics of one or more virtual servers.
+The [Teamspeak 3 (`teamspeak`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/teamspeak/README.md) uses the Teamspeak 3 ServerQuery interface of the Teamspeak server to collect statistics of one or more virtual servers.
 
 ### [Telegraf v1.x (`internal`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/internal)
 
 The [Telegraf v1.x (`internal`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/internal) collects metrics about the Telegraf v1.x agent itself.
 Note that some metrics are aggregates across all instances of one type of plugin.
 
-### [Temp (`temp`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/temp) -- NEW in v.1.8
+### [Temp (`temp`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/temp/README.md) -- NEW in v.1.8
 
-The [Temp (`temp`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/temp) collects temperature data from sensors.
+The [Temp (`temp`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/temp/README.md) collects temperature data from sensors.
 
-### [Tengine (`tengine`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/tengine) -- NEW in v.1.8
+### [Tengine Web Server (`tengine`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tengine/README.md) -- NEW in v.1.8
 
-The [Tengine (`tengine`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/tengine) gathers status metrics from the [Tengine Web Server](http://tengine.taobao.org/) using the [Reqstat module](http://tengine.taobao.org/document/http_reqstat.html).
-
-### [Tomcat (`tomcat`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/tomcat)
-
-The [Tomcat (`tomcat`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/tomcat) collects statistics available from the tomcat manager status page from
-the `http://<host>/manager/status/all?XML=true` URL. (`XML=true` will return only XML data).
-See the [Tomcat documentation](https://tomcat.apache.org/tomcat-9.0-doc/manager-howto.html#Server_Status) for
-details of these statistics.
+The [Tengine Web Server (`tengine`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tengine/README.md) gathers status metrics from the [Tengine Web Server](http://tengine.taobao.org/) using the [Reqstat module](http://tengine.taobao.org/document/http_reqstat.html).
 
 ### [Trig (`trig`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/trig)
 
@@ -594,52 +585,65 @@ The [Trig (`trig`) input plugin](https://github.com/influxdata/telegraf/tree/rel
 
 The [Twemproxy (`twemproxy`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/twemproxy) gathers data from Twemproxy instances, processes Twemproxy server statistics, processes pool data. and processes backend server (Redis/Memcached) statistics.
 
-### [Unbound (`unbound`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/unbound/README.md)
+### [Unbound (`unbound`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/unbound/README.md)
 
-The [Unbound (`unbound`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/unbound/README.md) gathers stats from [Unbound](https://www.unbound.net/), a validating, recursive, and
+The [Unbound (`unbound`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/unbound/README.md) gathers stats from [Unbound](https://www.unbound.net/), a validating, recursive, and
 caching DNS resolver.
 
-### [Varnish (`varnish`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/varnish)
+### [Varnish (`varnish`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/varnish/README.md)
 
-The [Varnish (`varnish`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/varnish) gathers stats from [Varnish HTTP Cache](https://varnish-cache.org/).
+The [Varnish (`varnish`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/varnish/README.md) gathers stats from [Varnish HTTP Cache](https://varnish-cache.org/).
 
-### [VMware vSphere (`vsphere`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere) -- NEW in v.1.8
+### [VMware vSphere (`vsphere`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere/README.md) -- NEW in v.1.8
 
-The [VMware vSphere (`vsphere`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere) uses the vSphere API to gather metrics from multiple vCenter servers (clusters, hosts, VMs, and data stores).
+The [VMware vSphere (`vsphere`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere/README.md) uses the vSphere API to gather metrics from multiple vCenter servers (clusters, hosts, VMs, and data stores). For more information on the available performance metrics, see [Common vSphere Performance Metrics](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere/METRICS.md).
 
-### [Webhooks (`webhooks`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks)
+### [Webhooks (`webhooks`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/README.md)
 
-The [Webhooks (`webhooks`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks) starts an HTTPS server and registers multiple webhook listeners.
+The [Webhooks (`webhooks`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/README.md) starts an HTTPS server and registers multiple webhook listeners.
 
-### [Win_perf_counters (`win_perf_counters`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/win_perf_counters)
+#### Available webhooks
 
-The way the [Win_perf_counters (`win_perf_counters`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/win_perf_counters) works is that on load of Telegraf, the plugin will be handed configuration
+* [Filestack](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/filestack/README.md)
+* [GitHub](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/github/README.md)
+* [Mandrill](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/mandrill/README.md)
+* [Papertrail](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/papertrail/README.md)
+* [Particle.io](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/particle/README.md)
+* [Rollbar](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks/rollbar)
+
+#### Add new webhooks
+If you need a webhook that is not supported, consider [adding a new webhook](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks#adding-new-webhooks-plugin).
+
+
+### [Windows Performance Counters (`win_perf_counters`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/win_perf_counters)
+
+The way the [Windows Performance Counters (`win_perf_counters`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/win_perf_counters) works is that on load of Telegraf, the plugin will be handed configuration
 from Telegraf. This configuration is parsed and then tested for validity such as if the Object, Instance and Counter
 existing. If it does not match at startup, it will not be fetched. Exceptions to this are in cases where you query for
 all instances "". By default the plugin does not return `_Total` when it is querying for all () as this is redundant.
 
-### [Win_services (`win_services`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/win_services)
+### [Windows Services (`win_services`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/win_services/README.md)
 
-The [Win_services (`win_services`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/win_services) reports Windows services info.
+The [Windows Services (`win_services`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/win_services/README.md) reports Windows services info.
 
-### [X509 Cert (`x509_cert`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/x509_cert) -- NEW in v.1.8
+### [X509 Certificate (`x509_cert`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/x509_cert/README.md) -- NEW in v.1.8
 
-The [X509 Cert (`x509_cert`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/x509_cert) provides information about X509 certificate accessible using the local file or network connection.
+The [X509 Cert (`x509_cert`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/x509_cert/README.md) provides information about X509 certificate accessible using the local file or network connection.
 
-### [ZFS (`zfs`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/zfs)
+### [ZFS (`zfs`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zfs/README.md)
 
-The [ZFS (`zfs`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/zfs) provides metrics from your ZFS filesystems. It supports ZFS on Linux and FreeBSD.
+The [ZFS (`zfs`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zfs/README.md) provides metrics from your ZFS filesystems. It supports ZFS on Linux and FreeBSD.
 It gets ZFS statistics from `/proc/spl/kstat/zfs` on Linux and from `sysctl` and `zpool` on FreeBSD.
 
-### [Zipkin (`zipkin`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/zipkin)
+### [Zipkin (`zipkin`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zipkin/README.md)
 
-The [Zipkin (`zipkin`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/zipkin) implements the Zipkin HTTP server to gather trace and timing data needed to troubleshoot latency problems in microservice architectures.
+The [Zipkin (`zipkin`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zipkin/README.md) implements the Zipkin HTTP server to gather trace and timing data needed to troubleshoot latency problems in microservice architectures.
 
 > ***Note:*** This plugin is experimental. Its data schema may be subject to change based on its main usage cases and the evolution of the OpenTracing standard.
 
-### [Zookeeper (`zookeeper`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/zookeeper)
+### [Zookeeper (`zookeeper`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zookeeper/README.md)
 
-The [Zookeeper (`zookeeper`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/zookeeper) collects variables outputted from the `mntr` command [Zookeeper Admin](https://zookeeper.apache.org/doc/trunk/zookeeperAdmin.html).
+The [Zookeeper (`zookeeper`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zookeeper/README.md) collects variables outputted from the `mntr` command [Zookeeper Admin](https://zookeeper.apache.org/doc/trunk/zookeeperAdmin.html).
 
 ## Deprecated Telegraf input plugins
 
@@ -648,26 +652,26 @@ The [Zookeeper (`zookeeper`) input plugin](https://github.com/influxdata/telegra
 > DEPRECATED as of version 1.7. The [Cassandra (`cassandra`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/cassandra) collects Cassandra 3 / JVM metrics exposed as MBean attributes through the jolokia REST endpoint.
 All metrics are collected for each server configured.
 
-### [HTTP JSON (`httpjson`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/httpjson)
+### [HTTP JSON (`httpjson`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/httpjson/README.md)
 
 > DEPRECATED as of version 1.6; use the [HTTP (`http`) input plugin](#http-http-https-github-com-influxdata-telegraf-tree-master-plugins-inputs-http).
 
-The [HTTP JSON (`httpjson`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/httpjson) collects data from HTTP URLs which respond with JSON.
+The [HTTP JSON (`httpjson`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/httpjson/README.md) collects data from HTTP URLs which respond with JSON.
 It flattens the JSON and finds all numeric values, treating them as floats.
 
-### [Jolokia (`jolokia`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jolokia)
+### [Jolokia (`jolokia`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jolokia/README.md)
 
 > DEPRECATED as of version 1.5; use the [Jolokia2 (`jolokia2`) input plugin](#jolokia2-agent-jolokia2-agent-https-github-com-influxdata-telegraf-tree-release-1-6-plugins-inputs-jolokia2-readme-md).
 
-### [SNMP Legacy (`snmp_legacy`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/snmp_legacy)
+### [SNMP Legacy (`snmp_legacy`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp_legacy/README.md)
 
-> DEPRECATED. Use the [SNMP (`snmp`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/snmp).
+> The [SNMP Legacy (`snmp_legacy` input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp_legacy/README.md) is DEPRECATED. Use the [SNMP (`snmp`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/snmp).
 
 The SNMP Legacy input plugin gathers metrics from SNMP agents.
 
-### [TCP Listener (`tcp_listener`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/tcp_listener)
+### [TCP Listener (`tcp_listener`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md)
 
-> DEPRECATED as of version 1.3; use the [Socket Listener (`socket_listener`) input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-tree-release-1-6-plugins-inputs-socket-listener).
+> The [TCP Listener (`tcp_listener` input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md) is EPRECATED as of version 1.3; use the [Socket Listener (`socket_listener`) input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-tree-release-1-6-plugins-inputs-socket-listener).
 
 ### [UDP Listener (`udp_listener`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/udp_listener)
 

--- a/content/telegraf/v1.8/plugins/inputs.md
+++ b/content/telegraf/v1.8/plugins/inputs.md
@@ -176,7 +176,7 @@ The [Fibaro (`fibaro`) input plugin](https://github.com/influxdata/telegraf/blob
 
 The [File (`file`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/file/README.md) updates a list of files every interval and parses the contents using the selected input data format.
 
-Files will always be read in their entirety, if you wish to tail/follow a file use the [tail input plugin](#tail-tail) instead.
+Files will always be read in their entirety, if you wish to tail/follow a file use the [tail input plugin](#tail-tail-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-tail-readme-md) instead.
 
 ### [Filecount (`filecount`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filecount/README.md) -- NEW in v.1.8
 
@@ -653,14 +653,14 @@ All metrics are collected for each server configured.
 
 ### [HTTP JSON (`httpjson`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/httpjson/README.md)
 
-> DEPRECATED as of version 1.6; use the [HTTP (`http`) input plugin](#http-http-https-github-com-influxdata-telegraf-tree-master-plugins-inputs-http).
+> DEPRECATED as of version 1.6; use the [HTTP (`http`) input plugin](#http-http-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-http-readme-md).
 
 The [HTTP JSON (`httpjson`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/httpjson/README.md) collects data from HTTP URLs which respond with JSON.
 It flattens the JSON and finds all numeric values, treating them as floats.
 
 ### [Jolokia (`jolokia`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jolokia/README.md)
 
-> DEPRECATED as of version 1.5; use the [Jolokia2 (`jolokia2`) input plugin](#jolokia2-agent-jolokia2-agent-https-github-com-influxdata-telegraf-tree-release-1-6-plugins-inputs-jolokia2-readme-md).
+> DEPRECATED as of version 1.5; use the [Jolokia2 (`jolokia2`) input plugin](#jolokia2-agent-jolokia2-agent-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-jolokia2-readme-md).
 
 ### [SNMP Legacy (`snmp_legacy`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp_legacy/README.md)
 
@@ -670,8 +670,8 @@ The SNMP Legacy input plugin gathers metrics from SNMP agents.
 
 ### [TCP Listener (`tcp_listener`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md)
 
-> The [TCP Listener (`tcp_listener` input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md) is EPRECATED as of version 1.3; use the [Socket Listener (`socket_listener`) input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-tree-release-1-6-plugins-inputs-socket-listener).
+> The [TCP Listener (`tcp_listener` input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md) is EPRECATED as of version 1.3; use the [Socket Listener (`socket_listener`) input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-socket-listener-readme-md).
 
 ### [UDP Listener (`udp_listener`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/udp_listener)
 
-> DEPRECATED as of version 1.3; use the [Socket Listener (`socket_listener`) input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-tree-release-1-6-plugins-inputs-socket-listener).
+> DEPRECATED as of version 1.3; use the [Socket Listener (`socket_listener`) input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-socket-listener-readme-md).

--- a/content/telegraf/v1.8/plugins/inputs.md
+++ b/content/telegraf/v1.8/plugins/inputs.md
@@ -119,7 +119,7 @@ The [Couchbase (`couchbase`) input plugin](https://github.com/influxdata/telegra
 
 The [CouchDB (`couchdb`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchdb/README.md) gathers metrics of CouchDB using `_stats` endpoint.
 
-### [CPU (`cpu`)](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cpu/README.md)
+### [CPU (`cpu`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cpu/README.md)
 
 The [CPU (`cpu`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cpu/README.md) gathers metrics about cpu usage.
 
@@ -129,7 +129,7 @@ The [Disk (`disk`) input plugin](https://github.com/influxdata/telegraf/blob/rel
 
 ### [DiskIO (`diskio`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/diskio/README.md)
 
-The [DiskIO (`diskio`) input plugin](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/diskio/README.md) gathers metrics about disk IO by device.
+The [DiskIO (`diskio`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/diskio/README.md) gathers metrics about disk IO by device.
 
 ### [Disque (`disque`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/disque)
 
@@ -327,7 +327,7 @@ The [Memcached (`memcached`) input plugin](https://github.com/influxdata/telegra
 The [Mesos (`mesos`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mesos/README.md) gathers metrics from Mesos. For more information, please check the
 [Mesos Observability Metrics](http://mesos.apache.org/documentation/latest/monitoring/) page.
 
-### [Mesosphere DC/OS (`dcos`)](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dcos/README.md)
+### [Mesosphere DC/OS (`dcos`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dcos/README.md)
 
 The [Mesosphere DC/OS (`dcos`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dcos/README.md) gathers metrics from a DC/OS cluster's [metrics component](https://docs.mesosphere.com/1.10/metrics/).
 
@@ -429,7 +429,7 @@ The [Phfusion 0Passenger (`passenger`) input plugin](https://github.com/influxda
 
 The [PHP FPM (`phpfpm`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/phpfpm/README.md) gets phpfpm statistics using either HTTP status page or fpm socket.
 
-### [Ping (`ping`)](hhttps://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ping/README.md)
+### [Ping (`ping`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ping/README.md)
 
 The [Ping (`ping`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ping/README.md) measures the round-trip for ping commands, response time, and other packet statistics.
 

--- a/content/telegraf/v1.8/plugins/inputs.md
+++ b/content/telegraf/v1.8/plugins/inputs.md
@@ -162,7 +162,7 @@ or [cluster-stats](https://www.elastic.co/guide/en/elasticsearch/reference/curre
 
 ### [Exec (`exec`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/exec/README.md)
 
-The [Exec (`exec`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/exec/README.md) parses supported [Telegraf input data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md) (InfluxDB Line Protocol, JSON, Graphite, Value, Nagios, Collectd, and Dropwizard into metrics. Each Telegraf metric includes the measurement name, tags, fields, and timesamp. See [Telegraf input data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md) for details on the supported data formats.
+The [Exec (`exec`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/exec/README.md) parses supported [Telegraf input data formats](/telegraf/v1.8/data_formats/input/) (InfluxDB Line Protocol, JSON, Graphite, Value, Nagios, Collectd, and Dropwizard into metrics. Each Telegraf metric includes the measurement name, tags, fields, and timesamp.
 
 ### [Fail2ban (`fail2ban`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fail2ban/README.md)
 
@@ -210,13 +210,13 @@ The [Hddtemp (`hddtemp`) input plugin](https://github.com/influxdata/telegraf/bl
 
 ### [HTTP (`http`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http/README.md)
 
-The [HTTP (`http`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http/README.md) collects metrics from one or more HTTP (or HTTPS) endpoints. The endpoint should have metrics formatted in one of the supported input data formats. Each data format has its own unique set of configuration options which can be added to the input configuration.
+The [HTTP (`http`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http/README.md) collects metrics from one or more HTTP (or HTTPS) endpoints. The endpoint should have metrics formatted in one of the [supported input data formats](/telegraf/v1.8/data_formats/input/). Each data format has its own unique set of configuration options which can be added to the input configuration.
 
 ### [HTTP Listener (`http_listener`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md)
 
-The [HTTP Listener (`http_listener`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md) listens for messages sent via HTTP POST. Messages are expected in the InfluxDB
-line protocol format ONLY (other Telegraf input data formats are not supported). The plugin allows Telegraf to serve
-as a proxy/router for the `/write` endpoint of the InfluxDB HTTP API.
+The [HTTP Listener (`http_listener`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md) listens for messages sent via HTTP POST. Messages are expected in the [InfluxDB
+Line Protocol input data format](/telegraf/v1.8/data_formats/input/influx) ONLY (other [Telegraf input data formats](/telegraf/v1.8/data_formats/input/) are not supported).
+This plugin allows Telegraf to serve as a proxy or router for the `/write` endpoint of the InfluxDB HTTP API.
 
 ### [HTTP Response (`http_response`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_response/README.md)
 
@@ -348,7 +348,7 @@ measurement containing values.
 ### [MQTT Consumer (`mqtt_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mqtt_consumer/README.md)
 
 The [MQTT Consumer (`mqtt_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mqtt_consumer/README.md) reads from specified MQTT topics and adds messages to InfluxDB. Messages are in the
-Telegraf Input Data Formats.
+[Telegraf input data formats](/telegraf/v1.8/data_formats/input/).
 
 ### [MySQL `(mysql`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mysql/README.md)
 
@@ -356,7 +356,7 @@ The [MySQL (`mysql`) input plugin](https://github.com/influxdata/telegraf/blob/r
 
 ### [NATS Consumer (`nats_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats_consumer/README.md)
 
-The [NATS Consumer (`nats_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats_consumer/README.md) reads from specified NATS subjects and adds messages to InfluxDB. Messages are expected in the Telegraf Input Data Formats. A Queue Group is used when subscribing to subjects so multiple instances of Telegraf can read from a NATS cluster in parallel.
+The [NATS Consumer (`nats_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats_consumer/README.md) reads from specified NATS subjects and adds messages to InfluxDB. Messages are expected in the [Telegraf input data formats](/telegraf/v1.8/data_formats/input/). A Queue Group is used when subscribing to subjects so multiple instances of Telegraf can read from a NATS cluster in parallel.
 
 ### [NATS Server Monitoring (`nats`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats/README.md)
 

--- a/content/telegraf/v1.8/plugins/inputs.md
+++ b/content/telegraf/v1.8/plugins/inputs.md
@@ -530,7 +530,7 @@ The [SNMP (`snmp`) input plugin](https://github.com/influxdata/telegraf/blob/rel
 
 The [Socket Listener (`socket_listener`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/socket_listener/README.md) listens for messages from streaming (tcp, unix) or datagram
 (UDP, unixgram) protocols. Messages are expected in the
-[Telegraf Input Data Formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md).
+[Telegraf Input Data Formats](/telegraf/v1.8/data_formats/input/).
 
 ### [StatsD (`statsd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/statsd/README.md)
 

--- a/content/telegraf/v1.8/plugins/outputs.md
+++ b/content/telegraf/v1.8/plugins/outputs.md
@@ -1,6 +1,6 @@
 ---
 title: Telegraf output plugins
-descriptions: Telegraf output plugins are used with the InfluxData time series platform to transform, decorate, and filter metrics. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
+descriptions: Use Telegraf output plugins to transform, decorate, and filter metrics. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
 menu:
   telegraf_1_8:
     name: Output
@@ -15,127 +15,127 @@ Telegraf allows users to specify multiple output sinks in the configuration file
 
 ## Supported Telegraf output plugins
 
-### [Amon (`amon`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/amon)
+### [Amazon CloudWatch (`cloudwatch`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cloudwatch/README.md)
 
-The [Amon (`amon`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/amon) writes to [Amon](https://www.amon.cx) and requires a serverkey and amoninstance URL which can be obtained [here](https://www.amon.cx/docs/monitoring/) for the account.
+The [Amazon CloudWatch (`cloudwatch`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cloudwatch/README.md) send metrics to Amazon CloudWatch.
 
-If the point value being sent cannot be converted to a float64, the metric is skipped.
+### [Amazon Kinesis (`kinesis`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kinesis/README.md)
+
+The [Amazon Kinesis (`kinesis`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kinesis/README.md) is an experimental plugin that is still in the early stages of development. It will batch up all of the Points in one Put request to Kinesis. This should save the number of API requests by a considerable level.
+
+### [Amon (`amon`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amon/README.md)
+
+The [Amon (`amon`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amon/README.md) writes metrics to an  [Amon server](https://github.com/amonapp/amon). For details on the Amon Agent, see [Monitoring Agent](https://docs.amon.cx/agent/) and requires a `apikey` and `amoninstance` URL.
+
+If the point value being sent cannot be converted to a float64 value, the metric is skipped.
 
 Metrics are grouped by converting any `_` characters to `.` in the Point Name.
 
-### [AMQP (`amqp`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/amqp)
+### [AMQP (`amqp`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amqp/README.md)
 
-The [AMQP (`amqp`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/amqp) writes to a AMQP 0-9-1 Exchange, a prominent implementation of this protocol being [RabbitMQ](https://www.rabbitmq.com/).
+The [AMQP (`amqp`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amqp/README.md) writes to a AMQP 0-9-1 Exchange, a prominent implementation of this protocol being [RabbitMQ](https://www.rabbitmq.com/).
 
 Metrics are written to a topic exchange using `tag`, defined in configuration file as `RoutingTag`, as a routing key.
 
-### [Application Insights (`application_insights`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/application_insights)
+### [Apache Kafka (`kafka`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kafka/README.md)
 
-The [Application Insights (`application_insights`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/application_insights) writes Telegraf metrics to [Application Insights (Microsoft Azure)](https://azure.microsoft.com/en-us/services/application-insights/).
+The [Apache Kafka (`kafka`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kafka/README.md) writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.html) acting a Kafka Producer.
 
-### [Azure Monitor (`azure_monitor`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/azure_monitor) -- NEW in v.1.8
+### [Application Insights (`application_insights`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/application_insights/README.md)
+
+The [Application Insights (`application_insights`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/application_insights/README.md) writes Telegraf metrics to [Application Insights (Microsoft Azure)](https://azure.microsoft.com/en-us/services/application-insights/).
+
+### [Azure Monitor (`azure_monitor`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/azure_monitor/README.md) -- NEW in v.1.8
 
 >**Note:** The Azure Monitor custom metrics service is currently in preview and not available in a subset of Azure regions.
 
-The [Azure Monitor (`azure_monitor`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/azure_monitor) sends custom metrics to Azure Monitor. Azure Monitor has a metric resolution of one minute. To handle this in Telegraf, the Azure Monitor output plugin automatically aggregates metrics into one minute buckets, which are then sent to Azure Monitor on every flush interval.
+The [Azure Monitor (`azure_monitor`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/azure_monitor/README.md) sends custom metrics to [Azure Monitor](https://azure.microsoft.com/en-us/services/monitor/). Azure Monitor has a metric resolution of one minute. To handle this in Telegraf, the Azure Monitor output plugin automatically aggregates metrics into one minute buckets, which are then sent to Azure Monitor on every flush interval.
 
 The metrics from each input plugin will be written to a separate Azure Monitor namespace, prefixed with `Telegraf/` by default. The field name for each metric is written as the Azure Monitor metric name. All field values are written as a summarized set that includes `min`, `max`, `sum`, and `count`. Tags are written as a dimension on each Azure Monitor metric.
 
-### [CloudWatch (`cloudwatch`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/cloudwatch)
+### [CrateDB (`cratedb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cratedb/README.md)
 
-The [CloudWatch (`cloudwatch`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/cloudwatch) send metrics to Amazon CloudWatch.
+The [CrateDB (`cratedb`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cratedb/README.md) writes to [CrateDB](https://crate.io/) using its [PostgreSQL protocol](https://crate.io/docs/crate/reference/protocols/postgres.html).
 
-### [CrateDB (`cratedb`)](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/cratedb)
+### [Datadog (`datadog`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/datadog/README.md)
 
-The [CrateDB (`cratedb`) output plugin](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/cratedb) writes to [CrateDB](https://crate.io/) using its [PostgreSQL protocol](https://crate.io/docs/crate/reference/protocols/postgres.html).
+The [Datadog (`datadog`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/datadog/README.md) writes to the [Datadog Metrics API](http://docs.datadoghq.com/api/#metrics) and requires an `apikey` which can be obtained [here](https://app.datadoghq.com/account/settings#api) for the account.
 
-### [Datadog (`datadog`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/datadog)
+### [Discard (`discard`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/discard/README.md)
 
-The [Datadog (`datadog`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/datadog) writes to the [Datadog Metrics API](http://docs.datadoghq.com/api/#metrics) and requires an `apikey` which can be obtained [here](https://app.datadoghq.com/account/settings#api) for the account.
+The [Discard (`discard`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/discard/README.md) simply drops all metrics that are sent to it. It is only meant to be used for testing purposes.
 
-### [Discard (`discard`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/discard)
+### [Elasticsearch (`elasticsearch`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/elasticsearch/README.md)
 
-The [Discard (`discard`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/discard) simply drops all metrics that are sent to it. It is only meant to be used for testing purposes.
+The [Elasticsearch (`elasticsearch`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/elasticsearch/README.md) writes to Elasticsearch via HTTP using [Elastic](http://olivere.github.io/elastic/). Currently it only supports Elasticsearch 5.x series.
 
-### [Elasticsearch (`elasticsearch`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/elasticsearch)
+### [File (`file`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/file/README.md)
 
-The [Elasticsearch (`elasticsearch`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/elasticsearch) writes to Elasticsearch via HTTP using [Elastic](http://olivere.github.io/elastic/). Currently it only supports Elasticsearch 5.x series.
+The [File (`file`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/file/README.md) writes Telegraf metrics to files.
 
-### [File (`file`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/file)
+### [Graphite (`graphite`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graphite/README.md)
 
-The [File (`file`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/file) writes Telegraf metrics to files.
+The [Graphite (`graphite`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graphite/README.md) writes to [Graphite](http://graphite.readthedocs.org/en/latest/index.html) via raw TCP.
 
-### [Graphite (`graphite`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/graphite)
+### [Graylog (`graylog`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graylog/README.md)
 
-The [Graphite (`graphite`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/graphite) writes to [Graphite](http://graphite.readthedocs.org/en/latest/index.html) via raw TCP.
+The  [Graylog (`graylog`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graylog/README.md) writes to a Graylog instance using the `gelf` format.
 
-### [Graylog (`graylog`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/graylog)
+### [HTTP (`http`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/http/README.md)
 
-The  [Graylog (`graylog`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/graylog) writes to a Graylog instance using the `gelf` format.
+The [HTTP (`http`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/http/README.md) sends metrics in a HTTP message encoded using one of the output data formats. For `data_formats` that support batching, metrics are sent in batch format.
 
-### [HTTP (`http`)](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/http)
+### [InfluxDB v1.x (`influxdb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb/README.md)
 
-The [HTTP (`http`) output plugin](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/http) sends metrics in a HTTP message encoded using one of the output data formats. For `data_formats` that support batching, metrics are sent in batch format.
+The [InfluxDB v1.x (`influxdb`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb/README.md) writes to InfluxDB using HTTP or UDP.
 
-### [InfluxDB v1.x (`influxdb`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/influxdb)
+### [InfluxDB v2 (`influxdb_v2`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb_v2/README.md)-- NEW in v.1.8
 
-The [InfluxDB v1.x (`influxdb`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/influxdb) writes to InfluxDB using HTTP or UDP.
+The [InfluxDB v2 (`influxdb_v2`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb_v2/README.md) writes metrics to the [InfluxDB 2.0](https://github.com/influxdata/platform) HTTP service.
 
-### [InfluxDB v2 (`influxdb_v2`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/influxdb)-- NEW in v.1.8
+### [Instrumental (`instrumental`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/instrumental/README.md)
 
-The [InfluxDB v2 (`influxdb_v2`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/influxdb) writes metrics to the [InfluxDB 2.0](https://github.com/influxdata/platform) HTTP service.
-
-### [Instrumental (`instrumental`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/instrumental)
-
-The [Instrumental (`instrumental`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/instrumental) writes to the [Instrumental Collector API](https://instrumentalapp.com/docs/tcp-collector) and requires a Project-specific API token.
+The [Instrumental (`instrumental`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/instrumental/README.md) writes to the [Instrumental Collector API](https://instrumentalapp.com/docs/tcp-collector) and requires a Project-specific API token.
 
 Instrumental accepts stats in a format very close to Graphite, with the only difference being that the type of stat (gauge, increment) is the first token, separated from the metric itself by whitespace. The increment type is only used if the metric comes in as a counter through [[input.statsd]].
 
-### [Kafka (`kafka`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/kafka)
+### [Librato (`librato`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/librato/README.md)
 
-The [Kafka (`kafka`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/kafka) writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.html) acting a Kafka Producer.
+The [Librato (`librato`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/librato/README.md) writes to the [Librato Metrics API](http://dev.librato.com/v1/metrics#metrics) and requires an `api_user` and `api_token` which can be obtained [here](https://metrics.librato.com/account/api_tokens) for the account.
 
-### [Kinesis (`kinesis`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/kinesis)
+### [MQTT Producer  (`mqtt`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/mqtt/README.md)
 
-The [Kinesis (`kinesis`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/kinesis) is an experimental plugin that is still in the early stages of development. It will batch up all of the Points in one Put request to Kinesis. This should save the number of API requests by a considerable level.
+The [MQTT Producer (`mqtt`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/mqtt/README.md) writes to the MQTT server using [supported output data formats](/telegraf/v1.8/data_formats/output/).
 
-### [Librato (`librato`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/librato)
+### [NATS Output (`nats`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nats/README.md)
 
-The [Librato (`librato`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/librato) writes to the [Librato Metrics API](http://dev.librato.com/v1/metrics#metrics) and requires an `api_user` and `api_token` which can be obtained [here](https://metrics.librato.com/account/api_tokens) for the account.
+The [NATS Output (`nats`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nats/README.md) writes to a (list of) specified NATS instance(s).
 
-### [MQTT (`mqtt`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/mqtt)
+### [NSQ (`nsq`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nsq/README.md)
 
-The [MQTT (`mqtt`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/mqtt) writes to the MQTT server using [supported output data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md).
+The [NSQ (`nsq`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nsq/README.md) writes to a specified NSQD instance, usually local to the producer. It requires a server name and a topic name.
 
-### [NATS Output (`nats`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/nats)
+### [OpenTSDB (`opentsdb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/opentsdb/README.md)
 
-The [NATS Output (`nats`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/nats) writes to a (list of) specified NATS instance(s).
-
-### [NSQ (`nsq`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/nsq)
-
-  The [NSQ (`nsq`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/nsq) writes to a specified NSQD instance, usually local to the producer. It requires a server name and a topic name.
-
-  ### [OpenTSDB (`opentsdb`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/opentsdb)
-
-  The [OpenTSDB (`opentsdb`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/opentsdb) writes to an OpenTSDB instance using either the telnet or HTTP mode.
+The [OpenTSDB (`opentsdb`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/opentsdb/README.md) writes to an OpenTSDB instance using either the telnet or HTTP mode.
 
 Using the HTTP API is the recommended way of writing metrics since OpenTSDB 2.0 To use HTTP mode, set `useHttp` to true in config. You can also control how many metrics are sent in each HTTP request by setting `batchSize` in config. See http://opentsdb.net/docs/build/html/api_http/put.html for details.
 
-### [Prometheus Client (`prometheus_client`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/prometheus_client)
+### [Prometheus Client (`prometheus_client`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/prometheus_client/README.md)
 
-The [Prometheus Client (`prometheus_client`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/prometheus_client) starts a [Prometheus](https://prometheus.io/) Client, it exposes all metrics on `/metrics` (default) to be polled by a Prometheus server.
+The [Prometheus Client (`prometheus_client`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/prometheus_client/README.md) starts a [Prometheus](https://prometheus.io/) Client, it exposes all metrics on `/metrics` (default) to be polled by a Prometheus server.
 
-### [Riemann (`riemann`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/riemann)
+### [Riemann (`riemann`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/riemann/README.md)
 
-The [Riemann (`riemann`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/riemann) writes to [Riemann](http://riemann.io/) using TCP or UDP.
+The [Riemann (`riemann`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/riemann/README.md) writes to [Riemann](http://riemann.io/) using TCP or UDP.
 
-### [Socket Writer (`socket_writer`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/socket_writer)
+### [Socket Writer (`socket_writer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/socket_writer/README.md)
 
-The [Socket Writer (`socket_writer`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/socket_writer) writes to a UDP, TCP, or UNIX socket. It can output data in any of the [supported output formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md).
+The [Socket Writer (`socket_writer`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/socket_writer/README.md) writes to a UDP, TCP, or UNIX socket. It can output data in any of the [supported output formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md).
 
-### [Wavefront (`wavefront`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/wavefront/README.md)
+### [Wavefront (`wavefront`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/wavefront/README.md)
 
-The [Wavefront (`wavefront`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/wavefront/README.md) writes to a Wavefront proxy, in Wavefront data format over TCP.
+The [Wavefront (`wavefront`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/wavefront/README.md) writes to a Wavefront proxy, in Wavefront data format over TCP.
 
 ## Deprecated Telegraf output plugins
 

--- a/content/telegraf/v1.8/plugins/processors.md
+++ b/content/telegraf/v1.8/plugins/processors.md
@@ -18,17 +18,17 @@ Processor plugins process metrics as they pass through and immediately emit resu
 ## Supported Telegraf processor plugins
 
 
-### [Converter (`converter`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/converter)
+### [Converter (`converter`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/converter/README.md)
 
-The [Converter (`converter`) processor plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/converter) is used to change the type of tag or field values. In addition to changing field types, it can convert between fields and tags. Values that cannot be converted are dropped.
+The [Converter (`converter`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/converter/README.md) is used to change the type of tag or field values. In addition to changing field types, it can convert between fields and tags. Values that cannot be converted are dropped.
 
-### [Enum (`enum`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/enum) -- NEW in v.1.8
+### [Enum (`enum`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/enum/README.md) -- NEW in v.1.8
 
-The [Enum (`enum`) processor plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/enum) allows the configuration of value mappings for metric fields. The main use case for this is to rewrite status codes such as `red`, a`mber`, and `green` by numeric values such as `0`, `1`, `2`. The plugin supports string and bool types for the field values. Multiple Fields can be configured with separate value mappings for each field. Default mapping values can be configured to be used for all values, which are not contained in the value_mappings. The processor supports explicit configuration of a destination field. By default the source field is overwritten.
+The [Enum (`enum`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/enum/README.md) allows the configuration of value mappings for metric fields. The main use case for this is to rewrite status codes such as `red`, `amber`, and `green` by numeric values such as `0`, `1`, `2`. The plugin supports string and bool types for the field values. Multiple Fields can be configured with separate value mappings for each field. Default mapping values can be configured to be used for all values, which are not contained in the value_mappings. The processor supports explicit configuration of a destination field. By default the source field is overwritten.
 
-### [Override (`override`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/override)
+### [Override (`override`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/override/README.md)
 
-The [Override (`override`) processor plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/override) allows overriding all modifications that are supported by input plugins and aggregator plugins:
+The [Override (`override`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/override/README.md) allows overriding all modifications that are supported by input plugins and aggregator plugins:
 
 * `name_override`
 * `name_prefix`
@@ -41,25 +41,25 @@ Values of `name_override`, `name_prefix`, `name_suffix`, and already present tag
 
 Use case of this plugin encompass ensuring certain tags or naming conventions are adhered to irrespective of input plugin configurations, e.g., by `taginclude`.
 
-### [Parser (`parser`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/parser) -- NEW in v.1.8
+### [Parser (`parser`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/parser/README.md) -- NEW in v.1.8
 
-The [Parser (`parser`) processor plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/parser) parses defined fields containing the specified data format and creates new metrics based on the contents of the field.
+The [Parser (`parser`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/parser/README.md) parses defined fields containing the specified data format and creates new metrics based on the contents of the field.
 
-### [Printer (`printer`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/printer)
+### [Printer (`printer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/printer/README.md)
 
-The [Printer (`printer`) processor plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/printer) simply prints every metric passing through it.
+The [Printer (`printer`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/printer/README.md) simply prints every metric passing through it.
 
-### [Regex (`regex`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/regex)
+### [Regex (`regex`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/regex/README.md)
 
-The [Regex (`regex`) processor plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/regex) transforms  -- NEW in v.1.8 tag and field values using a regular expression (regex) pattern. If `result_key `parameter is present, it can produce new tags and fields from existing ones.
+The [Regex (`regex`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/regex/README.md) transforms  -- NEW in v.1.8 tag and field values using a regular expression (regex) pattern. If `result_key `parameter is present, it can produce new tags and fields from existing ones.
 
-### [Rename (`rename`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/rename) -- NEW in v.1.8
+### [Rename (`rename`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/rename/README.md) -- NEW in v.1.8
 
-The [Rename (`rename`) processor plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/rename) renames InfluxDB measurements, fields, and tags.
+The [Rename (`rename`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/rename/README.md) renames InfluxDB measurements, fields, and tags.
 
-### [Strings (`strings`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/strings) -- NEW in v.1.8
+### [Strings (`strings`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/strings/README.md) -- NEW in v.1.8
 
-The [Strings (`strings`) processor plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/strings) maps certain Go string functions onto InfluxDB measurement, tag, and field values. Values can be modified in place or stored in another key.
+The [Strings (`strings`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/strings/README.md) maps certain Go string functions onto InfluxDB measurement, tag, and field values. Values can be modified in place or stored in another key.
 
 Implemented functions are:
 
@@ -73,9 +73,9 @@ Implemented functions are:
 
 Note that in this implementation these are processed in the order that they appear above. You can specify the `measurement`, `tag` or `field` that you want processed in each section and optionally a `dest` if you want the result stored in a new tag or field. You can specify lots of transformations on data with a single strings processor.
 
-### [TopK (`topk`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/topk)
+### [TopK (`topk`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/topk/README.md)
 
-The [TopK (`topk`) processor plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/processors/topk) is a filter designed to get the top series over a period of time. It can be tweaked to do its top `K` computation over a period of time, so spikes can be smoothed out.
+The [TopK (`topk`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/topk/README.md) is a filter designed to get the top series over a period of time. It can be tweaked to do its top `K` computation over a period of time, so spikes can be smoothed out.
 
 This processor goes through the following steps when processing a batch of metrics:
 


### PR DESCRIPTION
Changing all links to point to README files based on discussion with Daniel. Also modified names and ordering of some plugins. Data format links to new internal doc pages (not GitHub) added or updated.