### PR TITLE
Update backup_and_restore.md

### DIFF
--- a/content/influxdb/v1.6/administration/backup_and_restore.md
+++ b/content/influxdb/v1.6/administration/backup_and_restore.md
@@ -54,6 +54,7 @@ influxd backup
     [ -host <host:port> ]
     [ -retention <rp_name> ] | [ -shard <shard_ID> -retention <rp_name> ]
     [ -start <timestamp> [ -end <timestamp> ] | -since <timestamp> ]
+    [ -skip-errors ]
     <path-to-backup>
 ```
 
@@ -88,6 +89,7 @@ Optional arguments are enclosed in brackets.
 
 - `[ -since <timestamp> ]`: Perform an incremental backup after the specified timestamp [RFC3339 format](https://www.ietf.org/rfc/rfc3339.txt). Use `-start` instead, unless needed for legacy backup support.
 
+- `[ -skip-errors ]`: Optional flag to continue backing up the remaining shards when the current shard fails to backup.
 
 #### Backup examples
 


### PR DESCRIPTION
added a new flag to backup/restore that lets the backup continue if a shard fails to backup.  Sometimes when this occurs, it's acceptable e.g. when the shard has been disabled or is empty.  