### PR TITLE
Updated GCP Marketplace link so it doesn't require login

### DIFF
--- a/content/enterprise_influxdb/v1.6/other_installation/google_marketplace.md
+++ b/content/enterprise_influxdb/v1.6/other_installation/google_marketplace.md
@@ -8,7 +8,7 @@ menu:
     parent: Other installation options
 ---
 
-For users looking to deploy InfluxDB Enterprise on Google Cloud Platform (GCP) infrastructure, InfluxData provides an [InfluxDB Enterprise bring-your-own-license (BYOL) solution](https://console.cloud.google.com/partner/editor/influxdata-public/influxdb-enterprise-byol) on the [Google Cloud Platform Marketplace](https://cloud.google.com/marketplace/) that makes the installation and setup process easy and straightforward. Clusters deployed through the GCP Marketplace are ready for production.
+For users looking to deploy InfluxDB Enterprise on Google Cloud Platform (GCP) infrastructure, InfluxData provides an [InfluxDB Enterprise bring-your-own-license (BYOL) solution](https://console.cloud.google.com/marketplace/details/influxdata-public/influxdb-enterprise-byol) on the [Google Cloud Platform Marketplace](https://cloud.google.com/marketplace/) that makes the installation and setup process easy and straightforward. Clusters deployed through the GCP Marketplace are ready for production.
 
 > **Note:** The [Deployment Manager templates](https://cloud.google.com/deployment-manager/) used for the InfluxDB Enterprise BYOL solution are [open source](https://github.com/influxdata/google-deployment-manager-influxdb-enterprise). Issues and feature requests for the Marketplace deployment should be [submitted through the related GitHub repository](https://github.com/influxdata/google-deployment-manager-influxdb-enterprise/issues/new) (requires a GitHub account) or by contacting [InfluxData support](mailto:Support@InfluxData.com).
 


### PR DESCRIPTION
@gunnar, will this change still work. It's to the public listing for the InfluxDB Enterprise BYOL. The previous link required a login. A user reported it as a broken link in #1877.