### PR TITLE
Add newline so the markdown list renders properly influxdb/v1.6/concepts/crosswalk.md

### DIFF
--- a/content/influxdb/v1.6/concepts/crosswalk.md
+++ b/content/influxdb/v1.6/concepts/crosswalk.md
@@ -193,6 +193,7 @@ This is where trends over time begin to show, and actionable insight can be draw
 In addition, time series data is generally written once and rarely updated.
 
 The result is that InfluxDB is not a full CRUD database but more like a CR-ud, prioritizing the performance of creating and reading data over update and destroy, and [preventing some update and destroy behaviors](/influxdb/v1.6/concepts/insights_tradeoffs/) to make create and read more performant:
+
 * To update a point, insert one with [the same measurement, tag set, and timestamp](/influxdb/v1.6/troubleshooting/frequently-asked-questions/#how-does-influxdb-handle-duplicate-points).
 * You can [drop or delete a series](/influxdb/v1.6/query_language/database_management/#drop-series-from-the-index-with-drop-series), but not individual points based on field values. As a workaround, you can search for the field value, retrieve the time, then [DELETE based on the `time` field](/influxdb/v1.6/query_language/database_management/#delete-series-with-delete).
 * You can't update or rename tags yet - see GitHub issue [#4157](https://github.com/influxdata/influxdb/issues/4157) for more information. To modify the tag of a series of points, find the points with the offending tag value, change the value to the desired one, write the points back, then drop the series with the old tag value.


### PR DESCRIPTION
The makdown list at the bottom of the page of:
content/influxdb/v1.6/concepts/crosswalk.md

 was not parsed correctly by markdown because of a missing newline. 

Note that v1.5 uses a dash for lists but 1.6 and 1.4 uses asterisk, bit odd.