### PR TITLE
Updated all mentions and variations of OSX to macOS

### DIFF
--- a/content/chronograf/v0.10/introduction/getting_started.md
+++ b/content/chronograf/v0.10/introduction/getting_started.md
@@ -22,7 +22,7 @@ sudo service chronograf start
 ```
 Note that the Chronograf startup script needs root permission to ensure that it can write to `/var/log`, but the executable runs as a normal user.
 
-#### OS X via [Homebrew](http://brew.sh/)
+#### macOS via [Homebrew](http://brew.sh/)
 * Run Chronograf manually on the command line:
 
     ```
@@ -41,7 +41,7 @@ ln -sfv /usr/local/opt/chronograf/*.plist ~/Library/LaunchAgents
 launchctl load ~/Library/LaunchAgents/homebrew.mxcl.chronograf.plist
     ```
 
-#### Standalone OS X binary
+#### Standalone macOS binary
 Assuming you're working with Chronograf version 0.10, from the `chronograf-0.10/` directory:
 ```
 ./chronograf-0.10-darwin_amd64
@@ -57,8 +57,8 @@ Those settings are configurable; see the configuration file to change them and t
 We list the location of the configuration file by installation process below.
 
 > * Debian or RPM package: `/opt/chronograf/config.toml`
-> * OS X via Homebrew: `/usr/local/etc/chronograf.toml`
-> * Standalone OS X binary: `chronograf-0.x.x/chronograf.toml`
+> * macOS via Homebrew: `/usr/local/etc/chronograf.toml`
+> * Standalone macOS binary: `chronograf-0.x.x/chronograf.toml`
 
 Now that you've got everything installed and running it's time to start visualizing your data in Chronograf!
 

--- a/content/chronograf/v0.11/introduction/getting_started.md
+++ b/content/chronograf/v0.11/introduction/getting_started.md
@@ -26,7 +26,7 @@ sudo service chronograf start
 ```
 Note that the Chronograf startup script needs root permission to ensure that it can write to `/var/log`, but the executable runs as a normal user.
 
-#### OS X via [Homebrew](http://brew.sh/)
+#### macOS via [Homebrew](http://brew.sh/)
 * Run Chronograf manually on the command line:
 
     ```
@@ -45,7 +45,7 @@ ln -sfv /usr/local/opt/chronograf/*.plist ~/Library/LaunchAgents
 launchctl load ~/Library/LaunchAgents/homebrew.mxcl.chronograf.plist
     ```
 
-#### Standalone OS X binary
+#### Standalone macOS binary
 Assuming you're working with Chronograf version 0.11, from the `chronograf-0.11/` directory:
 ```
 ./chronograf-0.11-darwin_amd64
@@ -61,8 +61,8 @@ Those settings are configurable; see the configuration file to change them and t
 We list the location of the configuration file by installation process below.
 
 > * Debian or RPM package: `/opt/chronograf/config.toml`
-> * OS X via Homebrew: `/usr/local/etc/chronograf.toml`
-> * Standalone OS X binary: `chronograf-0.x.x/chronograf.toml`
+> * macOS via Homebrew: `/usr/local/etc/chronograf.toml`
+> * Standalone macOS binary: `chronograf-0.x.x/chronograf.toml`
 
 Now that you've got everything installed and running it's time to start visualizing your data in Chronograf!
 

--- a/content/chronograf/v0.12/introduction/getting_started.md
+++ b/content/chronograf/v0.12/introduction/getting_started.md
@@ -22,7 +22,7 @@ sudo service chronograf start
 ```
 Note that the Chronograf startup script needs root permission to ensure that it can write to `/var/log`, but the executable runs as a normal user.
 
-#### OS X via [Homebrew](http://brew.sh/)
+#### macOS via [Homebrew](http://brew.sh/)
 * Run Chronograf manually on the command line:
 
     ```
@@ -41,7 +41,7 @@ ln -sfv /usr/local/opt/chronograf/*.plist ~/Library/LaunchAgents
 launchctl load ~/Library/LaunchAgents/homebrew.mxcl.chronograf.plist
     ```
 
-#### Standalone OS X binary
+#### Standalone macOS binary
 Assuming you're working with Chronograf version 0.12, from the `chronograf-0.12/` directory:
 ```
 ./chronograf-0.12-darwin_amd64
@@ -57,8 +57,8 @@ Those settings are configurable; see the configuration file to change them and t
 We list the location of the configuration file by installation process below.
 
 > * Debian or RPM package: `/opt/chronograf/config.toml`
-> * OS X via Homebrew: `/usr/local/etc/chronograf.toml`
-> * Standalone OS X binary: `chronograf-0.x.x/chronograf.toml`
+> * macOS via Homebrew: `/usr/local/etc/chronograf.toml`
+> * Standalone macOS binary: `chronograf-0.x.x/chronograf.toml`
 
 Now that you've got everything installed and running it's time to start visualizing your data in Chronograf!
 

--- a/content/chronograf/v0.13/administration/configuration.md
+++ b/content/chronograf/v0.13/administration/configuration.md
@@ -11,8 +11,8 @@ menu:
 ### Configuration file location by installation type
 
 > * Debian or RPM package: `/opt/chronograf/config.toml`
-> * OS X via Homebrew: `/usr/local/etc/chronograf.toml`
-> * Standalone OS X binary: `chronograf-0.x.x/chronograf.toml`
+> * macOS via Homebrew: `/usr/local/etc/chronograf.toml`
+> * Standalone macOS binary: `chronograf-0.x.x/chronograf.toml`
 
 ### Chronograf configuration file
 

--- a/content/chronograf/v0.13/introduction/getting_started.md
+++ b/content/chronograf/v0.13/introduction/getting_started.md
@@ -22,7 +22,7 @@ sudo service chronograf start
 ```
 Note that the Chronograf startup script needs root permission to ensure that it can write to `/var/log`, but the executable runs as a normal user.
 
-#### Mac OS X using [Homebrew](http://brew.sh/)
+#### macOS using [Homebrew](http://brew.sh/)
 * Run Chronograf manually on the command line:
 
     ```
@@ -41,7 +41,7 @@ ln -sfv /usr/local/opt/chronograf/*.plist ~/Library/LaunchAgents
 launchctl load ~/Library/LaunchAgents/homebrew.mxcl.chronograf.plist
     ```
 
-#### Standalone OS X binary
+#### Standalone macOS binary
 Assuming you're working with Chronograf version 0.13, from the `chronograf-0.13/` directory:
 ```
 ./chronograf-0.13-darwin_amd64

--- a/content/chronograf/v0.13/introduction/installation.md
+++ b/content/chronograf/v0.13/introduction/installation.md
@@ -25,7 +25,7 @@ Follow the instructions in the Chronograf Downloads section on the [Downloads pa
 
 ### Start the Chronograf service
 
-#### Mac OS X (via Homebrew)
+#### macOS (via Homebrew)
 
 To run Chronograf manually, you can specify the configuration file on the
 command line:
@@ -47,7 +47,7 @@ launchctl load ~/Library/LaunchAgents/homebrew.mxcl.chronograf.plist
 sudo service chronograf start
 ```
 
-#### Standalone OS X binary
+#### Standalone macOS binary
 Assuming you’re working with Chronograf version 0.13, from the
 `chronograf-0.13/`` directory:
 ```

--- a/content/chronograf/v0.4/introduction/getting_started.md
+++ b/content/chronograf/v0.4/introduction/getting_started.md
@@ -24,12 +24,12 @@ sudo service chronograf start
 ```
 Note that the Chronograf startup script needs root permission to ensure that it can write to `/var/log`, but the executable runs as a normal user.
 
-#### OS X via [Homebrew](http://brew.sh/)
+#### macOS via [Homebrew](http://brew.sh/)
 ```
 chronograf
 ```
 
-#### Standalone OS X binary
+#### Standalone macOS binary
 Assuming you're working with Chronograf version 0.4, from the `chronograf-0.4/` directory:
 ```
 ./chronograf-0.4-darwin_amd64
@@ -45,8 +45,8 @@ Those settings are configurable; see the configuration file to change them and t
 We list the location of the configuration file by installation process below.
 
 > * Debian or RPM package: `/opt/chronograf/config.toml`
-> * OS X via Homebrew: `/usr/local/etc/chronograf.toml`
-> * Standalone OS X binary: `chronograf-0.x.x/chronograf.toml`
+> * macOS via Homebrew: `/usr/local/etc/chronograf.toml`
+> * Standalone macOS binary: `chronograf-0.x.x/chronograf.toml`
 
 Now that you've got everything installed and running it's time to start visualizing your data in Chronograf!
 

--- a/content/chronograf/v1.0/administration/configuration.md
+++ b/content/chronograf/v1.0/administration/configuration.md
@@ -50,5 +50,5 @@ chronograf -config chronograf.generated.conf
 By default, Chronograf will look for configuration files in these locations:
 
 * Debian or RPM package: `/opt/chronograf/config.toml`
-* OS X via Homebrew: `/usr/local/etc/chronograf.toml`
-* Standalone OS X binary: `chronograf-0.x.x/chronograf.toml`
+* macOS via Homebrew: `/usr/local/etc/chronograf.toml`
+* Standalone macOS binary: `chronograf-0.x.x/chronograf.toml`

--- a/content/chronograf/v1.0/introduction/getting_started.md
+++ b/content/chronograf/v1.0/introduction/getting_started.md
@@ -22,7 +22,7 @@ sudo service chronograf start
 ```
 Note that the Chronograf startup script needs root permission to ensure that it can write to `/var/log`, but the executable runs as a normal user.
 
-#### OS X via [Homebrew](http://brew.sh/)
+#### macOS via [Homebrew](http://brew.sh/)
 * Run Chronograf manually on the command line:
 
     ```
@@ -41,7 +41,7 @@ ln -sfv /usr/local/opt/chronograf/*.plist ~/Library/LaunchAgents
 launchctl load ~/Library/LaunchAgents/homebrew.mxcl.chronograf.plist
     ```
 
-#### Standalone OS X binary
+#### Standalone macOS binary
 Assuming you're working with Chronograf version 0.13, from the `chronograf-0.13/` directory:
 ```
 ./chronograf-0.13-darwin_amd64

--- a/content/chronograf/v1.0/introduction/installation.md
+++ b/content/chronograf/v1.0/introduction/installation.md
@@ -25,7 +25,7 @@ Follow the instructions in the Chronograf Downloads section on the [Downloads pa
 
 ### Start the Chronograf service
 
-#### Mac OS X (via Homebrew)
+#### macOS (via Homebrew)
 
 To run Chronograf manually, you can specify the configuration file on the
 command line:

--- a/content/chronograf/v1.4/administration/config-options.md
+++ b/content/chronograf/v1.4/administration/config-options.md
@@ -39,7 +39,7 @@ Examples:
 ```sh
   sudo systemctl start chronograf --develop --reporting-disabled
 ```
-* Mac OS X: Using shortcut options to set develop mode and disable reporting
+* macOS: Using shortcut options to set develop mode and disable reporting
 
 ```sh
   chronograf -d -r

--- a/content/chronograf/v1.5/administration/config-options.md
+++ b/content/chronograf/v1.5/administration/config-options.md
@@ -39,7 +39,7 @@ Examples:
 ```sh
   sudo systemctl start chronograf --develop --reporting-disabled
 ```
-* Mac OS X: Using shortcut options to set develop mode and disable reporting
+* macOS: Using shortcut options to set develop mode and disable reporting
 
 ```sh
   chronograf -d -r

--- a/content/chronograf/v1.6/administration/config-options.md
+++ b/content/chronograf/v1.6/administration/config-options.md
@@ -39,7 +39,7 @@ Examples:
 ```sh
   sudo systemctl start chronograf --develop --reporting-disabled
 ```
-* Mac OS X: Using shortcut options to set develop mode and disable reporting
+* macOS: Using shortcut options to set develop mode and disable reporting
 
 ```sh
   chronograf -d -r

--- a/content/enterprise_influxdb/v1.1/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.1/about-the-project/release-notes-changelog.md
@@ -44,7 +44,7 @@ Please see the [release notes](https://github.com/influxdata/influxdb/blob/1.1/C
 
 This release is built with Go 1.7.4.
 It resolves a security vulnerability reported in Go version 1.7.3 which impacts all
-users currently running on the Mac OS X platform, powered by the Darwin operating system.
+users currently running on the macOS platform, powered by the Darwin operating system.
 
 #### Bugfixes
 
@@ -208,7 +208,7 @@ Backup and restore has been updated to fix issues and refine existing capabiliti
 
 This release is built with Go 1.7.4.
 It resolves a security vulnerability reported in Go version 1.7.3 which impacts all
-users currently running on the Mac OS X platform, powered by the Darwin operating system.
+users currently running on the macOS platform, powered by the Darwin operating system.
 
 ### Features
 

--- a/content/enterprise_influxdb/v1.2/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.2/about-the-project/release-notes-changelog.md
@@ -178,7 +178,7 @@ Please see the OSS [release notes](https://github.com/influxdata/influxdb/blob/1
 
 This release is built with Go (golang) 1.7.4.
 It resolves a security vulnerability reported in Go (golang) version 1.7.3 which impacts all
-users currently running on the Mac OS X platform, powered by the Darwin operating system.
+users currently running on the macOS platform, powered by the Darwin operating system.
 
 #### Cluster-specific Bugfixes
 
@@ -364,7 +364,7 @@ development.
 
 This release is built with Go (golang) 1.7.4.
 It resolves a security vulnerability reported in Go (golang) version 1.7.3 which impacts all
-users currently running on the Mac OS X platform, powered by the Darwin operating system.
+users currently running on the macOS platform, powered by the Darwin operating system.
 
 ### Features
 

--- a/content/enterprise_influxdb/v1.3/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.3/about-the-project/release-notes-changelog.md
@@ -306,7 +306,7 @@ Please see the OSS [release notes](https://github.com/influxdata/influxdb/blob/1
 
 This release is built with Go (golang) 1.7.4.
 It resolves a security vulnerability reported in Go (golang) version 1.7.3 which impacts all
-users currently running on the Mac OS X platform, powered by the Darwin operating system.
+users currently running on the macOS platform, powered by the Darwin operating system.
 
 #### Cluster-specific Bugfixes
 

--- a/content/enterprise_influxdb/v1.5/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.5/about-the-project/release-notes-changelog.md
@@ -389,7 +389,7 @@ Please see the OSS [release notes](https://github.com/influxdata/influxdb/blob/1
 
 This release is built with Go (golang) 1.7.4.
 It resolves a security vulnerability reported in Go (golang) version 1.7.3 which impacts all
-users currently running on the Mac OS X platform, powered by the Darwin operating system.
+users currently running on the macOS platform, powered by the Darwin operating system.
 
 #### Cluster-specific bug fixes
 

--- a/content/enterprise_influxdb/v1.6/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.6/about-the-project/release-notes-changelog.md
@@ -398,7 +398,7 @@ Please see the OSS [release notes](https://github.com/influxdata/influxdb/blob/1
 
 This release is built with Go (golang) 1.7.4.
 It resolves a security vulnerability reported in Go (golang) version 1.7.3 which impacts all
-users currently running on the Mac OS X platform, powered by the Darwin operating system.
+users currently running on the macOS platform, powered by the Darwin operating system.
 
 #### Cluster-specific bug fixes
 

--- a/content/influxdb/v0.10/administration/config.md
+++ b/content/influxdb/v0.10/administration/config.md
@@ -89,7 +89,7 @@ There will always be at least one hostname present.
 * `snapshots` contains the server's snapshots taken for the purpose of log compaction.
 * `raft.db` is the BoltDB database that contains the Raft log and snapshots.
 
->**Note:** The default directory for OSX installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 ### hostname = "localhost"
 
@@ -150,7 +150,7 @@ This section controls where the actual shard data for InfluxDB lives and how it 
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OSX installations is `/Users/<username>/.influxdb/data`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`
 
 ### max-wal-size = 104857600
 
@@ -245,7 +245,7 @@ The hinted handoff directory.
 For best throughput, the HH directory and the WAL directory should be on different physical devices.
 If you have performance concerns, you will also want to make this setting different from the dir in the [[data]](/influxdb/v0.10/administration/config/#data) section.
 
->**Note:** The default directory for OSX installations is `/Users/<username>/.influxdb/hh`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/hh`
 
 
 ### max-size = 1073741824

--- a/content/influxdb/v0.10/administration/logs.md
+++ b/content/influxdb/v0.10/administration/logs.md
@@ -24,7 +24,7 @@ influxd 2>$HOME/my_log_file
 If InfluxDB was installed using a pre-built package, and then launched as a service, `stderr` is redirected to `/var/log/influxdb/influxd.log`, and all log data will be written to that file.
 You can override this location by setting the variable `STDERR` in the file `/etc/default/influxdb`.
 
->**Note:** On OSX the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
+>**Note:** On macOS the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
  
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v0.10/introduction/_index.md
+++ b/content/influxdb/v0.10/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installation](/influxdb/v0.10/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and macOS.
 
 ## [Getting Started](/influxdb/v0.10/introduction/getting_started/)
 

--- a/content/influxdb/v0.10/introduction/installation.md
+++ b/content/influxdb/v0.10/introduction/installation.md
@@ -110,9 +110,9 @@ sudo service influxd onestart
 
 To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.conf`.
 
-### Mac OS X
+### macOS
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v0.10/tools/shell.md
+++ b/content/influxdb/v0.10/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v0.10/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v0.10/write_protocols/udp.md
+++ b/content/influxdb/v0.10/write_protocols/udp.md
@@ -13,7 +13,7 @@ To configure InfluxDB to support writes over UDP you must adjust your config fil
 ## A note on UDP/IP OS Buffer sizes
 
 Some OSes (most notably, Linux) place very restricive limits on the performance of UDP protocols.
-Recent versions of FreeBSD, OSX, and Windows do not have this problem.
+Recent versions of FreeBSD, macOS, and Windows do not have this problem.
 It is _highly_ recommended that you increase these OS limits to 8MB before trying to run large amounts of UDP traffic to your instance.
 8MB is a starting recommendation, and should be adjusted to be in line with your `read-buffer` plugin setting.
 

--- a/content/influxdb/v0.11/administration/config.md
+++ b/content/influxdb/v0.11/administration/config.md
@@ -91,7 +91,7 @@ There will always be at least one hostname present.
 * `snapshots` contains the server's snapshots taken for the purpose of log compaction.
 * `raft.db` is the BoltDB database that contains the Raft log and snapshots.
 
->**Note:** The default directory for OSX installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 ### hostname = "localhost"
 
@@ -170,7 +170,7 @@ Controls if the node holds time series data shards in the cluster.
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OSX installations is `/Users/<username>/.influxdb/data`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`
 
 ### query-log-enabled = true
 
@@ -218,7 +218,7 @@ The hinted handoff directory.
 For best throughput, the HH directory and the WAL directory should be on different physical devices.
 If you have performance concerns, you will also want to make this setting different from the dir in the [[data]](/influxdb/v0.11/administration/config/#data) section.
 
->**Note:** The default directory for OSX installations is `/Users/<username>/.influxdb/hh`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/hh`
 
 ### max-size = 1073741824
 

--- a/content/influxdb/v0.11/administration/logs.md
+++ b/content/influxdb/v0.11/administration/logs.md
@@ -24,7 +24,7 @@ influxd 2>$HOME/my_log_file
 If InfluxDB was installed using a pre-built package, and then launched as a service, `stderr` is redirected to `/var/log/influxdb/influxd.log`, and all log data will be written to that file.
 You can override this location by setting the variable `STDERR` in the file `/etc/default/influxdb`.
 
->**Note:** On OSX the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
+>**Note:** On macOS the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
  
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v0.11/introduction/_index.md
+++ b/content/influxdb/v0.11/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installation](/influxdb/v0.11/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and macOS.
 
 ## [Getting Started](/influxdb/v0.11/introduction/getting_started/)
 

--- a/content/influxdb/v0.11/introduction/installation.md
+++ b/content/influxdb/v0.11/introduction/installation.md
@@ -110,9 +110,9 @@ sudo service influxd onestart
 
 To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.conf`.
 
-### Mac OS X
+### macOS
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v0.11/tools/shell.md
+++ b/content/influxdb/v0.11/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v0.11/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v0.11/write_protocols/udp.md
+++ b/content/influxdb/v0.11/write_protocols/udp.md
@@ -13,7 +13,7 @@ To configure InfluxDB to support writes over UDP you must adjust your config fil
 ## A note on UDP/IP OS Buffer sizes
 
 Some OSes (most notably, Linux) place very restricive limits on the performance of UDP protocols.
-Recent versions of FreeBSD, OSX, and Windows do not have this problem.
+Recent versions of FreeBSD, macOS, and Windows do not have this problem.
 It is _highly_ recommended that you increase these OS limits to 8MB before trying to run large amounts of UDP traffic to your instance.
 8MB is a starting recommendation, and should be adjusted to be in line with your `read-buffer` plugin setting.
 

--- a/content/influxdb/v0.12/administration/config.md
+++ b/content/influxdb/v0.12/administration/config.md
@@ -81,7 +81,7 @@ continuous queries.
 The `meta` directory.
 Files in the `meta` directory include: `meta.db` and the `snapshots` directory.
 
->**Note:** The default directory for OSX installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 ### retention-autocreate = true
 
@@ -108,7 +108,7 @@ This section controls where the actual shard data for InfluxDB lives and how it 
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OSX installations is `/Users/<username>/.influxdb/data`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`
 
 ### query-log-enabled = true
 

--- a/content/influxdb/v0.12/administration/logs.md
+++ b/content/influxdb/v0.12/administration/logs.md
@@ -24,7 +24,7 @@ influxd 2>$HOME/my_log_file
 If InfluxDB was installed using a pre-built package, and then launched as a service, `stderr` is redirected to `/var/log/influxdb/influxd.log`, and all log data will be written to that file.
 You can override this location by setting the variable `STDERR` in the file `/etc/default/influxdb`.
 
->**Note:** On OSX the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
+>**Note:** On macOS the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
  
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v0.12/administration/upgrading.md
+++ b/content/influxdb/v0.12/administration/upgrading.md
@@ -115,7 +115,7 @@ influxd config > /etc/influxdb/influxdb_012.conf.generated
 
 Compare your old configuration file against the newly generated [InfluxDB 0.12 file](/influxdb/v0.12/administration/config/) and manually update any defaults with your localized settings.
 
-> **Note:** If you're working on a system other than OS X you will need to
+> **Note:** If you're working on a system other than macOS you will need to
 change the following directories in your newly-generated configuration file:
 >
 * Change the `dir` setting in the `[meta]` section to `/var/lib/influxdb/meta`

--- a/content/influxdb/v0.12/introduction/_index.md
+++ b/content/influxdb/v0.12/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installation](/influxdb/v0.12/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and macOS.
 
 ## [Getting Started](/influxdb/v0.12/introduction/getting_started/)
 

--- a/content/influxdb/v0.12/introduction/installation.md
+++ b/content/influxdb/v0.12/introduction/installation.md
@@ -109,9 +109,9 @@ sudo service influxd onestart
 
 To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.conf`.
 
-### Mac OS X
+### macOS
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v0.12/tools/shell.md
+++ b/content/influxdb/v0.12/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v0.12/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v0.12/write_protocols/udp.md
+++ b/content/influxdb/v0.12/write_protocols/udp.md
@@ -14,7 +14,7 @@ To configure InfluxDB to support writes over UDP you must adjust your config fil
 ## A note on UDP/IP OS Buffer sizes
 
 Some OSes (most notably, Linux) place very restricive limits on the performance of UDP protocols.
-Recent versions of FreeBSD, OSX, and Windows do not have this problem.
+Recent versions of FreeBSD, macOS, and Windows do not have this problem.
 It is _highly_ recommended that you increase these OS limits to 8MB before trying to run large amounts of UDP traffic to your instance.
 8MB is a starting recommendation, and should be adjusted to be in line with your `read-buffer` plugin setting.
 

--- a/content/influxdb/v0.13/administration/config.md
+++ b/content/influxdb/v0.13/administration/config.md
@@ -128,7 +128,7 @@ continuous queries.
 The `meta` directory.
 Files in the `meta` directory include `meta.db`.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 ### retention-autocreate = true
 
@@ -155,7 +155,7 @@ This section controls where the actual shard data for InfluxDB lives and how it 
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/data`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`
 
 ### engine = "tsm1"
 

--- a/content/influxdb/v0.13/administration/logs.md
+++ b/content/influxdb/v0.13/administration/logs.md
@@ -24,7 +24,7 @@ influxd 2>$HOME/my_log_file
 If InfluxDB was installed using a pre-built package, and then launched as a service, `stderr` is redirected to `/var/log/influxdb/influxd.log`, and all log data will be written to that file.
 You can override this location by setting the variable `STDERR` in the file `/etc/default/influxdb`.
 
->**Note:** On OS X the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
+>**Note:** On macOS the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
 
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v0.13/introduction/_index.md
+++ b/content/influxdb/v0.13/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installation](/influxdb/v0.13/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and macOS.
 
 ## [Getting Started](/influxdb/v0.13/introduction/getting_started/)
 

--- a/content/influxdb/v0.13/introduction/installation.md
+++ b/content/influxdb/v0.13/introduction/installation.md
@@ -130,9 +130,9 @@ sudo service influxd onestart
 
 To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.conf`.
 
-### Mac OS X
+### macOS
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v0.13/testing/_index.md
+++ b/content/influxdb/v0.13/testing/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installation](/influxdb/v0.13/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and macOS.
 
 ## [Getting Started](/influxdb/v0.13/introduction/getting_started/)
 

--- a/content/influxdb/v0.13/tools/shell.md
+++ b/content/influxdb/v0.13/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v0.13/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v0.13/write_protocols/udp.md
+++ b/content/influxdb/v0.13/write_protocols/udp.md
@@ -14,7 +14,7 @@ To configure InfluxDB to support writes over UDP you must adjust your config fil
 ## A note on UDP/IP OS Buffer sizes
 
 Some OSes (most notably, Linux) place very restricive limits on the performance of UDP protocols.
-Recent versions of FreeBSD, OSX, and Windows do not have this problem.
+Recent versions of FreeBSD, macOS, and Windows do not have this problem.
 It is _highly_ recommended that you increase these OS limits to 8MB before trying to run large amounts of UDP traffic to your instance.
 8MB is a starting recommendation, and should be adjusted to be in line with your `read-buffer` plugin setting.
 

--- a/content/influxdb/v0.8/introduction/installation.md
+++ b/content/influxdb/v0.8/introduction/installation.md
@@ -70,10 +70,10 @@ sudo /etc/init.d/influxdb start
 
 ## OS 
 
-XInstallation of version 0.8.8 on OS X 10.8 and higher is available through [Homebrew](http://brew.sh/) [Tap](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md).
+XInstallation of version 0.8.8 on macOS 10.8 and higher is available through [Homebrew](http://brew.sh/) [Tap](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md).
 
 
-Installing the package on OS X:
+Installing the package on macOS:
 
 ```bash
 brew install homebrew/versions/influxdb08

--- a/content/influxdb/v0.9/introduction/_index.md
+++ b/content/influxdb/v0.9/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installation](/influxdb/v0.9/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and macOS.
 
 ## [Getting Started](/influxdb/v0.9/introduction/getting_started/)
 

--- a/content/influxdb/v0.9/introduction/installation.md
+++ b/content/influxdb/v0.9/introduction/installation.md
@@ -88,9 +88,9 @@ sudo service influxd onestart
 ```
 and/or adding `influxd_enable="YES"` to `/etc/rc.conf` to launch influxd during system boot.
 
-### OS X
+### macOS
 
-Users of OS X 10.8 and higher can install using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install using the [Homebrew](http://brew.sh/) package manager.
 
 ```bash
 brew update

--- a/content/influxdb/v0.9/tools/shell.md
+++ b/content/influxdb/v0.9/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v0.9/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 Access the CLI by starting the `influxd` process and entering `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v0.9/write_protocols/udp.md
+++ b/content/influxdb/v0.9/write_protocols/udp.md
@@ -14,7 +14,7 @@ To configure InfluxDB to support writes over UDP you must adjust your config fil
 
 Some OSes (most notably, Linux) place very restricive limits on the performance
 of UDP protocols.
-Recent versions of FreeBSD, OSX, and Windows do not have this
+Recent versions of FreeBSD, macOS, and Windows do not have this
 problem.
 It is _highly_ recommended that you increase these OS limits to
 8MB before trying to run large amounts of UDP traffic to your instance.

--- a/content/influxdb/v1.0/administration/config.md
+++ b/content/influxdb/v1.0/administration/config.md
@@ -305,7 +305,7 @@ continuous queries.
 The `meta` directory.
 Files in the `meta` directory include `meta.db`.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 ### retention-autocreate = true
 
@@ -328,7 +328,7 @@ This section controls where the actual shard data for InfluxDB lives and how it 
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/data`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`
 
 ### engine = "tsm1"
 

--- a/content/influxdb/v1.0/administration/logs.md
+++ b/content/influxdb/v1.0/administration/logs.md
@@ -29,7 +29,7 @@ as a service, `stderr` is redirected to
 that file.  You can override this location by setting the variable
 `STDERR` in the file `/etc/default/influxdb`.
 
->**Note:** On OS X the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
+>**Note:** On macOS the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
 
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v1.0/introduction/_index.md
+++ b/content/influxdb/v1.0/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installation](/influxdb/v1.0/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and macOS.
 
 ## [Getting Started](/influxdb/v1.0/introduction/getting_started/)
 

--- a/content/influxdb/v1.0/introduction/installation.md
+++ b/content/influxdb/v1.0/introduction/installation.md
@@ -36,7 +36,7 @@ you may want to check out our
 [RedHat & CentOS](#)
 [SLES & openSUSE](#)
 [FreeBSD/PC-BSD](#)
-[MAC OS X](#)
+[macOS](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
 
@@ -151,7 +151,7 @@ To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.co
 
 {{% tab-content %}}
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v1.0/tools/shell.md
+++ b/content/influxdb/v1.0/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v1.0/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v1.0/tools/udp.md
+++ b/content/influxdb/v1.0/tools/udp.md
@@ -15,7 +15,7 @@ To configure InfluxDB to support writes over UDP you must adjust your [config fi
 ## A note on UDP/IP OS Buffer sizes
 
 Some OSes (most notably, Linux) place very restricive limits on the performance of UDP protocols.
-Recent versions of FreeBSD, OSX, and Windows do not have this problem.
+Recent versions of FreeBSD, macOS, and Windows do not have this problem.
 It is _highly_ recommended that you increase these OS limits to 8MB before trying to run large amounts of UDP traffic to your instance.
 8MB is a starting recommendation, and should be adjusted to be in line with your `read-buffer` plugin setting.
 

--- a/content/influxdb/v1.1/administration/config.md
+++ b/content/influxdb/v1.1/administration/config.md
@@ -152,7 +152,7 @@ continuous queries.
 The `meta` directory.
 Files in the `meta` directory include `meta.db`.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 Environment variable: `INFLUXDB_META_DIR`
 
@@ -181,7 +181,7 @@ This section controls where the actual shard data for InfluxDB lives and how it 
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/data`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`
 
 Environment variable: `INFLUXDB_DATA_DIR`
 

--- a/content/influxdb/v1.1/administration/logs.md
+++ b/content/influxdb/v1.1/administration/logs.md
@@ -29,7 +29,7 @@ as a service, `stderr` is redirected to
 that file.  You can override this location by setting the variable
 `STDERR` in the file `/etc/default/influxdb`.
 
->**Note:** On OS X the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
+>**Note:** On macOS the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
 
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v1.1/introduction/_index.md
+++ b/content/influxdb/v1.1/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installation](/influxdb/v1.1/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and macOS.
 
 ## [Getting Started](/influxdb/v1.1/introduction/getting_started/)
 

--- a/content/influxdb/v1.1/introduction/installation.md
+++ b/content/influxdb/v1.1/introduction/installation.md
@@ -36,7 +36,7 @@ you may want to check out our
 [RedHat & CentOS](#)
 [SLES & openSUSE](#)
 [FreeBSD/PC-BSD](#)
-[MAC OS X](#)
+[macOS](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
 
@@ -151,7 +151,7 @@ To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.co
 
 {{% tab-content %}}
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v1.1/tools/shell.md
+++ b/content/influxdb/v1.1/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v1.1/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v1.2/administration/config.md
+++ b/content/influxdb/v1.2/administration/config.md
@@ -263,7 +263,7 @@ continuous queries.
 The `meta` directory.
 Files in the `meta` directory include `meta.db`.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 Environment variable: `INFLUXDB_META_DIR`
 
@@ -292,7 +292,7 @@ This section controls where the actual shard data for InfluxDB lives and how it 
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/data`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`
 
 Environment variable: `INFLUXDB_DATA_DIR`
 

--- a/content/influxdb/v1.2/administration/logs.md
+++ b/content/influxdb/v1.2/administration/logs.md
@@ -29,7 +29,7 @@ as a service, `stderr` is redirected to
 that file.  You can override this location by setting the variable
 `STDERR` in the file `/etc/default/influxdb`.
 
->**Note:** On OS X the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
+>**Note:** On macOS the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
 
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v1.2/introduction/_index.md
+++ b/content/influxdb/v1.2/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installation](/influxdb/v1.2/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, RedHat, CentOS, and macOS.
 
 ## [Getting Started](/influxdb/v1.2/introduction/getting_started/)
 

--- a/content/influxdb/v1.2/introduction/installation.md
+++ b/content/influxdb/v1.2/introduction/installation.md
@@ -44,7 +44,7 @@ you may want to check out our
 [RedHat & CentOS](#)
 [SLES & openSUSE](#)
 [FreeBSD/PC-BSD](#)
-[MAC OS X](#)
+[macOS](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
 
@@ -159,7 +159,7 @@ To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.co
 
 {{% tab-content %}}
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v1.2/tools/shell.md
+++ b/content/influxdb/v1.2/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v1.2/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v1.3/administration/config.md
+++ b/content/influxdb/v1.3/administration/config.md
@@ -283,7 +283,7 @@ continuous queries.
 The `meta` directory.
 Files in the `meta` directory include `meta.db`.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 Environment variable: `INFLUXDB_META_DIR`
 
@@ -312,7 +312,7 @@ This section controls where the actual shard data for InfluxDB lives and how it 
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/data`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`
 
 Environment variable: `INFLUXDB_DATA_DIR`
 

--- a/content/influxdb/v1.3/administration/logs.md
+++ b/content/influxdb/v1.3/administration/logs.md
@@ -29,7 +29,7 @@ as a service, `stderr` is redirected to
 that file.  You can override this location by setting the variable
 `STDERR` in the file `/etc/default/influxdb`.
 
->**Note:** On OS X the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
+>**Note:** On macOS the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
 
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v1.3/introduction/_index.md
+++ b/content/influxdb/v1.3/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installing InfluxDB](/influxdb/v1.3/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, Red Hat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, Red Hat, CentOS, and macOS.
 
 ## [Getting started with InfluxDB](/influxdb/v1.3/introduction/getting_started/)
 

--- a/content/influxdb/v1.3/introduction/installation.md
+++ b/content/influxdb/v1.3/introduction/installation.md
@@ -44,7 +44,7 @@ you may want to check out our
 [Red Hat & CentOS](#)
 [SLES & openSUSE](#)
 [FreeBSD/PC-BSD](#)
-[MAC OS X](#)
+[macOS](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
 
@@ -160,7 +160,7 @@ To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.co
 
 {{% tab-content %}}
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v1.3/tools/shell.md
+++ b/content/influxdb/v1.3/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v1.3/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v1.4/administration/config.md
+++ b/content/influxdb/v1.4/administration/config.md
@@ -87,7 +87,7 @@ The InfluxDB system has internal defaults for all of the settings in the configu
 The local InfluxDB configuration file is located here:
 
 - Linux: `/etc/influxdb/influxdb.conf`
-- MacOS: `/usr/local/etc/influxdb.conf`
+- macOS: `/usr/local/etc/influxdb.conf`
 
 Settings that are commented out are set to the internal system defaults. Uncommented settings override the internal defaults.
 Note that the local configuration file does not need to include every configuration setting.
@@ -183,7 +183,7 @@ which stores information on users, databases, retention policies, shards, and co
 The `meta` directory.
 Files in the `meta` directory include `meta.db`, the InfluxDB metastore file.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 Environment variable: `INFLUXDB_META_DIR`
 
@@ -212,7 +212,7 @@ The `[data]` settings control where the actual shard data for InfluxDB lives and
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/data`.
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`.
 
 Environment variable: `INFLUXDB_DATA_DIR`
 
@@ -228,7 +228,7 @@ Environment variable: `INFLUXDB_DATA_INDEX_VERSION`
 
 The WAL directory is the location of the [write ahead log](/influxdb/v1.4/concepts/glossary/#wal-write-ahead-log).
 
->**Note:** The default WAL directory for Mac OS X installations is `/Users/<username>/.influxdb/wal`.
+>**Note:** The default WAL directory for macOS installations is `/Users/<username>/.influxdb/wal`.
 
 Environment variable: `INFLUXDB_DATA_WAL_DIR`
 

--- a/content/influxdb/v1.4/administration/logs.md
+++ b/content/influxdb/v1.4/administration/logs.md
@@ -30,7 +30,7 @@ as a service, `stderr` is redirected to
 that file.  You can override this location by setting the variable
 `STDERR` in the file `/etc/default/influxdb`.
 
->**Note:** On OS X the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
+>**Note:** On macOS the logs, by default, are stored in the file `/usr/local/var/log/influxdb.log`
 
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v1.4/introduction/_index.md
+++ b/content/influxdb/v1.4/introduction/_index.md
@@ -10,7 +10,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installing InfluxDB](/influxdb/v1.4/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, Red Hat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, Red Hat, CentOS, and macOS.
 
 ## [Getting started with InfluxDB](/influxdb/v1.4/introduction/getting_started/)
 

--- a/content/influxdb/v1.4/introduction/installation.md
+++ b/content/influxdb/v1.4/introduction/installation.md
@@ -45,7 +45,7 @@ you may want to check out our
 [Red Hat & CentOS](#)
 [SLES & openSUSE](#)
 [FreeBSD/PC-BSD](#)
-[MAC OS X](#)
+[macOS](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
 
@@ -161,7 +161,7 @@ To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.co
 
 {{% tab-content %}}
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v1.4/tools/shell.md
+++ b/content/influxdb/v1.4/tools/shell.md
@@ -15,7 +15,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v1.4/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB using a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB using a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v1.5/administration/config.md
+++ b/content/influxdb/v1.5/administration/config.md
@@ -87,7 +87,7 @@ The InfluxDB system has internal defaults for all of the settings in the configu
 The local InfluxDB configuration file is located here:
 
 - Linux: `/etc/influxdb/influxdb.conf`
-- MacOS: `/usr/local/etc/influxdb.conf`
+- macOS: `/usr/local/etc/influxdb.conf`
 
 Settings that are commented out are set to the internal system defaults. Uncommented settings override the internal defaults.
 Note that the local configuration file does not need to include every configuration setting.
@@ -183,7 +183,7 @@ which stores information on users, databases, retention policies, shards, and co
 The `meta` directory.
 Files in the `meta` directory include `meta.db`, the InfluxDB metastore file.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 Environment variable: `INFLUXDB_META_DIR`
 
@@ -212,7 +212,7 @@ The `[data]` settings control where the actual shard data for InfluxDB lives and
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/data`.
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`.
 
 Environment variable: `INFLUXDB_DATA_DIR`
 
@@ -229,7 +229,7 @@ Environment variable: `INFLUXDB_DATA_INDEX_VERSION`
 
 The WAL directory is the location of the [write ahead log](/influxdb/v1.5/concepts/glossary/#wal-write-ahead-log).
 
->**Note:** The default WAL directory for Mac OS X installations is `/Users/<username>/.influxdb/wal`.
+>**Note:** The default WAL directory for macOS installations is `/Users/<username>/.influxdb/wal`.
 
 Environment variable: `INFLUXDB_DATA_WAL_DIR`
 

--- a/content/influxdb/v1.5/administration/logs.md
+++ b/content/influxdb/v1.5/administration/logs.md
@@ -38,7 +38,7 @@ If InfluxDB was installed using a prebuilt package, and then launched
 as a service, `stderr` is redirected to `/var/log/influxdb/influxd.log` and all log data will be written to that file.
 You can override this location by setting the environment variable `STDERR` in the InfluxDB configuration file `/etc/default/influxdb`.
 
->**Note:** Mac OS X logs are stored, by default, in the file `/usr/local/var/log/influxdb.log`.
+>**Note:** macOS logs are stored, by default, in the file `/usr/local/var/log/influxdb.log`.
 
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v1.5/introduction/_index.md
+++ b/content/influxdb/v1.5/introduction/_index.md
@@ -14,7 +14,7 @@ See the [InfluxData downloads page](https://influxdata.com/downloads/#influxdb) 
 
 ## [Installing InfluxDB OSS](/influxdb/v1.5/introduction/installation/)
 
-[Installing InfluxDB OSS](/influxdb/v1.5/introduction/installation/) provides instructions for installing InfluxDB on Ubuntu, Debian, Red Hat, CentOS, and Mac OS X.
+[Installing InfluxDB OSS](/influxdb/v1.5/introduction/installation/) provides instructions for installing InfluxDB on Ubuntu, Debian, Red Hat, CentOS, and macOS.
 
 ## [Getting started with InfluxDB OSS](/influxdb/v1.5/introduction/getting-started/)
 

--- a/content/influxdb/v1.5/introduction/installation.md
+++ b/content/influxdb/v1.5/introduction/installation.md
@@ -45,7 +45,7 @@ you may want to check out our
 [Red Hat & CentOS](#)
 [SLES & openSUSE](#)
 [FreeBSD/PC-BSD](#)
-[MAC OS X](#)
+[macOS](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
 
@@ -161,7 +161,7 @@ To have InfluxDB start at system boot, add `influxd_enable="YES"` to `/etc/rc.co
 
 {{% tab-content %}}
 
-Users of OS X 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install InfluxDB using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install InfluxDB by running:
 
 ```bash

--- a/content/influxdb/v1.5/tools/shell.md
+++ b/content/influxdb/v1.5/tools/shell.md
@@ -16,7 +16,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [Commands](/influxdb/v1.5/tools/shell/#commands)
 
 ### Using `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/influxdb/v1.6/administration/config.md
+++ b/content/influxdb/v1.6/administration/config.md
@@ -88,7 +88,7 @@ The InfluxDB system has internal defaults for all of the settings in the configu
 The local InfluxDB configuration file is located here:
 
 - Linux: `/etc/influxdb/influxdb.conf`
-- MacOS: `/usr/local/etc/influxdb.conf`
+- macOS: `/usr/local/etc/influxdb.conf`
 
 Settings that are commented out are set to the internal system defaults. Uncommented settings override the internal defaults.
 Note that the local configuration file does not need to include every configuration setting.
@@ -184,7 +184,7 @@ which stores information on users, databases, retention policies, shards, and co
 The `meta` directory.
 Files in the `meta` directory include `meta.db`, the InfluxDB metastore file.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/meta`
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/meta`
 
 Environment variable: `INFLUXDB_META_DIR`
 
@@ -213,7 +213,7 @@ The `[data]` settings control where the actual shard data for InfluxDB lives and
 The directory where InfluxDB stores the data.
 This directory may be changed.
 
->**Note:** The default directory for OS X installations is `/Users/<username>/.influxdb/data`.
+>**Note:** The default directory for macOS installations is `/Users/<username>/.influxdb/data`.
 
 Environment variable: `INFLUXDB_DATA_DIR`
 
@@ -230,7 +230,7 @@ Environment variable: `INFLUXDB_DATA_INDEX_VERSION`
 
 The WAL directory is the location of the [write ahead log](/influxdb/v1.6/concepts/glossary/#wal-write-ahead-log).
 
->**Note:** The default WAL directory for Mac OS X installations is `/Users/<username>/.influxdb/wal`.
+>**Note:** The default WAL directory for macOS installations is `/Users/<username>/.influxdb/wal`.
 
 Environment variable: `INFLUXDB_DATA_WAL_DIR`
 

--- a/content/influxdb/v1.6/administration/logs.md
+++ b/content/influxdb/v1.6/administration/logs.md
@@ -38,7 +38,7 @@ If InfluxDB was installed using a prebuilt package, and then launched
 as a service, `stderr` is redirected to `/var/log/influxdb/influxd.log` and all log data will be written to that file.
 You can override this location by setting the environment variable `STDERR` in the InfluxDB configuration file `/etc/default/influxdb`.
 
->**Note:** Mac OS X logs are stored, by default, in the file `/usr/local/var/log/influxdb.log`.
+>**Note:** macOS logs are stored, by default, in the file `/usr/local/var/log/influxdb.log`.
 
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v1.6/introduction/_index.md
+++ b/content/influxdb/v1.6/introduction/_index.md
@@ -14,7 +14,7 @@ Provides the location to download the latest stable and nightly builds of Influx
 
 ## [Installing InfluxDB OSS](/influxdb/v1.6/introduction/installation/)
 
-Provides instructions for installing InfluxDB on Ubuntu, Debian, Red Hat, CentOS, and OS X.
+Provides instructions for installing InfluxDB on Ubuntu, Debian, Red Hat, CentOS, and macOS.
 
 ## [Getting started with InfluxDB OSS](/influxdb/v1.6/introduction/getting-started/)
 

--- a/content/influxdb/v1.6/tools/shell.md
+++ b/content/influxdb/v1.6/tools/shell.md
@@ -16,7 +16,7 @@ Use `influx` to write data (manually or from a file), query data interactively, 
 * [`influx` Commands](/influxdb/v1.6/tools/shell/#influx-commands)
 
 ## Launch `influx`
-If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on OS X).
+If you [install](https://influxdata.com/downloads/) InfluxDB via a package manager, the CLI is installed at `/usr/bin/influx` (`/usr/local/bin/influx` on macOS).
 
 To access the CLI, first launch the `influxd` database process and then launch `influx` in your terminal.
 Once you've entered the shell and successfully connected to an InfluxDB node, you'll see the following output:

--- a/content/kapacitor/v0.13/introduction/installation.md
+++ b/content/kapacitor/v0.13/introduction/installation.md
@@ -49,7 +49,7 @@ manually by running:
 ./kapacitord -config <PATH TO CONFIGURATION>
 ```
 
-#### OS X (via Homebrew)
+#### macOS (via Homebrew)
 
 To have `launchd` start Kapacitor at login:
 

--- a/content/kapacitor/v1.0/introduction/installation.md
+++ b/content/kapacitor/v1.0/introduction/installation.md
@@ -42,7 +42,7 @@ manually by running:
 ./kapacitord -config <PATH TO CONFIGURATION>
 ```
 
-#### OS X (via Homebrew)
+#### macOS (via Homebrew)
 
 To have `launchd` start Kapacitor at login:
 

--- a/content/kapacitor/v1.1/introduction/installation.md
+++ b/content/kapacitor/v1.1/introduction/installation.md
@@ -42,7 +42,7 @@ manually by running:
 ./kapacitord -config <PATH TO CONFIGURATION>
 ```
 
-#### OS X (via Homebrew)
+#### macOS (via Homebrew)
 
 To have `launchd` start Kapacitor at login:
 

--- a/content/kapacitor/v1.2/introduction/installation.md
+++ b/content/kapacitor/v1.2/introduction/installation.md
@@ -42,7 +42,7 @@ manually by running:
 ./kapacitord -config <PATH TO CONFIGURATION>
 ```
 
-#### OS X (via Homebrew)
+#### macOS (via Homebrew)
 
 To have `launchd` start Kapacitor at login:
 

--- a/content/kapacitor/v1.3/introduction/installation.md
+++ b/content/kapacitor/v1.3/introduction/installation.md
@@ -42,7 +42,7 @@ manually by running:
 ./kapacitord -config <PATH TO CONFIGURATION>
 ```
 
-#### OS X (via Homebrew)
+#### macOS (via Homebrew)
 
 To have `launchd` start Kapacitor at login:
 

--- a/content/kapacitor/v1.4/introduction/installation.md
+++ b/content/kapacitor/v1.4/introduction/installation.md
@@ -42,7 +42,7 @@ manually by running:
 ./kapacitord -config <PATH TO CONFIGURATION>
 ```
 
-#### OS X (using Homebrew)
+#### macOS (using Homebrew)
 
 To have `launchd` start Kapacitor at login:
 

--- a/content/kapacitor/v1.5/introduction/installation.md
+++ b/content/kapacitor/v1.5/introduction/installation.md
@@ -42,7 +42,7 @@ manually by running:
 ./kapacitord -config <PATH TO CONFIGURATION>
 ```
 
-#### OS X (using Homebrew)
+#### macOS (using Homebrew)
 
 To have `launchd` start Kapacitor at login:
 

--- a/content/platform/installation/sandbox-install.md
+++ b/content/platform/installation/sandbox-install.md
@@ -18,7 +18,7 @@ The Sandbox is by far the easiest way to build the TICK stack, but it is not rec
 for production use.
 
 ## Requirements
-- Linux or MacOS <em style="opacity:.5;margin-left:.5em;">(Windows support is coming)</em>
+- Linux or macOS <em style="opacity:.5;margin-left:.5em;">(Windows support is coming)</em>
 - [Git](https://git-scm.com/)
 - [Docker](https://docs.docker.com/install/#supported-platforms)
 - [Docker Compose](https://docs.docker.com/compose/install/)

--- a/content/telegraf/v0.10/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.10/introduction/getting-started-telegraf.md
@@ -22,7 +22,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -39,7 +39,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf -config telegraf.conf
 ```

--- a/content/telegraf/v0.11/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.11/introduction/getting-started-telegraf.md
@@ -21,7 +21,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -38,7 +38,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf -config telegraf.conf
 ```

--- a/content/telegraf/v0.12/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.12/introduction/getting-started-telegraf.md
@@ -21,7 +21,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -38,7 +38,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf -config telegraf.conf
 ```

--- a/content/telegraf/v0.13/introduction/getting_started.md
+++ b/content/telegraf/v0.13/introduction/getting_started.md
@@ -21,7 +21,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -38,7 +38,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf -config telegraf.conf
 ```

--- a/content/telegraf/v0.13/introduction/installation.md
+++ b/content/telegraf/v0.13/introduction/installation.md
@@ -94,9 +94,9 @@ sudo pkg install telegraf
 
 The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 
-### Mac OS X
+### macOS
 
-Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
 Once `brew` is installed, you can install Telegraf by running:
 
 ```bash
@@ -106,7 +106,7 @@ brew install telegraf
 
 ### Start the Telegraf service
 
-#### OS X (via Homebrew)
+#### macOS (via Homebrew)
 To have launchd start telegraf at login:
 ```
 ln -sfv /usr/local/opt/telegraf/*.plist ~/Library/LaunchAgents

--- a/content/telegraf/v0.2/introduction/getting-started-telegraf.md
+++ b/content/telegraf/v0.2/introduction/getting-started-telegraf.md
@@ -19,7 +19,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/opt/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -38,7 +38,7 @@ telegraf -sample-config -filter cpu:mem -outputfilter influxdb > telegraf.conf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf -config telegraf.conf
 ```

--- a/content/telegraf/v1.0/introduction/getting_started.md
+++ b/content/telegraf/v1.0/introduction/getting_started.md
@@ -22,7 +22,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -39,7 +39,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf -config telegraf.conf
 ```

--- a/content/telegraf/v1.0/introduction/installation.md
+++ b/content/telegraf/v1.0/introduction/installation.md
@@ -27,7 +27,7 @@ which is located at `/etc/telegraf/telegraf.conf` for default installations.
   [RedHat & CentOS](#)
   [SLES & openSUSE](#)
   [FreeBSD/PC-BSD](#)
-  [MAC OS X](#)
+  [macOS](#)
   [Windows](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
@@ -117,7 +117,7 @@ which is located at `/etc/telegraf/telegraf.conf` for default installations.
   The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 {{% /tab-content %}}
 {{% tab-content %}}
-  Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+  Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
   Once `brew` is installed, you can install Telegraf by running:
 
   ```bash

--- a/content/telegraf/v1.1/introduction/getting_started.md
+++ b/content/telegraf/v1.1/introduction/getting_started.md
@@ -22,7 +22,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -39,7 +39,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf -config telegraf.conf
 ```

--- a/content/telegraf/v1.1/introduction/installation.md
+++ b/content/telegraf/v1.1/introduction/installation.md
@@ -27,7 +27,7 @@ which is located at `/etc/telegraf/telegraf.conf` for default installations.
   [RedHat & CentOS](#)
   [SLES & openSUSE](#)
   [FreeBSD/PC-BSD](#)
-  [MAC OS X](#)
+  [macOS](#)
   [Windows](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
@@ -117,7 +117,7 @@ which is located at `/etc/telegraf/telegraf.conf` for default installations.
   The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 {{% /tab-content %}}
 {{% tab-content %}}
-  Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+  Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
   Once `brew` is installed, you can install Telegraf by running:
 
   ```bash

--- a/content/telegraf/v1.2/introduction/getting_started.md
+++ b/content/telegraf/v1.2/introduction/getting_started.md
@@ -22,7 +22,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -39,7 +39,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf -config telegraf.conf
 ```

--- a/content/telegraf/v1.2/introduction/installation.md
+++ b/content/telegraf/v1.2/introduction/installation.md
@@ -33,7 +33,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   [RedHat & CentOS](#)
   [SLES & openSUSE](#)
   [FreeBSD/PC-BSD](#)
-  [MAC OS X](#)
+  [macOS](#)
   [Windows](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
@@ -123,7 +123,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 {{% /tab-content %}}
 {{% tab-content %}}
-  Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+  Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
   Once `brew` is installed, you can install Telegraf by running:
 
   ```bash

--- a/content/telegraf/v1.3/introduction/getting_started.md
+++ b/content/telegraf/v1.3/introduction/getting_started.md
@@ -22,7 +22,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -39,7 +39,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf -config telegraf.conf
 ```

--- a/content/telegraf/v1.3/introduction/installation.md
+++ b/content/telegraf/v1.3/introduction/installation.md
@@ -33,7 +33,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   [RedHat & CentOS](#)
   [SLES & openSUSE](#)
   [FreeBSD/PC-BSD](#)
-  [MAC OS X](#)
+  [macOS](#)
   [Windows](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
@@ -124,7 +124,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 {{% /tab-content %}}
 {{% tab-content %}}
-  Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+  Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
   Once `brew` is installed, you can install Telegraf by running:
 
   ```bash

--- a/content/telegraf/v1.4/introduction/getting_started.md
+++ b/content/telegraf/v1.4/introduction/getting_started.md
@@ -22,7 +22,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 ## Configuration
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -39,7 +39,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 
 ## Start the Telegraf Server
 Start the Telegraf server and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf --config telegraf.conf
 ```

--- a/content/telegraf/v1.4/introduction/installation.md
+++ b/content/telegraf/v1.4/introduction/installation.md
@@ -33,7 +33,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   [RedHat & CentOS](#)
   [SLES & openSUSE](#)
   [FreeBSD/PC-BSD](#)
-  [MAC OS X](#)
+  [macOS](#)
   [Windows](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
@@ -124,7 +124,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 {{% /tab-content %}}
 {{% tab-content %}}
-  Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+  Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
   Once `brew` is installed, you can install Telegraf by running:
 
   ```bash

--- a/content/telegraf/v1.5/introduction/getting-started.md
+++ b/content/telegraf/v1.5/introduction/getting-started.md
@@ -23,7 +23,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -42,7 +42,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 ## Start the Telegraf service
 
 Start the Telegraf service and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf --config telegraf.conf
 ```

--- a/content/telegraf/v1.5/introduction/installation.md
+++ b/content/telegraf/v1.5/introduction/installation.md
@@ -35,7 +35,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   [RedHat & CentOS](#)
   [SLES & openSUSE](#)
   [FreeBSD/PC-BSD](#)
-  [MAC OS X](#)
+  [macOS](#)
   [Windows](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
@@ -132,7 +132,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 {{% /tab-content %}}
 {{% tab-content %}}
-  Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+  Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
   Once `brew` is installed, you can install Telegraf by running:
 
   ```bash

--- a/content/telegraf/v1.6/introduction/getting-started.md
+++ b/content/telegraf/v1.6/introduction/getting-started.md
@@ -22,7 +22,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -41,7 +41,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 ## Start the Telegraf service
 
 Start the Telegraf service and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf --config telegraf.conf
 ```

--- a/content/telegraf/v1.6/introduction/installation.md
+++ b/content/telegraf/v1.6/introduction/installation.md
@@ -35,7 +35,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   [RedHat & CentOS](#)
   [SLES & openSUSE](#)
   [FreeBSD/PC-BSD](#)
-  [MAC OS X](#)
+  [macOS](#)
   [Windows](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
@@ -132,7 +132,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 {{% /tab-content %}}
 {{% tab-content %}}
-  Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+  Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
   Once `brew` is installed, you can install Telegraf by running:
 
   ```bash

--- a/content/telegraf/v1.7/introduction/getting-started.md
+++ b/content/telegraf/v1.7/introduction/getting-started.md
@@ -24,7 +24,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -43,7 +43,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 ## Start the Telegraf service
 
 Start the Telegraf service and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf --config telegraf.conf
 ```

--- a/content/telegraf/v1.7/introduction/installation.md
+++ b/content/telegraf/v1.7/introduction/installation.md
@@ -35,7 +35,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   [RedHat & CentOS](#)
   [SLES & openSUSE](#)
   [FreeBSD/PC-BSD](#)
-  [MAC OS X](#)
+  [macOS](#)
   [Windows](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
@@ -132,7 +132,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 {{% /tab-content %}}
 {{% tab-content %}}
-  Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+  Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
   Once `brew` is installed, you can install Telegraf by running:
 
   ```bash

--- a/content/telegraf/v1.8/introduction/getting-started.md
+++ b/content/telegraf/v1.8/introduction/getting-started.md
@@ -24,7 +24,7 @@ Follow the instructions in the Telegraf section on the [Downloads page](https://
 
 ### Configuration file location by installation type
 
-* OS X [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
+* macOS [Homebrew](http://brew.sh/): `/usr/local/etc/telegraf.conf`
 * Linux debian and RPM packages: `/etc/telegraf/telegraf.conf`
 * Standalone Binary: see the next section for how to create a configuration file
 
@@ -43,7 +43,7 @@ telegraf -sample-config -input-filter cpu:mem -output-filter influxdb > telegraf
 ## Start the Telegraf service
 
 Start the Telegraf service and direct it to the relevant configuration file:
-### OS X [Homebrew](http://brew.sh/)
+### macOS [Homebrew](http://brew.sh/)
 ```bash
 telegraf --config telegraf.conf
 ```

--- a/content/telegraf/v1.8/introduction/installation.md
+++ b/content/telegraf/v1.8/introduction/installation.md
@@ -35,7 +35,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   [RedHat & CentOS](#)
   [SLES & openSUSE](#)
   [FreeBSD/PC-BSD](#)
-  [MAC OS X](#)
+  [macOS](#)
   [Windows](#)
 {{% /tabs %}}
 {{< tab-content-container >}}
@@ -132,7 +132,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   The configuration file is located at `/usr/local/etc/telegraf.conf` with examples in `/usr/local/etc/telegraf.conf.sample`.
 {{% /tab-content %}}
 {{% tab-content %}}
-  Users of OS X 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
+  Users of macOS 10.8 and higher can install Telegraf using the [Homebrew](http://brew.sh/) package manager.
   Once `brew` is installed, you can install Telegraf by running:
 
   ```bash


### PR DESCRIPTION
Updated all mentions and variations of OSX to macOS to match Apple's official OS name change from 2016.