### PR TITLE
update bug fix in release notes for 1.6.4

### DIFF
--- a/content/enterprise_influxdb/v1.6/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.6/about-the-project/release-notes-changelog.md
@@ -58,7 +58,9 @@ The following summarizes the expected settings for proper configuration of JWT a
 
 ### Bug fixes
 
-* Reject `influxd-ctl update-data` from one existing host to another.
+* Reject `influxd-ctl add-data` if the host being added is already part of the cluster. 
+Also for `influxd-ctl update-data host1 host 2` where host2 != host1 will ALSO be rejected when host2 is already 
+part of the cluster.
 * Require `internal-shared-secret` if meta auth enabled.
 
 


### PR DESCRIPTION
describe defensive coding put in place to ensure that a host which already exists in the cluster isn't re-added.