### PR TITLE
Add generic api key (fixes #1863)

### DIFF
--- a/content/chronograf/v1.6/administration/config-options.md
+++ b/content/chronograf/v1.6/administration/config-options.md
@@ -399,3 +399,9 @@ Environment variable: `$GENERIC_TOKEN_URL`
 The URL that returns OpenID UserInfo-compatible information.
 
 Environment variable: `$GENERIC_API_URL`
+
+#### `--generic-api-key=`
+
+The key that returns OpenID UserInfo-compatible information.
+
+Environment variable: `$GENERIC_API_KEY`


### PR DESCRIPTION
Added generic-api-key to the Generic OAuth 2.0 configuration section per the linked issue--I just made my best guess of the details based on other entries in this doc, so let me know if I need to change anything. Thanks!