### PR TITLE
fix(flux): small typo fixes

### DIFF
--- a/content/flux/v0.7/introduction/getting-started/_index.md
+++ b/content/flux/v0.7/introduction/getting-started/_index.md
@@ -62,7 +62,7 @@ Flux's [`from()` function](/flux/v0.7/functions/inputs/from), which defines an I
 When using Flux with InfluxDB v1.x, use the following bucket naming convention which combines
 the database name and retention policy into a single bucket name:
 
-###### InfluxDB v1.x bucket naming convention**_
+###### InfluxDB v1.x bucket naming convention
 ```js
 // Pattern
 from(bucket:"<database>/<retention-policy>")
@@ -75,7 +75,7 @@ from(bucket:"telegraf/autogen")
 Flux uses pipe-forward operators (`|>`) extensively to chain operations together.
 After each function or operation, Flux returns a table or collection of tables containing data.
 The pipe-forward operator pipes those tables into the next function or operation where
-it is further processed or manipulated.
+they are further processed or manipulated.
 
 ### Tables
 Flux structures all data in tables.

--- a/content/flux/v0.7/introduction/getting-started/query-influxdb.md
+++ b/content/flux/v0.7/introduction/getting-started/query-influxdb.md
@@ -33,7 +33,7 @@ Flux requires a time range when querying time series data.
 "Unbounded" queries are very resource-intensive and as a protective measure,
 Flux will not query the database without a specified range.
 
-Use pipe forward operator (`|>`) to pipe data from your data source into the [`range()`](/flux/v0.7/functions/transformations/range)
+Use the pipe-forward operator (`|>`) to pipe data from your data source into the [`range()`](/flux/v0.7/functions/transformations/range)
 function, which specifies a time range for your query.
 It accepts two properties: `start` and `stop`.
 Ranges can be **relative** using negative [durations](/flux/v0.7/language/lexical-elements#duration-literals)
@@ -112,7 +112,7 @@ from(bucket:"telegraf/autogen")
   |> yield()
 ```
 
-> Chronograf and the `influx` CLI automatically assumes a `yield()` function at
+> Chronograf and the `influx` CLI automatically assume a `yield()` function at
 > the end of each script in order to output and visualize the data.
 > Best practice is to include a `yield()` function, but it is not always necessary.
 

--- a/content/flux/v0.7/introduction/getting-started/syntax-basics.md
+++ b/content/flux/v0.7/introduction/getting-started/syntax-basics.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 
-Flux, at its core, is scripting language designed specifically for working with data.
+Flux, at its core, is a scripting language designed specifically for working with data.
 This guide walks through a handful of simple expressions and how they are handled in Flux.
 
 ## Use the influx CLI
@@ -22,8 +22,8 @@ influx -type=flux
 ```
 
 > If using the [InfluxData Sandbox](/platform/installation/sandbox-install), use the `./sandbox enter`
-> command console into the `influxdb` container, where you can start the `influx` CLI in Flux mode.
-> You also need to specify the `host` as `influxdb` to connect to InfluxDB over the Docker network.
+> command to enter the `influxdb` container, where you can start the `influx` CLI in Flux mode.
+> You will also need to specify the `host` as `influxdb` to connect to InfluxDB over the Docker network.
 >
 ```bash
 ./sandbox enter influxdb
@@ -45,7 +45,7 @@ For example, simple addition:
 ```
 
 ### Variables
-Assign expressions to a variable using the assignment operator, `=`.
+Assign an expression to a variable using the assignment operator, `=`.
 
 ```js
 > s = "this is a string"
@@ -84,9 +84,10 @@ Jim
 Flux supports lists. List values must be the same type.
 
 ```js
-> l = [1,2,3,i]
+> n = 4
+> l = [1,2,3,n]
 > l
-[1, 2, 3, 1]
+[1, 2, 3, 4]
 ```
 
 ### Functions
@@ -105,17 +106,17 @@ Below is a simple function that squares a number, `n`.
 ### Pipe-forward operator
 Flux uses the pipe-forward operator (`|>`) extensively to chain operations together.
 After each function or operation, Flux returns a table or collection of tables containing data.
-The pipe-forward operator pipes those tables into the next function where it is further processed or manipulated.
+The pipe-forward operator pipes those tables into the next function where they are further processed or manipulated.
 
 ```js
 data |> someFunction() |> anotherFunction()
 ```
 
 ## Real-world application of basic syntax
-This likely seems familiar if you've already been through through the other [getting started guides](/flux/v0.7/introduction/getting-started)n.
+This likely seems familiar if you've already been through through the other [getting started guides](/flux/v0.7/introduction/getting-started).
 Flux's syntax is inspired by Javascript and other functional scripting languages.
-As you begin to apply these basic principles in real world use cases such as creating data stream variables,
-custom functions, etc., the power of Flux and its ability to query and process data becomes apparent.
+As you begin to apply these basic principles in real-world use cases such as creating data stream variables,
+custom functions, etc., the power of Flux and its ability to query and process data will become apparent.
 
 The examples below provide both multi-line and single-line versions of each input command.
 Carriage returns in Flux aren't necessary, but do help with readability.
@@ -136,20 +137,22 @@ or more input data streams.
 ```js
 timeRange = -1h
 
-cpuUsageUser = from(bucket:"telegraf/autogen")
-  |> range(start: timeRange)
-  |> filter(fn: (r) =>
-    r._measurement == "cpu" AND
-    r._field == "usage_user" AND
-    r.cpu == "cpu-total"
-  )
+cpuUsageUser =
+  from(bucket:"telegraf/autogen")
+    |> range(start: timeRange)
+    |> filter(fn: (r) =>
+      r._measurement == "cpu" AND
+      r._field == "usage_user" AND
+      r.cpu == "cpu-total"
+    )
 
-memUsagePercent = from(bucket:"telegraf/autogen")
-  |> range(start: timeRange)
-  |> filter(fn: (r) =>
-    r._measurement == "mem" AND
-    r._field == "used_percent"
-  )
+memUsagePercent =
+  from(bucket:"telegraf/autogen")
+    |> range(start: timeRange)
+    |> filter(fn: (r) =>
+      r._measurement == "mem" AND
+      r._field == "used_percent"
+    )
 ```
 
 These variables can be used in other functions, such as  `join()`, while keeping the syntax minimal and flexible.
@@ -160,9 +163,10 @@ To do this, pass the input stream (`tables`) and the number of results to return
 Then using Flux's `sort()` and `limit()` functions to find the top `n` results in the data set.
 
 ```js
-topN = (tables=<-, n) => tables
-  |> sort(desc: true)
-  |> limit(n: n)
+topN = (tables=<-, n) =>
+  tables
+    |> sort(desc: true)
+    |> limit(n: n)
 ```
 
 _More information about creating custom functions is available in the [Custom functions](/flux/v0.7/functions/custom-functions) documentation._
@@ -201,7 +205,7 @@ topN = (tables=<-, n) => tables |> sort(desc: true) |> limit(n: n)
 _More information about creating custom functions is available in the [Custom functions](/flux/v0.7/functions/custom-functions) documentation._
 
 Using the `cpuUsageUser` data stream variable defined [above](#define-data-stream-variables),
-Find the top five data points with the custom `topN` function and yield the results.
+find the top five data points with the custom `topN` function and yield the results.
 
 ```js
 cpuUsageUser |> topN(n:5) |> yield()

--- a/content/flux/v0.7/introduction/getting-started/transform-data.md
+++ b/content/flux/v0.7/introduction/getting-started/transform-data.md
@@ -37,7 +37,7 @@ You can also [create custom functions](/flux/v0.7/functions/custom-functions) in
 _Functions are covered in detail in the [Flux functions](/flux/v0.7/functions) documentation._
 
 A common type of function used when transforming data queried from InfluxDB is an aggregate function.
-Aggregate functions take a set of `_value` in a table, aggregate them, and transform
+Aggregate functions take a set of `_value`s in a table, aggregate them, and transform
 them into a new value.
 
 This example uses the [`mean()` function](/flux/v0.7/functions/transformations/aggregates/mean)
@@ -45,7 +45,7 @@ to average values within time windows.
 
 ## Window your data
 Flux's [`window()` function](/flux/v0.7/functions/transformations/window) partitions records based on a time value.
-Use the `every` parameter to define a duration of time between windows.
+Use the `every` parameter to define a duration of time for each window.
 
 For this example, window data in five minute intervals (`5m`).
 
@@ -65,8 +65,8 @@ When visualized, each table is assigned a unique color.
 ![Windowed data tables](/img/flux/flux-windowed-data.png)
 
 ## Aggregate windowed data
-Flux aggregate functions take the `_values` in each table and aggregate them in some way.
-Use the [`mean()` function](/flux/v0.7/functions/transformations/aggregates/mean) to average the `_values` of each table.
+Flux aggregate functions take the `_value`s in each table and aggregate them in some way.
+Use the [`mean()` function](/flux/v0.7/functions/transformations/aggregates/mean) to average the `_value`s of each table.
 
 ```js
 from(bucket:"telegraf/autogen")
@@ -87,7 +87,7 @@ Windowed tables are all still separate and, when visualized, will appear as sing
 ## Add times to your aggregates
 As values are aggregated, the resulting tables do not have a `_time` column because
 the records used for the aggregation all have different timestamps.
-Aggregate functions don't infer what time should be used for the aggregate value,
+Aggregate functions don't infer what time should be used for the aggregate value.
 Therefore the `_time` column is dropped.
 
 A `_time` column is required in the [next operation](#unwindow-aggregate-tables).
@@ -129,7 +129,7 @@ Once ungrouped and combined into a single table, the aggregate data points will 
 ![Unwindowed aggregate data](/img/flux/flux-windowed-aggregates-ungrouped.png)
 
 ## Helper functions
-This may seem like a lot of coding just to query that aggregates data, however going through the
+This may seem like a lot of coding just to build a query that aggregates data, however going through the
 process helps to understand how data changes "shape" as it is passed through each function.
 
 Flux provides (and allows you to create) "helper" functions that abstract many of these steps.


### PR DESCRIPTION
I was reading the getting started guide and noticed a couple small things.