### PR TITLE
Adding time zone configuration

### DIFF
--- a/content/kapacitor/v1.5/introduction/installation.md
+++ b/content/kapacitor/v1.5/introduction/installation.md
@@ -92,3 +92,20 @@ To generate a new configuration file, run:
 ```
 kapacitord config > kapacitor.generated.conf
 ```
+
+### Time zone
+
+In order to be able to present time in alerts notifications in a time zone of your choice, you can either change time zone of the system that runs kapacitor, or set the kapacitor process' TZ environment variable.
+
+#### systemd
+
+Add the environment variable using `systemctl edit kapacitor`:
+
+```
+[Service]
+Environment="TZ=Asia/Shanghai"
+```
+
+#### docker
+
+Set the environment variable either when starting the container (`-e TZ=Asia/Shanghai`), or in docker-compose.yml.


### PR DESCRIPTION
I need to present time in a time zone of my choice in alerts. Found the information on https://github.com/influxdata/kapacitor/issues/1014 useful, I believe it should be added to the documentation (could not find the TZ env variable anywhere in the docs).

Before I also add info about how to use that in alerts (`{{ .Time.Local.Format "Mon, Jan 2 2006 at 15:04:05 CST" }}`; elsewhere in the docs), I'd like to ask whether this is the prefered/only way to do this, or if there is a better way (on the way?) - I can imagine people would be interested to send alerts notifications to different teams in different time zones?

Also I believe this should be in the docker docs page in the docker hub (https://hub.docker.com/r/library/kapacitor/) - where can I find source for that content?