### PR TITLE
Reformat plugin headers and remove parens, etc

### DIFF
--- a/content/telegraf/v1.8/plugins/aggregators.md
+++ b/content/telegraf/v1.8/plugins/aggregators.md
@@ -16,28 +16,37 @@ Aggregators emit new aggregate metrics based on the metrics collected by the inp
 ## Supported Telegraf aggregator plugins
 
 
-### [BasicStats (`basicstats`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/basicstats/README.md)
+### BasicStats
 
-The [BasicStats (`basicstats`) aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/basicstats/README.md) gives count, max, min, mean, s2(variance), and stdev for a set of values, emitting the aggregate every period seconds.
+Plugin ID: `aggregators.basicstats`
 
-### [Histogram (`histogram`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/histogram/README.md)
+The [BasicStats aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/basicstats/README.md) gives count, max, min, mean, s2(variance), and stdev for a set of values, emitting the aggregate every period seconds.
 
-The [Histogram (`histogram`) aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/histogram/README.md) creates histograms containing the counts of field values within a range.
+### Histogram
+
+Plugin ID: `aggregators.histogram`
+
+The [Histogram aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/histogram/README.md) creates histograms containing the counts of field values within a range.
 
 Values added to a bucket are also added to the larger buckets in the distribution. This creates a [cumulative histogram](https://en.wikipedia.org/wiki/Histogram#/media/File:Cumulative_vs_normal_histogram.svg).
 
-Like other Telegraf aggregators, the metric is emitted every period seconds. Bucket counts however are not reset between periods and will be non-strictly increasing while Telegraf is running.
+Like other Telegraf aggregator plugins, the metric is emitted every period seconds. Bucket counts, however, are not reset between periods and will be non-strictly increasing while Telegraf is running.
 
-### [MinMax (`minmax`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/minmax/README.md)
+### MinMax
 
-The [MinMax (`minmax`) aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/minmax/README.md) aggregates min and max values of each field it sees, emitting the aggegrate every period seconds.
+Plugin ID:`aggregators.minmax`
 
-### [ValueCounter (`valuecounter`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/valuecounter/README.md) -- NEW in v.1.8
+The [MinMax aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/minmax/README.md) aggregates min and max values of each field it sees, emitting the aggegrate every period seconds.
 
-The [MinMax (`valuecounter`) aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/valuecounter/README.md) counts the occurrence of values in fields and emits the counter once every 'period' seconds.
+### ValueCounter
 
-A use case for the ValueCounter aggregator plugin is when you are processing a HTTP access log (with the logparser input plugin) and want to count the HTTP status codes.
+Plugin ID: `aggregators.valuecounter`
 
-The fields which will be counted must be configured with the fields configuration directive. When no fields are provided, the plugin will not count any fields. The results are emitted in fields, formatted as `originalfieldname_fieldvalue = count`.
+The [ValueCounter aggregator plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/aggregators/valuecounter/README.md) counts the occurrence of values in fields and emits the counter once every 'period' seconds.
+
+A use case for the ValueCounter aggregator plugin is when you are processing a HTTP access log with the [Logparser input plugin](/telegraf/v1.8/plugins/inputs/#logparser) and want to count the HTTP status codes.
+
+The fields which will be counted must be configured with the fields configuration directive. When no fields are provided, the plugin will not count any fields.
+The results are emitted in fields, formatted as `originalfieldname_fieldvalue = count`.
 
 ValueCounter only works on fields of the type `int`, `bool`, or `string`. Float fields are being dropped to prevent the creating of too many fields.

--- a/content/telegraf/v1.8/plugins/inputs.md
+++ b/content/telegraf/v1.8/plugins/inputs.md
@@ -20,447 +20,638 @@ View usage instructions for each service input by running `telegraf --usage <ser
 
 ## Supported Telegraf input plugins
 
-### [ActiveMQ (`activemq`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/activemq/README.md) -- NEW in v.1.8
+### ActiveMQ
 
-The [ActiveMQ (`activemq`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/activemq/README.md) gathers queues, topics, and subscriber metrics using the ActiveMQ Console API.
+Plugin ID: `inputs.activemq`
 
-### [Aerospike (`aerospike`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/aerospike/README.md)
+The [ActiveMQ input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/activemq/README.md) gathers queues, topics, and subscriber metrics using the ActiveMQ Console API.
 
-The [Aerospike (`aerospike`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/aerospike/README.md) queries Aerospike servers and gets node statistics and  statistics for all configured namespaces.
+### Aerospike
 
-### [Amazon CloudWatch Statistics (`cloudwatch`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cloudwatch/README.md)
+Plugin ID: `inputs.aerospike`
 
-The [Amazon CloudWatch Statistics (`cloudwatch`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cloudwatch/README.md) pulls metric statistics from Amazon CloudWatch.
+The [Aerospike input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/aerospike/README.md) queries Aerospike servers and gets node statistics and  statistics for all configured namespaces.
 
-### [AMQP Consumer (`amqp_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/amqp_consumer/README.md)
+### Amazon CloudWatch Statistics
 
-The [AMQP Consumer (`amqp_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/amqp_consumer/README.md) provides a consumer for use with AMQP 0-9-1, a prominent implementation of this protocol
+Plugin ID: `inputs.cloudwatch`
+
+The [Amazon CloudWatch Statistics input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cloudwatch/README.md) pulls metric statistics from Amazon CloudWatch.
+
+### AMQP Consumer
+
+Plugin ID: `inputs.amqp_consumer`
+
+The [AMQP Consumer input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/amqp_consumer/README.md) provides a consumer for use with AMQP 0-9-1, a prominent implementation of this protocol
 being RabbitMQ.
 
-### [Apache HTTP Server  (`apache`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/apache/README.md)
+### Apache HTTP Server  
 
-The [Apache HTTP Server (`apache`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/apache/README.md) collects server performance information using the `mod_status` module of the Apache HTTP Server.
+Plugin ID: `inputs.apache`
 
-Typically, the `mod_status` module is configured to expose a page at the `/server-status?auto` location of the Apache
-server. The [ExtendedStatus](https://httpd.apache.org/docs/2.4/mod/core.html#extendedstatus) option must be enabled in order
-to collect all available fields. For information about how to configure your server reference the
-[module documenation](https://httpd.apache.org/docs/2.4/mod/mod_status.html#enable).
+The [Apache HTTP Server input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/apache/README.md) collects server performance information using the `mod_status` module of the Apache HTTP Server.
 
-### [Apache Kafka Consumer (`kafka_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kafka_consumer/README.md)
+Typically, the `mod_status` module is configured to expose a page at the `/server-status?auto` location of the Apache server.
+The [ExtendedStatus](https://httpd.apache.org/docs/2.4/mod/core.html#extendedstatus) option must be enabled in order to collect all available fields.
+For information about how to configure your server reference, see the
+[module documentation](https://httpd.apache.org/docs/2.4/mod/mod_status.html#enable).
 
-The [Apache Kafka Consumer (`kafka_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kafka_consumer/README.md) polls a specified Kafka topic and adds messages to InfluxDB.
+### Apache Kafka Consumer
+
+Plugin ID: `inputs.kafka_consumer`
+
+The [Apache Kafka Consumer input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kafka_consumer/README.md) polls a specified Kafka topic and adds messages to InfluxDB.
 Messages are expected in the line protocol format.
 [Consumer Group](http://godoc.org/github.com/wvanbergen/kafka/consumergroup) is used to talk to the Kafka cluster so
 multiple instances of Telegraf can read from the same topic in parallel.
 
-### [Apache Solr (`solr`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/solr/README.md)
+### Apache Solr
+
+Plugin ID: `inputs.solr`
 
 The [Apache Solr (`solr`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/solr/README.md) collects stats using the MBean Request Handler.
 
-### [Apache Tomcat (`tomcat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tomcat/README.md)
+### Apache Tomcat
 
-The [Apache Tomcat (`tomcat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tomcat/README.md) collects statistics available from the Apache Tomcat manager status page (`http://<host>/manager/status/all?XML=true`). Using `XML=true` returns XML data).
+Plugin ID: `inputs.tomcat`
+
+The [Apache Tomcat input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tomcat/README.md) collects statistics available from the Apache Tomcat manager status page (`http://<host>/manager/status/all?XML=true`). Using `XML=true` returns XML data).
 See the [Apache Tomcat documentation](https://tomcat.apache.org/tomcat-9.0-doc/manager-howto.html#Server_Status) for details on these statistics.
 
-### [Aurora (`aurora`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/aurora/README.md)
+### Aurora
+
+Plugin ID: `inputs.aurora`
 
 The [Aurora input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/aurora/README.md) gathers metrics from [Apache Aurora](https://aurora.apache.org/) schedulers. For monitoring recommendations, see [Monitoring your Aurora cluster](https://aurora.apache.org/documentation/latest/operations/monitoring/).
 
-### [Bcache (`bcache`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bcache/README.md)
+### Bcache
 
-The [Bcache (`bcache`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bcache/README.md) gets bcache statistics from the `stats_total` directory and `dirty_data` file.
+Plugin ID: `inputs.bcache`
 
-### [Beanstalkd (`beanstalkd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/beanstalkd/README.md) -- NEW in v.1.8
+The [Bcache input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bcache/README.md) gets bcache statistics from the `stats_total` directory and `dirty_data` file.
 
-The [Beanstalkd (`beanstalkd`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/beanstalkd/README.md) collects server stats as well as tube stats (reported by `stats` and `stats-tube` commands respectively).
+### Beanstalkd
 
-### [Bond (`bond`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bond/README.md)
+Plugin ID: `inputs.beanstalkd`
 
-The [Bond (`bond`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bond/README.md) collects network bond interface status, bond's slaves interfaces status and failures count of
+The [Beanstalkd input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/beanstalkd/README.md) collects server stats as well as tube stats (reported by `stats` and `stats-tube` commands respectively).
+
+### Bond
+
+Plugin ID: `inputs.bond`
+
+The [Bond input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/bond/README.md) collects network bond interface status, bond's slaves interfaces status and failures count of
 bond's slaves interfaces. The plugin collects these metrics from `/proc/net/bonding/*` files.
 
-### [Burrow (`burrow`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/burrow/README.md)
+### Burrow
 
-The [Burrow (`burrow` input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/burrow/README.md) collects Apache Kafka topic, consumer, and partition status using the [Burrow](https://github.com/linkedin/Burrow) HTTP [HTTP Endpoint](https://github.com/linkedin/Burrow/wiki/HTTP-Endpoint).
+Plugin ID: `inputs.burrow`
 
-### [Ceph Storage (`ceph`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ceph/README.md)
+The [Burrow input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/burrow/README.md) collects Apache Kafka topic, consumer, and partition status using the [Burrow](https://github.com/linkedin/Burrow) HTTP [HTTP Endpoint](https://github.com/linkedin/Burrow/wiki/HTTP-Endpoint).
 
-The [Ceph Storage (`ceph`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ceph/README.md) collects performance metrics from the MON and OSD nodes in a Ceph storage cluster.
+### Ceph Storage
 
-### [CGroup (`cgroup`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cgroup/README.md)
+Plugin ID: `inputs.ceph`
 
-The [CGroup (`cgroup`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cgroup/README.md) captures specific statistics per cgroup.
+The [Ceph Storage input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ceph/README.md) collects performance metrics from the MON and OSD nodes in a Ceph storage cluster.
 
-### [Chrony (`chrony`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/chrony/README.md)
+### CGroup
 
-The [Chrony (`chrony`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/chrony/README.md) gets standard chrony metrics, requires chronyc executable.
+Plugin ID: `inputs.cgroup`
 
-### [Conntrack (`conntrack`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/conntrack/README.md)
+The [CGroup input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cgroup/README.md) captures specific statistics per cgroup.
 
-The [Conntrack (`conntrack`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/conntrack/README.md) collects stats from Netfilter's conntrack-tools.
+### Chrony
 
-The conntrack-tools provide a mechanism for tracking various aspects of network connections as they are processed by
-netfilter. At runtime, conntrack exposes many of those connection statistics within `/proc/sys/net`. Depending on your
-kernel version, these files can be found in either `/proc/sys/net/ipv4/netfilter` or `/proc/sys/net/netfilter` and will be
-prefixed with either `ip_` or `nf_`. This plugin reads the files specified in its configuration and publishes each one as
-a field, with the prefix normalized to `ip_`.
+Plugin ID: `inputs.chrony`
 
-### [Consul (`consul`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/consul/README.md)
+The [Chrony input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/chrony/README.md) gets standard chrony metrics, requires chronyc executable.
 
-The [Consul (`consul`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/consul/README.md) will collect statistics about all health checks registered in the Consul.
+### Conntrack `inputs.conntrack`
+
+The [Conntrack input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/conntrack/README.md) collects stats from Netfilter's conntrack-tools.
+
+The conntrack-tools provide a mechanism for tracking various aspects of network connections as they are processed by netfilter.
+At runtime, conntrack exposes many of those connection statistics within `/proc/sys/net`.
+Depending on your kernel version, these files can be found in either `/proc/sys/net/ipv4/netfilter` or `/proc/sys/net/netfilter` and will be prefixed with either `ip_` or `nf_`.
+This plugin reads the files specified in its configuration and publishes each one as a field, with the prefix normalized to `ip_`.
+
+### Consul
+
+Plugin ID: `inputs.consul`
+
+The [Consul input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/consul/README.md) will collect statistics about all health checks registered in the Consul.
 It uses Consul API to query the data.
 It will not report the telemetry but Consul can report those stats already using StatsD protocol, if needed.
 
-### [Couchbase (`couchbase`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchbase/README.md)
+### Couchbase
 
-The [Couchbase (`couchbase`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchbase/README.md) reads per-node and per-bucket metrics from Couchbase.
+Plugin ID: `inputs.couchbase`
 
-### [CouchDB (`couchdb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchdb/README.md)
+The [Couchbase input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchbase/README.md) reads per-node and per-bucket metrics from Couchbase.
 
-The [CouchDB (`couchdb`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchdb/README.md) gathers metrics of CouchDB using `_stats` endpoint.
+### CouchDB
 
-### [CPU (`cpu`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cpu/README.md)
+Plugin ID: `inputs.couchdb`
 
-The [CPU (`cpu`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cpu/README.md) gathers metrics about cpu usage.
+The [CouchDB input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/couchdb/README.md) gathers metrics of CouchDB using `_stats` endpoint.
 
-### [Disk (`disk`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/disk/README.md)
+### CPU
 
-The [Disk (`disk`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/disk/README.md) gathers metrics about disk usage by mount point.
+Plugin ID: `inputs.cpu`
 
-### [DiskIO (`diskio`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/diskio/README.md)
+The [CPU input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/cpu/README.md) gathers metrics about cpu usage.
 
-The [DiskIO (`diskio`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/diskio/README.md) gathers metrics about disk IO by device.
+### Disk
 
-### [Disque (`disque`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/disque)
+Plugin ID: `inputs.disk`
 
-The [Disque (`disque`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/disque) gathers metrics from one or more [Disque](https://github.com/antirez/disque) servers.
+The [Disk input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/disk/README.md) gathers metrics about disk usage by mount point.
 
-### [DMCache (`dmcache`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dmcache/README.md)
+### DiskIO
 
-The [DMCache (`dmcache`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dmcache/README.md) provides a native collection for dmsetup-based statistics for dm-cache.
+Plugin ID: `inputs.diskio`
 
-### [DNS Query (`dns_query`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dns_query/README.md)
+The [DiskIO input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/diskio/README.md) gathers metrics about disk IO by device.
+
+### Disque
+
+Plugin ID: `inputs.disque`
+
+The [Disque input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/disque) gathers metrics from one or more [Disque](https://github.com/antirez/disque) servers.
+
+### DMCache
+
+Plugin ID: `inputs.dmcache`
+
+The [DMCache input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dmcache/README.md) provides a native collection for dmsetup-based statistics for dm-cache.
+
+### DNS Query
+
+Plugin ID: `inputs.dns_query`
 
 The [DNS Query (`dns_query`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dns_query/README.md) gathers DNS query times in milliseconds - like [Dig](https://en.wikipedia.org/wiki/Dig_(command)).
 
-### [Docker (`docker`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/docker/README.md)
+### Docker
 
-The [Docker (`docker`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/docker/README.md) uses the Docker Engine API to gather metrics on running Docker containers. The Docker plugin
+Plugin ID: `inputs.docker`
+
+The [Docker input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/docker/README.md) uses the Docker Engine API to gather metrics on running Docker containers. The Docker plugin
 uses the [Official Docker Client](https://github.com/moby/moby/tree/master/client) to gather stats from the
 [Engine API](https://docs.docker.com/engine/api/v1.20/) library documentation.
 
-### [Dovecot (`dovecot`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dovecot/README.md)
+### Dovecot
 
-The [Dovecot (`dovecot`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dovecot/README.md) uses the dovecot Stats protocol to gather metrics on configured domains. For more information,
+Plugin ID: `inputs.dovecot`
+
+The [Dovecot input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dovecot/README.md) uses the dovecot Stats protocol to gather metrics on configured domains. For more information,
 see the [Dovecot documentation](http://wiki2.dovecot.org/Statistics).
 
-### [Elasticsearch (`elasticsearch`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/elasticsearch/README.md)
+### Elasticsearch
 
-The [Elasticsearch (`elasticsearch`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/elasticsearch/README.md) queries endpoints to obtain [node](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html)
+Plugin ID: `inputs.elasticsearch`
+
+The [Elasticsearch sinput plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/elasticsearch/README.md) queries endpoints to obtain [node](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html)
 and optionally [cluster-health](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html)
 or [cluster-stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-stats.html) metrics.
 
-### [Exec (`exec`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/exec/README.md)
+### Exec
 
-The [Exec (`exec`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/exec/README.md) parses supported [Telegraf input data formats](/telegraf/v1.8/data_formats/input/) (InfluxDB Line Protocol, JSON, Graphite, Value, Nagios, Collectd, and Dropwizard into metrics. Each Telegraf metric includes the measurement name, tags, fields, and timesamp.
+Plugin ID: `inputs.exec`
 
-### [Fail2ban (`fail2ban`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fail2ban/README.md)
+The [Exec input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/exec/README.md) parses supported [Telegraf input data formats](/telegraf/v1.8/data_formats/input/) (InfluxDB Line Protocol, JSON, Graphite, Value, Nagios, Collectd, and Dropwizard into metrics. Each Telegraf metric includes the measurement name, tags, fields, and timesamp.
 
-The [Fail2ban (`fail2ban`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fail2ban/README.md) gathers the count of failed and banned ip addresses using [fail2ban](https://www.fail2ban.org/).
+### Fail2ban
 
-### [Fibaro (`fibaro`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fibaro/README.md)
+Plugin ID: `inputs.fail2ban`
 
-The [Fibaro (`fibaro`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fibaro/README.md) makes HTTP calls to the Fibaro controller API to gather values of hooked devices. Those values could be true (`1`) or false (`0`) for switches, percentage for dimmers, temperature, etc.
+The [Fail2ban input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fail2ban/README.md) gathers the count of failed and banned ip addresses using [fail2ban](https://www.fail2ban.org/).
 
-### [File (`file`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/file/README.md) -- NEW in v.1.8
+### Fibaro
 
-The [File (`file`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/file/README.md) updates a list of files every interval and parses the contents using the selected input data format.
+Plugin ID: `inputs.fibaro`
+
+The [Fibaro input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fibaro/README.md) makes HTTP calls to the Fibaro controller API to gather values of hooked devices. Those values could be true (`1`) or false (`0`) for switches, percentage for dimmers, temperature, etc.
+
+### File
+
+Plugin ID: `inputs.file`
+
+The [File input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/file/README.md) updates a list of files every interval and parses the contents using the selected input data format.
 
 Files will always be read in their entirety, if you wish to tail/follow a file use the [tail input plugin](#tail-tail-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-tail-readme-md) instead.
 
-### [Filecount (`filecount`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filecount/README.md) -- NEW in v.1.8
+### Filecount
 
-The [Filecount (`filecount`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filecount/README.md) counts files in directories that match certain criteria.
+Plugin ID: `inputs.filecount`
 
-### [Filestat (`filestat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filestat/README.md)
+The [Filecount input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filecount/README.md) counts files in directories that match certain criteria.
 
-The [Filestat (`filestat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filestat/README.md) gathers metrics about file existence, size, and other stats.
+### Filestat
 
-### [Fluentd (`fluentd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fluentd/README.md)
+Plugin ID: `inputs.filestat`
 
-The [Fluentd (`fluentd`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fluentd/README.md) gathers metrics from plugin endpoint provided by in_monitor plugin. This plugin understands
+The [Filestat input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/filestat/README.md) gathers metrics about file existence, size, and other stats.
+
+### Fluentd
+
+Plugin ID: `inputs.fluentd`
+
+The [Fluentd input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/fluentd/README.md) gathers metrics from plugin endpoint provided by in_monitor plugin. This plugin understands
 data provided by `/api/plugin.json` resource (`/api/config.json` is not covered).
 
-### [Graylog (`graylog`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/graylog/README.md)
+### Graylog
 
-The [Graylog (`graylog`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/graylog/README.md) can collect data from remote Graylog service URLs. This plugin currently supports two
+Plugin ID: `inputs.graylog`
+
+The [Graylog input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/graylog/README.md) can collect data from remote Graylog service URLs. This plugin currently supports two
 types of endpoints:
 
 * multiple (e.g., `http://[graylog-server-ip]:12900/system/metrics/multiple`)
 * namespace (e.g., `http://[graylog-server-ip]:12900/system/metrics/namespace/{namespace}`)
 
-### [HAproxy (`haproxy`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/haproxy/README.md)
+### HAproxy
 
-The [HAproxy (`haproxy`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/haproxy/README.md) gathers metrics directly from any running HAproxy instance. It can do so by using CSV
+Plugin ID: `inputs.haproxy`
+
+The [HAproxy input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/haproxy/README.md) gathers metrics directly from any running HAproxy instance. It can do so by using CSV
 generated by HAproxy status page or from admin sockets.
 
-### [Hddtemp (`hddtemp`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/hddtemp/README.md)
+### Hddtemp
 
-The [Hddtemp (`hddtemp`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/hddtemp/README.md) reads data from `hddtemp` daemons.
+Plugin ID: `inputs.hddtemp`
 
-### [HTTP (`http`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http/README.md)
+The [Hddtemp input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/hddtemp/README.md) reads data from `hddtemp` daemons.
 
-The [HTTP (`http`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http/README.md) collects metrics from one or more HTTP (or HTTPS) endpoints. The endpoint should have metrics formatted in one of the [supported input data formats](/telegraf/v1.8/data_formats/input/). Each data format has its own unique set of configuration options which can be added to the input configuration.
+### HTTP
 
-### [HTTP Listener (`http_listener`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md)
+Plugin ID: `inputs.http`
 
-The [HTTP Listener (`http_listener`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md) listens for messages sent via HTTP POST. Messages are expected in the [InfluxDB
+The [HTTP input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http/README.md) collects metrics from one or more HTTP (or HTTPS) endpoints. The endpoint should have metrics formatted in one of the [supported input data formats](/telegraf/v1.8/data_formats/input/). Each data format has its own unique set of configuration options which can be added to the input configuration.
+
+### HTTP Listener
+
+Plugin ID: `inputs.http_listener`
+
+The [HTTP Listener input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_listener/README.md) listens for messages sent via HTTP POST. Messages are expected in the [InfluxDB
 Line Protocol input data format](/telegraf/v1.8/data_formats/input/influx) ONLY (other [Telegraf input data formats](/telegraf/v1.8/data_formats/input/) are not supported).
 This plugin allows Telegraf to serve as a proxy or router for the `/write` endpoint of the InfluxDB HTTP API.
 
-### [HTTP Response (`http_response`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_response/README.md)
+### HTTP Response
 
-The [HTTP Response (`http_response`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_response/README.md) gathers metrics for HTTP responses. The measurements and fields include `response_time`, `http_response_code`, and `result_type`. Tags for measurements include `server` and `method`.
+Plugin ID: `inputs.http_response`
 
-### [Icinga2 (`icinga2`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/incinga2) -- NEW in v.1.8
+The [HTTP Response input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/http_response/README.md) gathers metrics for HTTP responses. The measurements and fields include `response_time`, `http_response_code`, and `result_type`. Tags for measurements include `server` and `method`.
 
-The [Icinga2 (`icinga2`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/icinga2) gather status on running services and hosts using the [Icinga2 Remote API](https://docs.icinga.com/icinga2/latest/doc/module/icinga2/chapter/icinga2-api).
+### Icinga2
 
-### [InfluxDB v1.x (`influxdb`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/influxdb)
+Plugin ID: `inputs.icinga2`
 
-The [InfluxDB v1.x (`influxdb`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/influxdb) gathers metrics from the exposed InfluxDB v1.x `/debug/vars` endpoint.  Using Telegraf to extract these metrics to create a "monitor of monitors" is a best practice and allows you to reduce the overhead associated with
+The [Icinga2 input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/icinga2) gather status on running services and hosts using the [Icinga2 Remote API](https://docs.icinga.com/icinga2/latest/doc/module/icinga2/chapter/icinga2-api).
+
+### InfluxDB v1.x
+
+Plugin ID: `inputs.influxdb`
+
+The [InfluxDB v1.x input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/influxdb) gathers metrics from the exposed InfluxDB v1.x `/debug/vars` endpoint.  Using Telegraf to extract these metrics to create a "monitor of monitors" is a best practice and allows you to reduce the overhead associated with
 capturing and storing these metrics locally within the `_internal` database for production deployments.
 [Read more about this approach here.](https://www.influxdata.com/blog/influxdb-debugvars-endpoint/)
 
-### [Interrupts (`interrupts`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/interrupts)
+### Interrupts
 
-The [Interrupts (`interrupts`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/interrupts) gathers metrics about IRQs, including `interrupts` (from `/proc/interrupts`) and `soft_interrupts` (from `/proc/softirqs`).
+Plugin ID: `inputs.interrupts`
 
-### [IPMI Sensor (`ipmi_sensor`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/ipmi_sensor)
+The [Interrupts input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/interrupts) gathers metrics about IRQs, including `interrupts` (from `/proc/interrupts`) and `soft_interrupts` (from `/proc/softirqs`).
 
-The [IPMI Sensor (`ipmi_sensor`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/ipmi_sensor) queries the local machine or remote host sensor statistics using the `ipmitool` utility.
+### IPMI Sensor
 
-### [ipset (`ipset`)](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ipset)
+Plugin ID: `inputs.ipmi_sensor`
 
-The [Ipset (`ipset`) input plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ipset) gathers packets and bytes counters from Linux `ipset`. It uses the output of the command `ipset save`. Ipsets created without the `counters` option are ignored.
+The [IPMI Sensor input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/ipmi_sensor) queries the local machine or remote host sensor statistics using the `ipmitool` utility.
 
-### [IPtables (`iptables`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/iptables)
+### Ipset
 
-The [IPtables (`iptables`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/iptables) gathers packets and bytes counters for rules within a set of table and chain from the Linux's iptables firewall.
+Plugin ID: `inputs.ipset`
 
-### [Jolokia2 Agent (`jolokia2_agent`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jolokia2/README.md)
+The [Ipset input plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ipset) gathers packets and bytes counters from Linux `ipset`. It uses the output of the command `ipset save`. Ipsets created without the `counters` option are ignored.
 
-The [Jolokia2 Agent (`jolokia2_agent`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jolokia2/README.md) reads JMX metrics from one or more [Jolokia](https://jolokia.org/) agent REST endpoints using the
+### IPtables
+
+Plugin ID: `inputs.iptables`
+
+The [IPtables input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/iptables) gathers packets and bytes counters for rules within a set of table and chain from the Linux's iptables firewall.
+
+### Jolokia2 Agent
+
+Plugin ID: `inputs.jolokia2_agent`
+
+The [Jolokia2 Agent input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jolokia2/README.md) reads JMX metrics from one or more [Jolokia](https://jolokia.org/) agent REST endpoints using the
  [JSON-over-HTTP protocol](https://jolokia.org/reference/html/protocol.html).
 
-### [Jolokia2 Proxy (`jolokia2_proxy`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jolokia2/README.md)
+### Jolokia2 Proxy
 
-The [Jolokia2 Proxy (`jolokia2_proxy`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jolokia2/README.md) eads JMX metrics from one or more targets by interacting with a [Jolokia](https://jolokia.org/) proxy REST endpoint using the [Jolokia](https://jolokia.org/) [JSON-over-HTTP protocol](https://jolokia.org/reference/html/protocol.html).
+Plugin ID: `inputs.jolokia2_proxy`
 
-### [JTI OpenConfig Telemetry (`jti_openconfig_telemetry`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jti_openconfig_telemetry/README.md)
+The [Jolokia2 Proxy input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/jolokia2/README.md) eads JMX metrics from one or more targets by interacting with a [Jolokia](https://jolokia.org/) proxy REST endpoint using the [Jolokia](https://jolokia.org/) [JSON-over-HTTP protocol](https://jolokia.org/reference/html/protocol.html).
 
-The [JTI OpenConfig Telemetry (`jti_openconfig_telemetry`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jti_openconfig_telemetry/README.md) reads Juniper Networks implementation of OpenConfig telemetry data from listed sensors using the Junos Telemetry Interface. Refer to
+### JTI OpenConfig Telemetry
+
+Plugin ID: `inputs.jti_openconfig_telemetry`
+
+The [JTI OpenConfig Telemetry input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jti_openconfig_telemetry/README.md) reads Juniper Networks implementation of OpenConfig telemetry data from listed sensors using the Junos Telemetry Interface. Refer to
 [openconfig.net](http://openconfig.net/) for more details about OpenConfig and [Junos Telemetry Interface (JTI)](https://www.juniper.net/documentation/en_US/junos/topics/concept/junos-telemetry-interface-oveview.html).
 
-### [Kapacitor (`kapacitor`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kapacitor/README.md)
+### Kapacitor
 
-The [Kapacitor (`kapacitor`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kapacitor/README.md) will collect metrics from the given Kapacitor instances.
+Plugin ID: `inputs.kapacitor`
 
-### [Kernel (`kernel`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kernel/README.md)
+The [Kapacitor input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kapacitor/README.md) will collect metrics from the given Kapacitor instances.
 
-The [Kernel (`kernel`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kernel/README.md) gathers kernel statistics from `/proc/stat`.
+### Kernel
 
-### [Kernel VMStat (`kernel_vmstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kernel_vmstat/README.md)
+Plugin ID: `inputs.kernel`
+
+The [Kernel input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kernel/README.md) gathers kernel statistics from `/proc/stat`.
+
+### Kernel VMStat
+
+Plugin ID: `inputs.kernel_vmstat`
 
 The [Kernel VMStat input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kernel_vmstat/README.md) gathers kernel statistics from `/proc/vmstat`.
 
-### [Kibana (`kibana`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kibana/README.md) -- NEW in v.1.8
+### Kibana
 
-The [Kibana (`kibana`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kibana/README.md) queries the Kibana status API to obtain the health status of Kibana and some useful metrics.
+Plugin ID: `inputs.kibana`
 
-### [Kubernetes (`kubernetes`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kubernetes/README.md)
+The [Kibana input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kibana/README.md) queries the Kibana status API to obtain the health status of Kibana and some useful metrics.
+
+### Kubernetes
+
+Plugin ID: `inputs.kubernetes`
 
 >***Note:*** The Kubernetes input plugin is experimental and may cause high cardinality issues with moderate to
 large Kubernetes deployments.
 
-The [Kubernetes (`kubernetes`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kubernetes/README.md) talks to the kubelet API using the `/stats/summary` endpoint to gather metrics about the running pods
+The [Kubernetes input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/kubernetes/README.md) talks to the kubelet API using the `/stats/summary` endpoint to gather metrics about the running pods
 and containers for a single host. It is assumed that this plugin is running as part of a daemonset within a
 Kubernetes installation. This means that Telegraf is running on every node within the cluster. Therefore, you
 should configure this plugin to talk to its locally running kubelet.
 
-### [LeoFS (`leofs`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/leofs/README.md)
+### LeoFS
 
-The [LeoFS (`leofs`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/leofs/README.md) gathers metrics of LeoGateway, LeoManager, and LeoStorage using SNMP. See [System monitoring](https://leo-project.net/leofs/docs/admin/system_admin/monitoring/) in the [LeoFS documentation](https://leo-project.net/leofs/docs/) for more information.
+Plugin ID: `inputs.leofs`
 
-### [Linux Sysctl FS (`linux_sysctl_fs`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/linux_sysctl_fs/README.md)
+The [LeoFS input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/leofs/README.md) gathers metrics of LeoGateway, LeoManager, and LeoStorage using SNMP. See [System monitoring](https://leo-project.net/leofs/docs/admin/system_admin/monitoring/) in the [LeoFS documentation](https://leo-project.net/leofs/docs/) for more information.
+
+### Linux Sysctl FS
+
+Plugin ID: `inputs.linux_sysctl_fs`
 
 The [Linux Sysctl FS input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/linux_sysctl_fs/README.md) provides Linux system level file (`sysctl fs`) metrics. The documentation on these fields can be found at https://www.kernel.org/doc/Documentation/sysctl/fs.txt.
 
-### [Logparser (`logparser`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/logparser/README.md)
+### Logparser
 
-The [Logparser (`logparser`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/logparser/README.md) streams and parses the given log files. Currently, it has the capability of parsing "grok" patterns
+Plugin ID: `inputs.logparser`
+
+The [Logparser input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/logparser/README.md) streams and parses the given log files. Currently, it has the capability of parsing "grok" patterns
 from log files, which also supports regular expression (regex) patterns.
 
-### [Lustre2 (`lustre2`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/lustre2)
+### Lustre2
+
+Plugin ID: `inputs.lustre2`
 
 Lustre Jobstats allows for RPCs to be tagged with a value, such as a job's ID.  This allows for per job statistics.
-The [Lustre2 (`lustre2`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/lustre2) collects statistics and tags the data with the `jobid`.
+The [Lustre2 input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/lustre2) collects statistics and tags the data with the `jobid`.
 
-### [Mailchimp (`mailchimp`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mailchimp)
+### Mailchimp
 
-The [Mailchimp (`mailchimp`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mailchimp) gathers metrics from the `/3.0/reports` MailChimp API.
+Plugin ID: `inputs.mailchimp`
 
-### [Mcrouter (`mcrouter`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mcrouter/README.md)
+The [Mailchimp input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/mailchimp) gathers metrics from the `/3.0/reports` MailChimp API.
 
-The [Mcrouter (`mcrouter`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mcrouter/README.md) gathers statistics data from a mcrouter instance. [Mcrouter](https://github.com/facebook/mcrouter) is a memcached protocol router, developed and maintained by Facebook, for scaling memcached (http://memcached.org/) deployments. It's a core component of cache infrastructure at Facebook and Instagram where mcrouter handles almost 5 billion requests per second at peak.
+### Mcrouter
 
-### [Mem (`mem`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mem/README.md)
+Plugin ID: `inputs.mcrouter`
 
-The [Mem (`mem`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mem/README.md) collects system memory metrics. For a more complete explanation of the difference between used and actual_used RAM, see [Linux ate my ram](https://www.linuxatemyram.com/).
+The [Mcrouter input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mcrouter/README.md) gathers statistics data from a mcrouter instance. [Mcrouter](https://github.com/facebook/mcrouter) is a memcached protocol router, developed and maintained by Facebook, for scaling memcached (http://memcached.org/) deployments. It's a core component of cache infrastructure at Facebook and Instagram where mcrouter handles almost 5 billion requests per second at peak.
 
-### [Memcached (`memcached`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/memcached/README.md)
+### Mem
 
-The [Memcached (`memcached`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/memcached/README.md) gathers statistics data from a Memcached server.
+Plugin ID: `inputs.mem`
 
-### [Mesos (`mesos`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mesos/README.md)
+The [Mem input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mem/README.md) collects system memory metrics. For a more complete explanation of the difference between used and actual_used RAM, see [Linux ate my ram](https://www.linuxatemyram.com/).
 
-The [Mesos (`mesos`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mesos/README.md) gathers metrics from Mesos. For more information, please check the
+### Memcached
+
+Plugin ID: `inputs.memcached`
+
+The [Memcached input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/memcached/README.md) gathers statistics data from a Memcached server.
+
+### Mesos
+
+Plugin ID: `inputs.mesos`
+
+The [Mesos input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mesos/README.md) gathers metrics from Mesos. For more information, please check the
 [Mesos Observability Metrics](http://mesos.apache.org/documentation/latest/monitoring/) page.
 
-### [Mesosphere DC/OS (`dcos`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dcos/README.md)
+### Mesosphere DC/OS
 
-The [Mesosphere DC/OS (`dcos`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dcos/README.md) gathers metrics from a DC/OS cluster's [metrics component](https://docs.mesosphere.com/1.10/metrics/).
+Plugin ID: `inputs.dcos`
 
-### [Microsoft SQL Server (`sqlserver`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sqlserver/README.md)
+The [Mesosphere DC/OS input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/dcos/README.md) gathers metrics from a DC/OS cluster's [metrics component](https://docs.mesosphere.com/1.10/metrics/).
 
-The [Microsoft SQL Server (`sqlserver`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sqlserver/README.md) provides metrics for your Microsoft SQL Server instance. It currently works with SQL Server
+### Microsoft SQL Server
+
+Plugin ID: `inputs.sqlserver`
+
+The [Microsoft SQL Server input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sqlserver/README.md) provides metrics for your Microsoft SQL Server instance. It currently works with SQL Server
 versions 2008+. Recorded metrics are lightweight and use Dynamic Management Views supplied by SQL Server.
 
-### [Minecraft (`minecraft`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/minecraft/README.md)
+### Minecraft
 
-The [Minecraft (`minecraft`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/minecraft/README.md) uses the RCON protocol to collect statistics from a scoreboard on a Minecraft server.
+Plugin ID: `inputs.minecraft`
 
-### [MongoDB (`mongodb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mongodb/README.md)
+The [Minecraft input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/minecraft/README.md) uses the RCON protocol to collect statistics from a scoreboard on a Minecraft server.
 
-The [MongoDB (`mongodb`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mongodb/README.md) collects MongoDB stats exposed by `serverStatus` and few more and create a single
+### MongoDB
+
+Plugin ID: `inputs.mongodb`
+
+The [MongoDB input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mongodb/README.md) collects MongoDB stats exposed by `serverStatus` and few more and create a single
 measurement containing values.
 
-### [MQTT Consumer (`mqtt_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mqtt_consumer/README.md)
+### MQTT Consumer
 
-The [MQTT Consumer (`mqtt_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mqtt_consumer/README.md) reads from specified MQTT topics and adds messages to InfluxDB. Messages are in the
+Plugin ID: `inputs.mqtt_consumer`
+
+The [MQTT Consumer input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mqtt_consumer/README.md) reads from specified MQTT topics and adds messages to InfluxDB. Messages are in the
 [Telegraf input data formats](/telegraf/v1.8/data_formats/input/).
 
-### [MySQL `(mysql`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mysql/README.md)
+### MySQL
 
-The [MySQL (`mysql`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mysql/README.md) gathers the statistics data from MySQL servers.
+Plugin ID: `inputs.mysql`
 
-### [NATS Consumer (`nats_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats_consumer/README.md)
+The [MySQL input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/mysql/README.md) gathers the statistics data from MySQL servers.
 
-The [NATS Consumer (`nats_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats_consumer/README.md) reads from specified NATS subjects and adds messages to InfluxDB. Messages are expected in the [Telegraf input data formats](/telegraf/v1.8/data_formats/input/). A Queue Group is used when subscribing to subjects so multiple instances of Telegraf can read from a NATS cluster in parallel.
+### NATS Consumer
 
-### [NATS Server Monitoring (`nats`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats/README.md)
+Plugin ID: `inputs.nats_consumer`
 
-The [NATS Server Monitoring (`nats`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats/README.md) gathers metrics when using the [NATS Server monitoring server](https://www.nats.io/documentation/server/gnatsd-monitoring/).
+The [NATS Consumer input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats_consumer/README.md) reads from specified NATS subjects and adds messages to InfluxDB. Messages are expected in the [Telegraf input data formats](/telegraf/v1.8/data_formats/input/). A Queue Group is used when subscribing to subjects so multiple instances of Telegraf can read from a NATS cluster in parallel.
 
-### [Net (`net`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NET_README.md)
+### NATS Server Monitoring
 
-The [Net (`net`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NET_README.md) gathers metrics about network interface usage (Linux only).
+Plugin ID: `inputs.nats`
 
-### [Netstat (`netstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NETSTAT_README.md)
+The [NATS Server Monitoring input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nats/README.md) gathers metrics when using the [NATS Server monitoring server](https://www.nats.io/documentation/server/gnatsd-monitoring/).
 
-The [Netstat (`netstat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NETSTAT_README.md) gathers TCP metrics such as established, time-wait and sockets counts by using `lsof`.
+### Net
 
-### [Network Response (`net_response`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net_response/README.md)
+Plugin ID: `inputs.net`
 
-The [Network Response (`net_response`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net_response/README.md) tests UDP and TCP connection response time. It can also check response text.
+The [Net input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NET_README.md) gathers metrics about network interface usage (Linux only).
 
-### [NGINX (`nginx`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx/README.md)
+### Netstat
 
-The [NGINX (nginx) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx/README.md) reads NGINX basic status information (`ngx_http_stub_status_module`).
+Plugin ID: `inputs.netstat`
 
-### [NGINX Plus (`nginx_plus`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx_plus/README.md)
+The [Netstat input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net/NETSTAT_README.md) gathers TCP metrics such as established, time-wait and sockets counts by using `lsof`.
 
-The [NGINX Plus (`nginx_plus`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx_plus/README.md) is for NGINX Plus, the commercial version of the open source web server NGINX. To use this plugin you will need a license.
+### Network Response
+
+Plugin ID: `inputs.net_response`
+
+The [Network Response input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/net_response/README.md) tests UDP and TCP connection response time. It can also check response text.
+
+### NGINX
+
+Plugin ID: `inputs.nginx`
+
+The [NGINX input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx/README.md) reads NGINX basic status information (`ngx_http_stub_status_module`).
+
+### NGINX Plus
+
+Plugin ID: `inputs.nginx_plus`
+
+The [NGINX Plus input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nginx_plus/README.md) is for NGINX Plus, the commercial version of the open source web server NGINX. To use this plugin you will need a license.
 For more information, see [What’s the Difference between Open Source NGINX and NGINX Plus?](https://www.nginx.com/blog/whats-difference-nginx-foss-nginx-plus/).
 
 Structures for NGINX Plus have been built based on history of [status module documentation](http://nginx.org/en/docs/http/ngx_http_status_module.html).
 
-### [NSQ (`nsq`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nsq)
+### NSQ
 
-### [NSQ Consumer (`nsq_consumer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nsq_consumer/README.md)
+Plugin ID: `inputs.nsq`
 
-The [NSQ Consumer (`nsq_consumer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nsq_consumer/README.md) polls a specified NSQD topic and adds messages to InfluxDB. This plugin allows a message to be in any of the supported data_format types.
+The [NSQ input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/nsq) ...
 
-### [Nstat (`nstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nstat/README.md)
+### NSQ Consumer
 
-The [Nstat (`nstat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nstat/README.md) collects network metrics from `/proc/net/netstat`, `/proc/net/snmp`, and `/proc/net/snmp6` files.
+Plugin ID: `inputs.nsq_consumer`
 
-### [NTPq (`ntpq`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ntpq/README.md)
+The [NSQ Consumer input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nsq_consumer/README.md) polls a specified NSQD topic and adds messages to InfluxDB. This plugin allows a message to be in any of the supported data_format types.
 
-The [NTPq (`ntpq`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ntpq/README.md) gets standard NTP query metrics, requires ntpq executable.
+### Nstat
 
-### [NVIDIA SMI (`nvidia-smi`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nvidia_smi/README.md)
+Plugin ID: `inputs.nstat`
 
-The [NVIDIA SMI (`nvidia-smi`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nvidia_smi/README.md) uses a query on the [NVIDIA System Management Interface (`nvidia-smi`)](https://developer.nvidia.com/nvidia-system-management-interface) binary to pull GPU stats including memory and GPU usage, temp and other.
+The [Nstat input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nstat/README.md) collects network metrics from `/proc/net/netstat`, `/proc/net/snmp`, and `/proc/net/snmp6` files.
 
-### [OpenLDAP (`openldap`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/openldap/README.md)
+### NTPq
 
-The [OpenLDAP (`openldap`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/openldap/README.md) gathers metrics from OpenLDAP's `cn=Monitor` backend.
+Plugin ID: `inputs.ntpq`
 
-### [OpenSMTPD (`opensmtpd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/opensmtpd/README.md)
+The [NTPq input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ntpq/README.md) gets standard NTP query metrics, requires ntpq executable.
 
-The [OpenSMTPD (`opensmtpd`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/opensmtpd/README.md) gathers stats from [OpenSMTPD](https://www.opensmtpd.org/), a free implementation of the server-side SMTP protocol.
+### NVIDIA SMI
 
-### [PF (`pf`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pf/README.md)
+Plugin ID: `inputs.nvidia-smi`
 
-The [PF (`pf`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pf/README.md) gathers information from the FreeBSD/OpenBSD pf firewall. Currently it can retrive information about
+The [NVIDIA SMI input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/nvidia_smi/README.md) uses a query on the [NVIDIA System Management Interface (`nvidia-smi`)](https://developer.nvidia.com/nvidia-system-management-interface) binary to pull GPU stats including memory and GPU usage, temp and other.
+
+### OpenLDAP
+
+Plugin ID: `inputs.openldap`
+
+The [OpenLDAP input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/openldap/README.md) gathers metrics from OpenLDAP's `cn=Monitor` backend.
+
+### OpenSMTPD
+
+Plugin ID: `inputs.opensmtpd`
+
+The [OpenSMTPD input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/opensmtpd/README.md) gathers stats from [OpenSMTPD](https://www.opensmtpd.org/), a free implementation of the server-side SMTP protocol.
+
+### PF
+
+Plugin ID: `inputs.pf`
+
+The [PF input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pf/README.md) gathers information from the FreeBSD/OpenBSD pf firewall. Currently it can retrive information about
 the state table: the number of current entries in the table, and counters for the number of searches, inserts, and
 removals to the table. The pf plugin retrieves this information by invoking the `pfstat` command.
 
-### [PgBouncer (`pgbouncer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pgbouncer/README.md) -- NEW in v.1.8
+### PgBouncer
 
-The [PgBouncer (`pgbouncer`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pgbouncer/README.md) provides metrics for your PgBouncer load balancer. For information about the metrics, see the [PgBouncer documentation](https://pgbouncer.github.io/usage.html).
+Plugin ID: `inputs.pgbouncer`
 
-### [Phfusion Passenger (`passenger`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/passenger/README.md)
+The [PgBouncer input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/pgbouncer/README.md) provides metrics for your PgBouncer load balancer. For information about the metrics, see the [PgBouncer documentation](https://pgbouncer.github.io/usage.html).
 
-The [Phfusion 0Passenger (`passenger`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/passenger/README.md) gets Phusion Passenger statistics using their command line utility `passenger-status`.
+### Phfusion Passenger
 
-### [PHP FPM (`phpfpm`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/phpfpm/README.md)
+Plugin ID: `inputs.passenger`
 
-The [PHP FPM (`phpfpm`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/phpfpm/README.md) gets phpfpm statistics using either HTTP status page or fpm socket.
+The [Phfusion 0Passenger input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/passenger/README.md) gets Phusion Passenger statistics using their command line utility `passenger-status`.
 
-### [Ping (`ping`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ping/README.md)
+### PHP FPM
 
-The [Ping (`ping`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ping/README.md) measures the round-trip for ping commands, response time, and other packet statistics.
+Plugin ID: `inputs.phpfpm`
 
-### [Postfix (`postfix`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postfix/README.md)
+The [PHP FPM input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/phpfpm/README.md) gets phpfpm statistics using either HTTP status page or fpm socket.
 
-The [Postfix (`postfix`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postfix/README.md) reports metrics on the postfix queues. For each of the active, hold, incoming, maildrop, and
+### Ping
+
+Plugin ID: `inputs.ping`
+
+The [Ping input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/ping/README.md) measures the round-trip for ping commands, response time, and other packet statistics.
+
+### Postfix
+
+Plugin ID: `inputs.postfix`
+
+The [Postfix input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postfix/README.md) reports metrics on the postfix queues. For each of the active, hold, incoming, maildrop, and
 deferred [queues](http://www.postfix.org/QSHAPE_README.html#queues), it will report the queue length (number of items),
 size (bytes used by items), and age (age of oldest item in seconds).
 
-### [PostgreSQL (`postgresql`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postgresql/README.md)
+### PostgreSQL
 
-The [PostgreSQL (`postgresql`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postgresql/README.md) provides metrics for your PostgreSQL database. It currently works with PostgreSQL versions 8.1+.
+Plugin ID: `inputs.postgresql`
+
+The [PostgreSQL input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postgresql/README.md) provides metrics for your PostgreSQL database. It currently works with PostgreSQL versions 8.1+.
 It uses data from the built in `pg_stat_database` and `pg_stat_bgwriter` views. The metrics recorded depend on your
 version of postgres.
 
-### [PostgreSQL Extensible (`postgresql_extensible`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/postgresql_extensible/README.md)
+### PostgreSQL Extensible
 
-This [PostgreSQL Extensible (`postgresql_extensible`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/postgresql_extensible) provides metrics for your Postgres database. It has been designed to parse SQL queries in the plugin section of `telegraf.conf` files.
+Plugin ID: `inputs.postgresql_extensible`
 
-### [PowerDNS (`powerdns`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/powerdns/README.md)
+This [PostgreSQL Extensible input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/postgresql_extensible) provides metrics for your Postgres database. It has been designed to parse SQL queries in the plugin section of `telegraf.conf` files.
 
-The [PowerDNS (`powerdns`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/powerdns/README.md) gathers metrics about PowerDNS using UNIX sockets.
+### PowerDNS
 
-### [Processes (`processes`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/processes/README.md)
+Plugin ID: `inputs.powerdns`
 
-The [Processes (`processes`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/processes/README.md)
+The [PowerDNS input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/powerdns/README.md) gathers metrics about PowerDNS using UNIX sockets.
+
+### Processes
+
+Plugin ID: `inputs.processes`
+
+The [Processes input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/processes/README.md)
 gathers info about the total number of processes and groups them by status (zombie, sleeping, running, etc.). On Linux, this plugin requires access to `procfs` (`/proc`); on other operating systems, it requires access to execute `ps`.
 
-### [Procstat (`procstat`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/procstat/README.md)
+### Procstat
 
-The [Procstat (`procstat`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/procstat/README.md) can be used to monitor system resource usage by an individual process using their `/proc` data.
+Plugin ID: `inputs.procstat`
+
+The [Procstat input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/procstat/README.md) can be used to monitor system resource usage by an individual process using their `/proc` data.
 
 Processes can be specified either by `pid` file, by executable name, by command line pattern matching, by username,
 by systemd unit name, or by cgroup name/path (in this order or priority). This plugin uses `pgrep` when an executable
@@ -470,136 +661,191 @@ measurements for every process specified. A prefix can be set to isolate individ
 The Procstat input plugin will tag processes according to how they are specified in the configuration. If a pid file is used, a
 "pidfile" tag will be generated. On the other hand, if an executable is used an "exe" tag will be generated.
 
-### [Prometheus Format  (`prometheus`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/prometheus/README.md)
+### Prometheus Format
 
-The [Prometheus Format (`prometheus`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/prometheus/README.md) input plugin gathers metrics from HTTP servers exposing metrics in Prometheus format.
+Plugin ID: `inputs.prometheus`
 
-### [Puppet Agent (`puppetagent`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/puppetagent)
+The [Prometheus Format input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/prometheus/README.md) input plugin gathers metrics from HTTP servers exposing metrics in Prometheus format.
 
-The [Puppet Agent (`puppetagent`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/puppetagent) collects variables outputted from the `last_run_summary.yaml` file usually
+### Puppet Agent
+
+Plugin ID: `inputs.puppetagent`
+
+The [Puppet Agent input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/puppetagent) collects variables outputted from the `last_run_summary.yaml` file usually
 located in `/var/lib/puppet/state/` Puppet Agent Runs. For more information, see [Puppet Monitoring: How  to Monitor the Success or Failure of Puppet Runs](https://puppet.com/blog/puppet-monitoring-how-to-monitor-success-or-failure-of-puppet-runs)
 
-### [RabbitMQ (`rabbitmq`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/rabbitmq/README.md)
+### RabbitMQ
 
-The [RabbitMQ (`rabbitmq`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/rabbitmq/README.md) reads metrics from RabbitMQ servers via the [Management Plugin](https://www.rabbitmq.com/management.html).
+Plugin ID: `inputs.rabbitmq`
 
-### [Raindrops Middleware (`raindrops`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/raindrops/README.md)
+The [RabbitMQ input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/rabbitmq/README.md) reads metrics from RabbitMQ servers via the [Management Plugin](https://www.rabbitmq.com/management.html).
 
-The [Raindrops Middleware (`raindrops`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/raindrops/README.md) reads from the specified [Raindrops middleware](http://raindrops.bogomips.org/Raindrops/Middleware.html)
+### Raindrops Middleware
+
+Plugin ID: `inputs.raindrops`
+
+The [Raindrops Middleware input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/raindrops/README.md) reads from the specified [Raindrops middleware](http://raindrops.bogomips.org/Raindrops/Middleware.html)
 URI and adds the statistics to InfluxDB.
 
-### [Redis (`redis`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/redis/README.md)
+### Redis
 
-The [Redis (`redis`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/redis/README.md) gathers the results of the INFO Redis command. There are two separate measurements: `redis`
+Plugin ID: `inputs.redis`
+
+The [Redis input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/redis/README.md) gathers the results of the INFO Redis command. There are two separate measurements: `redis`
 and `redis_keyspace`, the latter is used for gathering database-related statistics.
 
-Additionally the plugin also calculates the hit/miss ratio (`keyspace_hitrate`) and the elapsed time since the last RDB
-save (`rdb_last_save_time_elapsed`).
+Additionally the plugin also calculates the hit/miss ratio (`keyspace_hitrate`) and the elapsed time since the last RDB save (`rdb_last_save_time_elapsed`).
 
-### [RethinkDB (`rethinkdb`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/rethinkdb)
+### RethinkDB
 
-The [RethinkDB (`rethinkdb`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/rethinkdb) works with RethinkDB 2.3.5+ databases that requires username, password authorization,
+Plugin ID: `inputs.rethinkdb`
+
+The [RethinkDB input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/rethinkdb) works with RethinkDB 2.3.5+ databases that requires username, password authorization,
 and Handshake protocol v1.0.
 
-### [Riak (`riak`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/riak/README.md)
+### Riak
 
-The [Riak (`riak`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/riak/README.md) gathers metrics from one or more Riak instances.
+Plugin ID: `inputs.riak`
 
-### [Salesforce (`salesforce`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/salesforce/README.md)
+The [Riak input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/riak/README.md) gathers metrics from one or more Riak instances.
 
-The [Salesforce (`salesforce`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/salesforce/README.md) gathers metrics about the limits in your Salesforce organization and the remaining usage.
+### Salesforce
+
+Plugin ID: `inputs.salesforce`
+
+The [Salesforce input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/salesforce/README.md) gathers metrics about the limits in your Salesforce organization and the remaining usage.
 It fetches its data from the limits endpoint of the Salesforce REST API.
 
-### [Sensors (`sensors`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sensors/README.md)
+### Sensors
 
-The [Sensors (`sensors`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sensors/README.md) collects collects sensor metrics with the sensors executable from the `lm-sensor` package.
+Plugin ID: `inputs.sensors`
 
-### [SMART (`smart`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/smart/README.md)
+The [Sensors input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/sensors/README.md) collects collects sensor metrics with the sensors executable from the `lm-sensor` package.
 
-The [SMART (`smart`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/smart/README.md) gets metrics using the command line utility `smartctl` for SMART (Self-Monitoring, Analysis
+### SMART
+
+Plugin ID: `inputs.smart`
+
+The [SMART input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/smart/README.md) gets metrics using the command line utility `smartctl` for SMART (Self-Monitoring, Analysis
 and Reporting Technology) storage devices. SMART is a monitoring system included in computer hard disk drives (HDDs)
 and solid-state drives (SSDs), which include most modern ATA/SATA, SCSI/SAS and NVMe disks. The plugin detects and
 reports on various indicators of drive reliability, with the intent of enabling the anticipation of hardware failures.
 See [smartmontools](https://www.smartmontools.org/).
 
-### [SNMP (`snmp`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp/README.md)
+### SNMP
 
-The [SNMP (`snmp`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp/README.md) gathers metrics from SNMP agents.
+Plugin ID: `inputs.snmp`
 
-### [Socket Listener (`socket_listener`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/socket_listener/README.md)
+The [SNMP input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp/README.md) gathers metrics from SNMP agents.
 
-The [Socket Listener (`socket_listener`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/socket_listener/README.md) listens for messages from streaming (tcp, unix) or datagram
+### Socket Listener
+
+Plugin ID: `inputs.socket_listener`
+
+The [Socket Listener input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/socket_listener/README.md) listens for messages from streaming (tcp, unix) or datagram
 (UDP, unixgram) protocols. Messages are expected in the
 [Telegraf Input Data Formats](/telegraf/v1.8/data_formats/input/).
 
-### [StatsD (`statsd`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/statsd/README.md)
+### StatsD
 
-The [StatsD (`statsd`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/statsd/README.md) is a special type of plugin which runs a backgrounded `statsd` listener service while Telegraf is running.
+Plugin ID: `inputs.statsd`
+
+The [StatsD input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/statsd/README.md) is a special type of plugin which runs a backgrounded `statsd` listener service while Telegraf is running.
 StatsD messages are formatted as described in the original [etsy statsd](https://github.com/etsy/statsd/blob/master/docs/metric_types.md) implementation.
 
-### [Swap (`swap`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/swap/README.md)
+### Swap
 
-The [Swap (`swap`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/swap/README.md) gathers metrics about swap memory usage. For more information about Linux swap spaces, see [All about Linux swap space](https://www.linux.com/news/all-about-linux-swap-space)
+Plugin ID: `inputs.swap`
 
-### [Syslog (`syslog`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/syslog/README.md)
+The [Swap input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/swap/README.md) gathers metrics about swap memory usage. For more information about Linux swap spaces, see [All about Linux swap space](https://www.linux.com/news/all-about-linux-swap-space)
 
-The [Syslog (`syslog`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/syslog/README.md) listens for syslog messages transmitted over
+### Syslog
+
+Plugin ID: `inputs.syslog`
+
+The [Syslog input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/syslog/README.md) listens for syslog messages transmitted over
 [UDP](https://tools.ietf.org/html/rfc5426) or [TCP](https://tools.ietf.org/html/rfc5425). Syslog messages should be formatted according to [RFC 5424](https://tools.ietf.org/html/rfc5424).
 
-### [Sysstat (`sysstat`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/sysstat)
+### Sysstat
 
-The [Sysstat (`sysstat`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/sysstat) collects [sysstat](https://github.com/sysstat/sysstat) system metrics with the sysstat
+Plugin ID: `inputs.sysstat`
+
+The [Sysstat input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/sysstat) collects [sysstat](https://github.com/sysstat/sysstat) system metrics with the sysstat
 collector utility `sadc` and parses the created binary data file with the `sadf` utility.
 
-### [System (`system`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/README.md)
+### System
 
-The [System (`system`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/README.md) gathers general stats on system load, uptime, and number of users logged in. It is basically equivalent to the UNIX `uptime` command.
+Plugin ID: `inputs.system`
 
-### [Tail (`tail`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tail/README.md)
+The [System input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/system/README.md) gathers general stats on system load, uptime, and number of users logged in. It is basically equivalent to the UNIX `uptime` command.
 
-The [Tail (`tail`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tail/README.md) "tails" a log file and parses each log message.
+### Tail
 
-### [Teamspeak 3 (`teamspeak`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/teamspeak/README.md)
+Plugin ID: `inputs.tail`
 
-The [Teamspeak 3 (`teamspeak`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/teamspeak/README.md) uses the Teamspeak 3 ServerQuery interface of the Teamspeak server to collect statistics of one or more virtual servers.
+The [Tail input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tail/README.md) "tails" a log file and parses each log message.
 
-### [Telegraf v1.x (`internal`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/internal)
+### Teamspeak 3
 
-The [Telegraf v1.x (`internal`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/internal) collects metrics about the Telegraf v1.x agent itself.
+Plugin ID: `inputs.teamspeak`
+
+The [Teamspeak 3 input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/teamspeak/README.md) uses the Teamspeak 3 ServerQuery interface of the Teamspeak server to collect statistics of one or more virtual servers.
+
+### Telegraf v1.x
+
+Plugin ID: `inputs.internal`
+
+The [Telegraf v1.x input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/internal) collects metrics about the Telegraf v1.x agent itself.
 Note that some metrics are aggregates across all instances of one type of plugin.
 
-### [Temp (`temp`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/temp/README.md) -- NEW in v.1.8
+### Temp
 
-The [Temp (`temp`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/temp/README.md) collects temperature data from sensors.
+Plugin ID: `temp`
 
-### [Tengine Web Server (`tengine`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tengine/README.md) -- NEW in v.1.8
+The [Temp input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/temp/README.md) collects temperature data from sensors.
 
-The [Tengine Web Server (`tengine`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tengine/README.md) gathers status metrics from the [Tengine Web Server](http://tengine.taobao.org/) using the [Reqstat module](http://tengine.taobao.org/document/http_reqstat.html).
+### Tengine Web Server
 
-### [Trig (`trig`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/trig)
+Plugin ID: `inputs.tengine`
 
-The [Trig (`trig`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/trig) inserts sine and cosine waves for demonstration purposes.
+The [Tengine Web Server input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tengine/README.md) gathers status metrics from the [Tengine Web Server](http://tengine.taobao.org/) using the [Reqstat module](http://tengine.taobao.org/document/http_reqstat.html).
 
-### [Twemproxy (`twemproxy`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/twemproxy)
+### Trig
 
-The [Twemproxy (`twemproxy`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/twemproxy) gathers data from Twemproxy instances, processes Twemproxy server statistics, processes pool data. and processes backend server (Redis/Memcached) statistics.
+Plugin ID: `inputs.trig`
 
-### [Unbound (`unbound`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/unbound/README.md)
+The [Trig input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/trig) inserts sine and cosine waves for demonstration purposes.
 
-The [Unbound (`unbound`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/unbound/README.md) gathers stats from [Unbound](https://www.unbound.net/), a validating, recursive, and
+### Twemproxy
+
+Plugin ID: `inputs.twemproxy`
+
+The [Twemproxy input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/twemproxy) gathers data from Twemproxy instances, processes Twemproxy server statistics, processes pool data. and processes backend server (Redis/Memcached) statistics.
+
+### Unbound
+
+Plugin ID: `inputs.unbound`
+
+The [Unbound input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/unbound/README.md) gathers stats from [Unbound](https://www.unbound.net/), a validating, recursive, and
 caching DNS resolver.
 
-### [Varnish (`varnish`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/varnish/README.md)
+### Varnish
 
-The [Varnish (`varnish`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/varnish/README.md) gathers stats from [Varnish HTTP Cache](https://varnish-cache.org/).
+Plugin ID: `inputs.varnish`
 
-### [VMware vSphere (`vsphere`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere/README.md) -- NEW in v.1.8
+The [Varnish input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/varnish/README.md) gathers stats from [Varnish HTTP Cache](https://varnish-cache.org/).
 
-The [VMware vSphere (`vsphere`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere/README.md) uses the vSphere API to gather metrics from multiple vCenter servers (clusters, hosts, VMs, and data stores). For more information on the available performance metrics, see [Common vSphere Performance Metrics](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere/METRICS.md).
+### VMware vSphere
 
-### [Webhooks (`webhooks`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/README.md)
+Plugin ID: `inputs.vsphere`
 
-The [Webhooks (`webhooks`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/README.md) starts an HTTPS server and registers multiple webhook listeners.
+The [VMware vSphere input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere/README.md) uses the vSphere API to gather metrics from multiple vCenter servers (clusters, hosts, VMs, and data stores). For more information on the available performance metrics, see [Common vSphere Performance Metrics](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/vsphere/METRICS.md).
+
+### Webhooks
+
+Plugin ID: `inputs.webhooks`
+
+The [Webhooks input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/webhooks/README.md) starts an HTTPS server and registers multiple webhook listeners.
 
 #### Available webhooks
 
@@ -614,64 +860,90 @@ The [Webhooks (`webhooks`) input plugin](https://github.com/influxdata/telegraf/
 If you need a webhook that is not supported, consider [adding a new webhook](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/webhooks#adding-new-webhooks-plugin).
 
 
-### [Windows Performance Counters (`win_perf_counters`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/win_perf_counters)
+### Windows Performance Counters
 
-The way the [Windows Performance Counters (`win_perf_counters`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/win_perf_counters) works is that on load of Telegraf, the plugin will be handed configuration
-from Telegraf. This configuration is parsed and then tested for validity such as if the Object, Instance and Counter
-existing. If it does not match at startup, it will not be fetched. Exceptions to this are in cases where you query for
-all instances "". By default the plugin does not return `_Total` when it is querying for all () as this is redundant.
+Plugin ID: `inputs.win_perf_counters`
 
-### [Windows Services (`win_services`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/win_services/README.md)
+The way the [Windows Performance Counters input plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/win_perf_counters) works is that on load of Telegraf, the plugin will be handed configuration
+from Telegraf.
+This configuration is parsed and then tested for validity such as if the Object, Instance and Counter existing.
+If it does not match at startup, it will not be fetched.
+Exceptions to this are in cases where you query for all instances `""`.
+By default the plugin does not return `_Total` when it is querying for all () as this is redundant.
 
-The [Windows Services (`win_services`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/win_services/README.md) reports Windows services info.
+### Windows Services
 
-### [X.509 Certificate (`x509_cert`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/x509_cert/README.md) -- NEW in v.1.8
+Plugin ID: `inputs.win_services`
 
-The [X.509 Certificate (`x509_cert`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/x509_cert/README.md) provides information about X.509 certificate accessible using the local file or network connection.
+The [Windows Services input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/win_services/README.md) reports Windows services info.
 
-### [ZFS (`zfs`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zfs/README.md)
+### X.509 Certificate
 
-The [ZFS (`zfs`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zfs/README.md) provides metrics from your ZFS filesystems. It supports ZFS on Linux and FreeBSD.
+Plugin ID: `inputs.x509_cert`
+
+The [X.509 Certificate input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/x509_cert/README.md) provides information about X.509 certificate accessible using the local file or network connection.
+
+### ZFS
+
+Plugin ID: `inputs.zfs`
+
+The [ZFS input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zfs/README.md) provides metrics from your ZFS filesystems. It supports ZFS on Linux and FreeBSD.
 It gets ZFS statistics from `/proc/spl/kstat/zfs` on Linux and from `sysctl` and `zpool` on FreeBSD.
 
-### [Zipkin (`zipkin`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zipkin/README.md)
+### Zipkin
 
-The [Zipkin (`zipkin`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zipkin/README.md) implements the Zipkin HTTP server to gather trace and timing data needed to troubleshoot latency problems in microservice architectures.
+Plugin ID: `inputs.zipkin`
+
+The [Zipkin input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zipkin/README.md) implements the Zipkin HTTP server to gather trace and timing data needed to troubleshoot latency problems in microservice architectures.
 
 > ***Note:*** This plugin is experimental. Its data schema may be subject to change based on its main usage cases and the evolution of the OpenTracing standard.
 
-### [Zookeeper (`zookeeper`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zookeeper/README.md)
+### Zookeeper
+
+Plugin ID: `inputs.zookeeper`
 
 The [Zookeeper (`zookeeper`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/zookeeper/README.md) collects variables outputted from the `mntr` command [Zookeeper Admin](https://zookeeper.apache.org/doc/trunk/zookeeperAdmin.html).
 
 ## Deprecated Telegraf input plugins
 
-### [Cassandra (`cassandra`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/cassandra)
+### Cassandra
 
-> DEPRECATED as of version 1.7. The [Cassandra (`cassandra`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/cassandra) collects Cassandra 3 / JVM metrics exposed as MBean attributes through the jolokia REST endpoint.
+Plugin ID: `inputs.cassandra`
+
+> DEPRECATED as of version 1.7. The [Cassandra input plugin](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/cassandra) collects Cassandra 3 / JVM metrics exposed as MBean attributes through the jolokia REST endpoint.
 All metrics are collected for each server configured.
 
-### [HTTP JSON (`httpjson`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/httpjson/README.md)
+### HTTP JSON
 
-> DEPRECATED as of version 1.6; use the [HTTP (`http`) input plugin](#http-http-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-http-readme-md).
+Plugin ID: `inputs.httpjson`
 
-The [HTTP JSON (`httpjson`) input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/httpjson/README.md) collects data from HTTP URLs which respond with JSON.
+> DEPRECATED as of version 1.6; use the [HTTP input plugin](#http-http-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-http-readme-md).
+
+The [HTTP JSON input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/httpjson/README.md) collects data from HTTP URLs which respond with JSON.
 It flattens the JSON and finds all numeric values, treating them as floats.
 
-### [Jolokia (`jolokia`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/jolokia/README.md)
+### Jolokia
 
-> DEPRECATED as of version 1.5; use the [Jolokia2 (`jolokia2`) input plugin](#jolokia2-agent-jolokia2-agent-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-jolokia2-readme-md).
+Plugin ID: `inputs.jolokia`
 
-### [SNMP Legacy (`snmp_legacy`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp_legacy/README.md)
+> DEPRECATED as of version 1.5; use the [Jolokia2 input plugin](#jolokia2-agent-jolokia2-agent-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-jolokia2-readme-md).
 
-> The [SNMP Legacy (`snmp_legacy` input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp_legacy/README.md) is DEPRECATED. Use the [SNMP (`snmp`) input plugin](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/snmp).
+### SNMP Legacy
+
+Plugin ID: `inputs.snmp_legacy`
+
+> The [SNMP Legacy input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp_legacy/README.md) is DEPRECATED. Use the [SNMP input plugin](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/snmp).
 
 The SNMP Legacy input plugin gathers metrics from SNMP agents.
 
-### [TCP Listener (`tcp_listener`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md)
+### TCP Listener
 
-> The [TCP Listener (`tcp_listener` input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md) is EPRECATED as of version 1.3; use the [Socket Listener (`socket_listener`) input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-socket-listener-readme-md).
+Plugin ID: `inputs.tcp_listener`
 
-### [UDP Listener (`udp_listener`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/inputs/udp_listener)
+> The [TCP Listener input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md) is EPRECATED as of version 1.3; use the [Socket Listener input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-socket-listener-readme-md).
 
-> DEPRECATED as of version 1.3; use the [Socket Listener (`socket_listener`) input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-socket-listener-readme-md).
+### UDP Listener
+
+Plugin ID: `inputs.udp_listener`
+
+> DEPRECATED as of version 1.3; use the [Socket Listener input plugin](#socket-listener-socket-listener-https-github-com-influxdata-telegraf-blob-release-1-8-plugins-inputs-socket-listener-readme-md).

--- a/content/telegraf/v1.8/plugins/outputs.md
+++ b/content/telegraf/v1.8/plugins/outputs.md
@@ -7,140 +7,192 @@ menu:
     weight: 20
     parent: Plugins
 ---
-
 Telegraf allows users to specify multiple output sinks in the configuration file.
-
-> ***Note:*** Telegraf plugins added in the current release are noted with ` -- NEW in v1.8`.
->The [Release notes and changelog](/telegraf/v1.8/about_the_project/release-notes-changelog) has a list of new plugins and updates for other plugins. See the plugin README files for more details.
 
 ## Supported Telegraf output plugins
 
-### [Amazon CloudWatch (`cloudwatch`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cloudwatch/README.md)
+### Amazon CloudWatch
 
-The [Amazon CloudWatch (`cloudwatch`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cloudwatch/README.md) send metrics to Amazon CloudWatch.
+Plugin ID: `outputs.cloudwatch`
 
-### [Amazon Kinesis (`kinesis`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kinesis/README.md)
+The [Amazon CloudWatch output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cloudwatch/README.md) send metrics to Amazon CloudWatch.
 
-The [Amazon Kinesis (`kinesis`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kinesis/README.md) is an experimental plugin that is still in the early stages of development. It will batch up all of the Points in one Put request to Kinesis. This should save the number of API requests by a considerable level.
+### Amazon Kinesis
 
-### [Amon (`amon`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amon/README.md)
+Plugin ID: `outputs.kinesis`
 
-The [Amon (`amon`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amon/README.md) writes metrics to an  [Amon server](https://github.com/amonapp/amon). For details on the Amon Agent, see [Monitoring Agent](https://docs.amon.cx/agent/) and requires a `apikey` and `amoninstance` URL.
+The [Amazon Kinesis output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kinesis/README.md) is an experimental plugin that is still in the early stages of development. It will batch up all of the Points in one Put request to Kinesis. This should save the number of API requests by a considerable level.
+
+### Amon
+
+Plugin ID: `outputs.amon`
+
+The [Amon output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amon/README.md) writes metrics to an  [Amon server](https://github.com/amonapp/amon). For details on the Amon Agent, see [Monitoring Agent](https://docs.amon.cx/agent/) and requires a `apikey` and `amoninstance` URL.
 
 If the point value being sent cannot be converted to a float64 value, the metric is skipped.
 
 Metrics are grouped by converting any `_` characters to `.` in the Point Name.
 
-### [AMQP (`amqp`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amqp/README.md)
+### AMQP  
 
-The [AMQP (`amqp`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amqp/README.md) writes to a AMQP 0-9-1 Exchange, a prominent implementation of this protocol being [RabbitMQ](https://www.rabbitmq.com/).
+Plugin ID: `outputs.amqp`
+
+The [AMQP output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/amqp/README.md) writes to a AMQP 0-9-1 Exchange, a prominent implementation of this protocol being [RabbitMQ](https://www.rabbitmq.com/).
 
 Metrics are written to a topic exchange using `tag`, defined in configuration file as `RoutingTag`, as a routing key.
 
-### [Apache Kafka (`kafka`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kafka/README.md)
+### Apache Kafka
 
-The [Apache Kafka (`kafka`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kafka/README.md) writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.html) acting a Kafka Producer.
+Plugin ID: `outputs.kafka`
 
-### [CrateDB (`cratedb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cratedb/README.md)
+The [Apache Kafka output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/kafka/README.md) writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.html) acting a Kafka Producer.
 
-The [CrateDB (`cratedb`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cratedb/README.md) writes to [CrateDB](https://crate.io/) using its [PostgreSQL protocol](https://crate.io/docs/crate/reference/protocols/postgres.html).
+### CrateDB
 
-### [Datadog (`datadog`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/datadog/README.md)
+Plugin ID: `cratedb`
 
-The [Datadog (`datadog`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/datadog/README.md) writes to the [Datadog Metrics API](http://docs.datadoghq.com/api/#metrics) and requires an `apikey` which can be obtained [here](https://app.datadoghq.com/account/settings#api) for the account.
+The [CrateDB output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/cratedb/README.md) writes to [CrateDB](https://crate.io/) using its [PostgreSQL protocol](https://crate.io/docs/crate/reference/protocols/postgres.html).
 
-### [Discard (`discard`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/discard/README.md)
+### Datadog
 
-The [Discard (`discard`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/discard/README.md) simply drops all metrics that are sent to it. It is only meant to be used for testing purposes.
+Plugin ID: `outputs.datadog`
 
-### [Elasticsearch (`elasticsearch`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/elasticsearch/README.md)
+The [Datadog output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/datadog/README.md) writes to the [Datadog Metrics API](http://docs.datadoghq.com/api/#metrics) and requires an `apikey` which can be obtained [here](https://app.datadoghq.com/account/settings#api) for the account.
 
-The [Elasticsearch (`elasticsearch`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/elasticsearch/README.md) writes to Elasticsearch via HTTP using [Elastic](http://olivere.github.io/elastic/). Currently it only supports Elasticsearch 5.x series.
+### Discard
 
-### [File (`file`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/file/README.md)
+Plugin ID: `outputs.discard`
 
-The [File (`file`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/file/README.md) writes Telegraf metrics to files.
+The [Discard output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/discard/README.md) simply drops all metrics that are sent to it. It is only meant to be used for testing purposes.
 
-### [Graphite (`graphite`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graphite/README.md)
+### Elasticsearch
 
-The [Graphite (`graphite`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graphite/README.md) writes to [Graphite](http://graphite.readthedocs.org/en/latest/index.html) via raw TCP.
+Plugin ID: `outputs.elasticsearch`
 
-### [Graylog (`graylog`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graylog/README.md)
+The [Elasticsearch output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/elasticsearch/README.md) writes to Elasticsearch via HTTP using [Elastic](http://olivere.github.io/elastic/). Currently it only supports Elasticsearch 5.x series.
 
-The  [Graylog (`graylog`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graylog/README.md) writes to a Graylog instance using the `gelf` format.
+### File
 
-### [HTTP (`http`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/http/README.md)
+Plugin ID: `outputs.file`
 
-The [HTTP (`http`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/http/README.md) sends metrics in a HTTP message encoded using one of the output data formats. For `data_formats` that support batching, metrics are sent in batch format.
+The [File output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/file/README.md) writes Telegraf metrics to files.
 
-### [InfluxDB v1.x (`influxdb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb/README.md)
+### Graphite
 
-The [InfluxDB v1.x (`influxdb`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb/README.md) writes to InfluxDB using HTTP or UDP.
+Plugin ID: `outputs.graphite`
 
-### [InfluxDB v2 (`influxdb_v2`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb_v2/README.md)-- NEW in v.1.8
+The [Graphite output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graphite/README.md) writes to [Graphite](http://graphite.readthedocs.org/en/latest/index.html) via raw TCP.
 
-The [InfluxDB v2 (`influxdb_v2`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb_v2/README.md) writes metrics to the [InfluxDB 2.0](https://github.com/influxdata/platform) HTTP service.
+### Graylog
 
-### [Instrumental (`instrumental`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/instrumental/README.md)
+Plugin ID: `outputs.graylog`
 
-The [Instrumental (`instrumental`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/instrumental/README.md) writes to the [Instrumental Collector API](https://instrumentalapp.com/docs/tcp-collector) and requires a Project-specific API token.
+The  [Graylog output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/graylog/README.md) writes to a Graylog instance using the `gelf` format.
+
+### HTTP
+
+Plugin ID: `outputs.http`
+
+The [HTTP output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/http/README.md) sends metrics in a HTTP message encoded using one of the output data formats. For `data_formats` that support batching, metrics are sent in batch format.
+
+### InfluxDB v1.x
+
+Plugin ID: `outputs.influxdb`
+
+The [InfluxDB v1.x output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb/README.md) writes to InfluxDB using HTTP or UDP.
+
+### InfluxDB v2
+
+Plugin ID: `outputs.influxdb_v2`
+
+The [InfluxDB v2 output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/influxdb_v2/README.md) writes metrics to the [InfluxDB 2.0](https://github.com/influxdata/platform) HTTP service.
+
+### Instrumental
+
+Plugin ID: `outputs.instrumental`
+
+The [Instrumental output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/instrumental/README.md) writes to the [Instrumental Collector API](https://instrumentalapp.com/docs/tcp-collector) and requires a Project-specific API token.
 
 Instrumental accepts stats in a format very close to Graphite, with the only difference being that the type of stat (gauge, increment) is the first token, separated from the metric itself by whitespace. The increment type is only used if the metric comes in as a counter through [[input.statsd]].
 
-### [Librato (`librato`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/librato/README.md)
+### Librato
 
-The [Librato (`librato`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/librato/README.md) writes to the [Librato Metrics API](http://dev.librato.com/v1/metrics#metrics) and requires an `api_user` and `api_token` which can be obtained [here](https://metrics.librato.com/account/api_tokens) for the account.
+Plugin ID: `outputs.librato`
 
-### [Microsoft Azure Application Insights (`application_insights`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/application_insights/README.md)
+The [Librato output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/librato/README.md) writes to the [Librato Metrics API](http://dev.librato.com/v1/metrics#metrics) and requires an `api_user` and `api_token` which can be obtained [here](https://metrics.librato.com/account/api_tokens) for the account.
 
-The [Microsoft Azure Application Insights (`application_insights`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/application_insights/README.md) writes Telegraf metrics to [Application Insights (Microsoft Azure)](https://azure.microsoft.com/en-us/services/application-insights/).
+### Microsoft Azure Application Insights
 
-### [Microsoft Azure Monitor (`azure_monitor`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/azure_monitor/README.md) -- NEW in v.1.8
+Plugin ID: `outputs.application_insights`
+
+The [Microsoft Azure Application Insights output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/application_insights/README.md) writes Telegraf metrics to [Application Insights (Microsoft Azure)](https://azure.microsoft.com/en-us/services/application-insights/).
+
+### Microsoft Azure Monitor
+
+Plugin ID: `outputs.azure_monitor`
 
 >**Note:** The Azure Monitor custom metrics service is currently in preview and not available in a subset of Azure regions.
 
-The [Microsoft Azure Monitor (`azure_monitor`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/azure_monitor/README.md) sends custom metrics to [Microsoft Azure Monitor](https://azure.microsoft.com/en-us/services/monitor/). Azure Monitor has a metric resolution of one minute. To handle this in Telegraf, the Azure Monitor output plugin automatically aggregates metrics into one minute buckets, which are then sent to Azure Monitor on every flush interval. 
+The [Microsoft Azure Monitor output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/azure_monitor/README.md) sends custom metrics to [Microsoft Azure Monitor](https://azure.microsoft.com/en-us/services/monitor/). Azure Monitor has a metric resolution of one minute. To handle this in Telegraf, the Azure Monitor output plugin automatically aggregates metrics into one minute buckets, which are then sent to Azure Monitor on every flush interval.
 
 For a Microsoft blog posting on using Telegraf with Microsoft Azure Monitor, see [Collect custom metrics for a Linux VM with the InfluxData Telegraf Agent](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/metrics-store-custom-linux-telegraf).
 
 The metrics from each input plugin will be written to a separate Azure Monitor namespace, prefixed with `Telegraf/` by default. The field name for each metric is written as the Azure Monitor metric name. All field values are written as a summarized set that includes `min`, `max`, `sum`, and `count`. Tags are written as a dimension on each Azure Monitor metric.
 
-### [MQTT Producer  (`mqtt`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/mqtt/README.md)
+### MQTT Producer  
 
-The [MQTT Producer (`mqtt`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/mqtt/README.md) writes to the MQTT server using [supported output data formats](/telegraf/v1.8/data_formats/output/).
+Plugin ID: `outputs.mqtt`
 
-### [NATS Output (`nats`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nats/README.md)
+The [MQTT Producer output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/mqtt/README.md) writes to the MQTT server using [supported output data formats](/telegraf/v1.8/data_formats/output/).
 
-The [NATS Output (`nats`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nats/README.md) writes to a (list of) specified NATS instance(s).
+### NATS Output
 
-### [NSQ (`nsq`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nsq/README.md)
+Plugin ID: `outputs.nats`
 
-The [NSQ (`nsq`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nsq/README.md) writes to a specified NSQD instance, usually local to the producer. It requires a server name and a topic name.
+The [NATS Output output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nats/README.md) writes to a (list of) specified NATS instance(s).
 
-### [OpenTSDB (`opentsdb`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/opentsdb/README.md)
+### NSQ
 
-The [OpenTSDB (`opentsdb`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/opentsdb/README.md) writes to an OpenTSDB instance using either the telnet or HTTP mode.
+Plugin ID: `outputs.nsq`
+
+The [NSQ output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/nsq/README.md) writes to a specified NSQD instance, usually local to the producer. It requires a server name and a topic name.
+
+### OpenTSDB
+
+Plugin ID: `outputs.opentsdb`
+
+The [OpenTSDB output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/opentsdb/README.md) writes to an OpenTSDB instance using either the telnet or HTTP mode.
 
 Using the HTTP API is the recommended way of writing metrics since OpenTSDB 2.0 To use HTTP mode, set `useHttp` to true in config. You can also control how many metrics are sent in each HTTP request by setting `batchSize` in config. See http://opentsdb.net/docs/build/html/api_http/put.html for details.
 
-### [Prometheus Client (`prometheus_client`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/prometheus_client/README.md)
+### Prometheus Client
 
-The [Prometheus Client (`prometheus_client`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/prometheus_client/README.md) starts a [Prometheus](https://prometheus.io/) Client, it exposes all metrics on `/metrics` (default) to be polled by a Prometheus server.
+Plugin ID: `outputs.prometheus_client`
 
-### [Riemann (`riemann`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/riemann/README.md)
+The [Prometheus Client output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/prometheus_client/README.md) starts a [Prometheus](https://prometheus.io/) Client, it exposes all metrics on `/metrics` (default) to be polled by a Prometheus server.
 
-The [Riemann (`riemann`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/riemann/README.md) writes to [Riemann](http://riemann.io/) using TCP or UDP.
+### Riemann
 
-### [Socket Writer (`socket_writer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/socket_writer/README.md)
+Plugin ID: `outputs.riemann`
 
-The [Socket Writer (`socket_writer`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/socket_writer/README.md) writes to a UDP, TCP, or UNIX socket. It can output data in any of the [supported output formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md).
+The [Riemann output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/riemann/README.md) writes to [Riemann](http://riemann.io/) using TCP or UDP.
 
-### [Wavefront (`wavefront`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/wavefront/README.md)
+### Socket Writer
 
-The [Wavefront (`wavefront`) output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/wavefront/README.md) writes to a Wavefront proxy, in Wavefront data format over TCP.
+Plugin ID: `outputs.socket_writer`
+
+The [Socket Writer output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/socket_writer/README.md) writes to a UDP, TCP, or UNIX socket. It can output data in any of the [supported output formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md).
+
+### Wavefront
+
+Plugin ID: `outputs.wavefront`
+
+The [Wavefront output plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/outputs/wavefront/README.md) writes to a Wavefront proxy, in Wavefront data format over TCP.
 
 ## Deprecated Telegraf output plugins
 
-### [Riemann Legacy (`riemann_legacy`)](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/riemann_legacy)
+### Riemann Legacy
 
-The [Riemann Legacy (`riemann_legacy`) output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/riemann_legacy) will be deprecated in a future release, see https://github.com/influxdata/telegraf/issues/1878 for more details & discussion.
+Plugin ID: `outputs.riemann_legacy`
+
+The [Riemann Legacy output plugin](https://github.com/influxdata/telegraf/tree/release-1.8/plugins/outputs/riemann_legacy) will be deprecated in a future release, see https://github.com/influxdata/telegraf/issues/1878 for more details & discussion.

--- a/content/telegraf/v1.8/plugins/processors.md
+++ b/content/telegraf/v1.8/plugins/processors.md
@@ -18,17 +18,23 @@ Processor plugins process metrics as they pass through and immediately emit resu
 ## Supported Telegraf processor plugins
 
 
-### [Converter (`converter`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/converter/README.md)
+### Converter
 
-The [Converter (`converter`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/converter/README.md) is used to change the type of tag or field values. In addition to changing field types, it can convert between fields and tags. Values that cannot be converted are dropped.
+Plugin ID: `processors.converter`
 
-### [Enum (`enum`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/enum/README.md) -- NEW in v.1.8
+The [Converter processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/converter/README.md) is used to change the type of tag or field values. In addition to changing field types, it can convert between fields and tags. Values that cannot be converted are dropped.
 
-The [Enum (`enum`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/enum/README.md) allows the configuration of value mappings for metric fields. The main use case for this is to rewrite status codes such as `red`, `amber`, and `green` by numeric values such as `0`, `1`, `2`. The plugin supports string and bool types for the field values. Multiple Fields can be configured with separate value mappings for each field. Default mapping values can be configured to be used for all values, which are not contained in the value_mappings. The processor supports explicit configuration of a destination field. By default the source field is overwritten.
+### Enum
 
-### [Override (`override`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/override/README.md)
+Plugin ID: `processors.enum`
 
-The [Override (`override`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/override/README.md) allows overriding all modifications that are supported by input plugins and aggregator plugins:
+The [Enum processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/enum/README.md) allows the configuration of value mappings for metric fields. The main use case for this is to rewrite status codes such as `red`, `amber`, and `green` by numeric values such as `0`, `1`, `2`. The plugin supports string and bool types for the field values. Multiple Fields can be configured with separate value mappings for each field. Default mapping values can be configured to be used for all values, which are not contained in the value_mappings. The processor supports explicit configuration of a destination field. By default the source field is overwritten.
+
+### Override
+
+Plugin ID: `processors.override`
+
+The [Override processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/override/README.md) allows overriding all modifications that are supported by input plugins and aggregator plugins:
 
 * `name_override`
 * `name_prefix`
@@ -41,25 +47,35 @@ Values of `name_override`, `name_prefix`, `name_suffix`, and already present tag
 
 Use case of this plugin encompass ensuring certain tags or naming conventions are adhered to irrespective of input plugin configurations, e.g., by `taginclude`.
 
-### [Parser (`parser`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/parser/README.md) -- NEW in v.1.8
+### Parser
 
-The [Parser (`parser`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/parser/README.md) parses defined fields containing the specified data format and creates new metrics based on the contents of the field.
+Plugin ID: `processors.parser`
 
-### [Printer (`printer`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/printer/README.md)
+The [Parser processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/parser/README.md) parses defined fields containing the specified data format and creates new metrics based on the contents of the field.
 
-The [Printer (`printer`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/printer/README.md) simply prints every metric passing through it.
+### Printer
 
-### [Regex (`regex`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/regex/README.md)
+Plugin ID: `processors.printer`
 
-The [Regex (`regex`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/regex/README.md) transforms  -- NEW in v.1.8 tag and field values using a regular expression (regex) pattern. If `result_key `parameter is present, it can produce new tags and fields from existing ones.
+The [Printer processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/printer/README.md) simply prints every metric passing through it.
 
-### [Rename (`rename`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/rename/README.md) -- NEW in v.1.8
+### Regex
 
-The [Rename (`rename`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/rename/README.md) renames InfluxDB measurements, fields, and tags.
+Plugin ID: `processors.regex`
 
-### [Strings (`strings`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/strings/README.md) -- NEW in v.1.8
+The [Regex processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/regex/README.md) transforms  -- NEW in v.1.8 tag and field values using a regular expression (regex) pattern. If `result_key `parameter is present, it can produce new tags and fields from existing ones.
 
-The [Strings (`strings`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/strings/README.md) maps certain Go string functions onto InfluxDB measurement, tag, and field values. Values can be modified in place or stored in another key.
+### Rename
+
+Plugin ID: `processors.rename`
+
+The [Rename processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/rename/README.md) renames InfluxDB measurements, fields, and tags.
+
+### Strings
+
+Plugin ID: `processors.strings`
+
+The [Strings processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/strings/README.md) maps certain Go string functions onto InfluxDB measurement, tag, and field values. Values can be modified in place or stored in another key.
 
 Implemented functions are:
 
@@ -73,9 +89,11 @@ Implemented functions are:
 
 Note that in this implementation these are processed in the order that they appear above. You can specify the `measurement`, `tag` or `field` that you want processed in each section and optionally a `dest` if you want the result stored in a new tag or field. You can specify lots of transformations on data with a single strings processor.
 
-### [TopK (`topk`)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/topk/README.md)
+### TopK
 
-The [TopK (`topk`) processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/topk/README.md) is a filter designed to get the top series over a period of time. It can be tweaked to do its top `K` computation over a period of time, so spikes can be smoothed out.
+Plugin ID: `processors.topk`
+
+The [TopK processor plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/processors/topk/README.md) is a filter designed to get the top series over a period of time. It can be tweaked to do its top `K` computation over a period of time, so spikes can be smoothed out.
 
 This processor goes through the following steps when processing a batch of metrics:
 


### PR DESCRIPTION
Remove links in headers.
Remove parens for plugin names and move to new lines.