### PR TITLE
Add missing DATABASE keyword

### DIFF
--- a/content/influxdb/v1.7/administration/backup_and_restore.md
+++ b/content/influxdb/v1.7/administration/backup_and_restore.md
@@ -198,7 +198,7 @@ restore: DB metadata not changed. database may already exist
     ```
     > USE telegraf_bak
     > SELECT * INTO telegraf..:MEASUREMENT FROM /.*/ GROUP BY *
-    > DROP telegraf_bak
+    > DROP DATABASE telegraf_bak
     ```
 
 **To restore to a retention policy that already exists:**


### PR DESCRIPTION
The current documentation states: 

> Sideload the data (using a SELECT ... INTO statement) into the existing target database and drop the temporary database.

But the DROP command is missing the "DATABASE" keyword.

