### PR TITLE
Fixed EPRECATED

### DIFF
--- a/content/telegraf/v1.8/plugins/inputs.md
+++ b/content/telegraf/v1.8/plugins/inputs.md
@@ -940,7 +940,7 @@ The SNMP Legacy input plugin gathers metrics from SNMP agents.
 
 Plugin ID: `inputs.tcp_listener`
 
-> The [TCP Listener input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md) is EPRECATED as of version 1.3; use the [Socket Listener input plugin](#socket-listener).
+> The [TCP Listener input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md) is DEPRECATED as of version 1.3; use the [Socket Listener input plugin](#socket-listener).
 
 ### UDP Listener
 

--- a/content/telegraf/v1.8/plugins/inputs.md
+++ b/content/telegraf/v1.8/plugins/inputs.md
@@ -932,7 +932,7 @@ Plugin ID: `inputs.jolokia`
 
 Plugin ID: `inputs.snmp_legacy`
 
-> The [SNMP Legacy input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp_legacy/README.md) is DEPRECATED. Use the [SNMP input plugin](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/snmp).
+> The [SNMP Legacy input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/snmp_legacy/README.md) is DEPRECATED. Use the [SNMP input plugin](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/snmp).
 
 The SNMP Legacy input plugin gathers metrics from SNMP agents.
 
@@ -940,7 +940,7 @@ The SNMP Legacy input plugin gathers metrics from SNMP agents.
 
 Plugin ID: `inputs.tcp_listener`
 
-> The [TCP Listener input plugin)](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md) is DEPRECATED as of version 1.3; use the [Socket Listener input plugin](#socket-listener).
+> The [TCP Listener input plugin](https://github.com/influxdata/telegraf/blob/release-1.8/plugins/inputs/tcp_listener/README.md) is DEPRECATED as of version 1.3; use the [Socket Listener input plugin](#socket-listener).
 
 ### UDP Listener
 


### PR DESCRIPTION
in TCP Listener and removed some extra `)` in the new "DEPRECATED" section.

Fixes: #1992 