### PR TITLE
Add Erlang client library

### DIFF
--- a/content/influxdb/v1.7/tools/api_client_libraries.md
+++ b/content/influxdb/v1.7/tools/api_client_libraries.md
@@ -20,6 +20,11 @@ Thanks to the open source community for your contributions, commitment, and effo
 * [Instream (instream)](https://github.com/mneudert/instream)
   * Maintained by [Marc Neudert (mneudert)](https://github.com/mneudert)
 
+## Erlang
+
+* [Erlang InfluxDB UDP Writer](https://github.com/palkan/influx_udp)
+  * Maintained by [Vladimir Dementyev (palkan)](https://github.com/palkan)
+
 ## Go
 
 * [InfluxDB Client](https://github.com/influxdb/influxdb/blob/master/client/README.md)


### PR DESCRIPTION
This library seems to be the best maintained one.

There are several other projects on GitHub that claim to be Erlang InfluxDB clients, but they're either old, unmaintained, experimental, or lack documentation.

Hope this helps 😘