### PR TITLE
Syntax error in example tick script

### DIFF
--- a/content/kapacitor/v1.5/nodes/alert_node.md
+++ b/content/kapacitor/v1.5/nodes/alert_node.md
@@ -1107,7 +1107,7 @@ are considered different states.
 _**Example**_
 ```js
 stream
-  from()
+  |from()
     .measurement('cpu')
   |window()
     .period(10s)


### PR DESCRIPTION
The example code here was missing a `|` character