### PR TITLE
Fix broken text formatting in InfluxDB FAQ

### DIFF
--- a/content/influxdb/v1.4/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.4/troubleshooting/frequently-asked-questions.md
@@ -834,8 +834,7 @@ Use the `::` syntax to specify if the key is a field key or tag key.
 
 #### Examples
 
-##### Sample data:
-<br>
+##### Sample data:  
 ```
 > INSERT candied,almonds=true almonds=50,half_almonds=51 1465317610000000000
 > INSERT candied,almonds=true almonds=55,half_almonds=56 1465317620000000000

--- a/content/influxdb/v1.5/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.5/troubleshooting/frequently-asked-questions.md
@@ -834,8 +834,7 @@ Use the `::` syntax to specify if the key is a field key or tag key.
 
 #### Examples
 
-##### Sample data:
-<br>
+##### Sample data:  
 ```
 > INSERT candied,almonds=true almonds=50,half_almonds=51 1465317610000000000
 > INSERT candied,almonds=true almonds=55,half_almonds=56 1465317620000000000

--- a/content/influxdb/v1.6/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.6/troubleshooting/frequently-asked-questions.md
@@ -843,8 +843,7 @@ Use the `::` syntax to specify if the key is a field key or tag key.
 
 #### Examples
 
-##### Sample data:
-<br>
+##### Sample data:  
 ```
 > INSERT candied,almonds=true almonds=50,half_almonds=51 1465317610000000000
 > INSERT candied,almonds=true almonds=55,half_almonds=56 1465317620000000000

--- a/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
@@ -839,8 +839,7 @@ Use the `::` syntax to specify if the key is a field key or tag key.
 
 #### Examples
 
-##### Sample data:
-<br>
+##### Sample data:  
 ```
 > INSERT candied,almonds=true almonds=50,half_almonds=51 1465317610000000000
 > INSERT candied,almonds=true almonds=55,half_almonds=56 1465317620000000000


### PR DESCRIPTION
Although it renders correctly on `docs.influxdata.com`, when you try to display these pages in Github UI it's all messed up.