### PR TITLE
Replace curl with wget in Linux context

### DIFF
--- a/content/influxdb/v0.10/introduction/installation.md
+++ b/content/influxdb/v0.10/introduction/installation.md
@@ -35,7 +35,7 @@ Debian and Ubuntu users can install the latest stable version of InfluxDB using 
 For Ubuntu users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -43,7 +43,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v0.11/introduction/installation.md
+++ b/content/influxdb/v0.11/introduction/installation.md
@@ -35,7 +35,7 @@ Debian and Ubuntu users can install the latest stable version of InfluxDB using 
 For Ubuntu users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -43,7 +43,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v0.12/introduction/installation.md
+++ b/content/influxdb/v0.12/introduction/installation.md
@@ -34,7 +34,7 @@ Debian and Ubuntu users can install the latest stable version of InfluxDB using 
 For Ubuntu users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -42,7 +42,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v0.13/introduction/installation.md
+++ b/content/influxdb/v0.13/introduction/installation.md
@@ -41,7 +41,7 @@ users can install the latest stable version of InfluxDB using the
 For Ubuntu users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -49,7 +49,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v0.9/introduction/installation.md
+++ b/content/influxdb/v0.9/introduction/installation.md
@@ -22,7 +22,7 @@ Debian and Ubuntu users can install the latest stable version of InfluxDB using 
 For Ubuntu users, you can add the InfluxData repository configuration by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -30,7 +30,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, you can add the InfluxData repository configuration by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v1.0/introduction/installation.md
+++ b/content/influxdb/v1.0/introduction/installation.md
@@ -52,7 +52,7 @@ users can install the latest stable version of InfluxDB using the
 For Ubuntu users, add the InfluxData repository with the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -60,7 +60,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, add the InfluxData repository:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v1.1/introduction/installation.md
+++ b/content/influxdb/v1.1/introduction/installation.md
@@ -52,7 +52,7 @@ users can install the latest stable version of InfluxDB using the
 For Ubuntu users, add the InfluxData repository with the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -60,7 +60,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, add the InfluxData repository:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v1.2/introduction/installation.md
+++ b/content/influxdb/v1.2/introduction/installation.md
@@ -60,7 +60,7 @@ users can install the latest stable version of InfluxDB using the
 For Ubuntu users, add the InfluxData repository with the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -68,7 +68,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, add the InfluxData repository:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v1.3/introduction/installation.md
+++ b/content/influxdb/v1.3/introduction/installation.md
@@ -60,7 +60,7 @@ users can install the latest stable version of InfluxDB using the
 For Ubuntu users, add the InfluxData repository with the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -68,7 +68,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, add the InfluxData repository:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v1.4/introduction/installation.md
+++ b/content/influxdb/v1.4/introduction/installation.md
@@ -61,7 +61,7 @@ users can install the latest stable version of InfluxDB using the
 For Ubuntu users, add the InfluxData repository with the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -69,7 +69,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, add the InfluxData repository:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v1.5/introduction/installation.md
+++ b/content/influxdb/v1.5/introduction/installation.md
@@ -61,7 +61,7 @@ users can install the latest stable version of InfluxDB using the
 For Ubuntu users, add the InfluxData repository with the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -69,7 +69,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, add the InfluxData repository:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v1.6/introduction/installation.md
+++ b/content/influxdb/v1.6/introduction/installation.md
@@ -61,7 +61,7 @@ users can install the latest stable version of InfluxDB using the
 For Ubuntu users, add the InfluxData repository with the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -69,7 +69,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, add the InfluxData repository:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/influxdb/v1.7/introduction/installation.md
+++ b/content/influxdb/v1.7/introduction/installation.md
@@ -61,7 +61,7 @@ users can install the latest stable version of InfluxDB using the
 For Ubuntu users, add the InfluxData repository with the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -69,7 +69,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, add the InfluxData repository:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v0.13/introduction/installation.md
+++ b/content/telegraf/v0.13/introduction/installation.md
@@ -29,7 +29,7 @@ Debian and Ubuntu users can install the latest stable version of Telegraf using 
 For Ubuntu users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/lsb-release
 echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 ```
@@ -37,7 +37,7 @@ echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stabl
 For Debian users, you can add the InfluxData repository by using the following commands:
 
 ```bash
-curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
 source /etc/os-release
 test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
 test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.0/introduction/installation.md
+++ b/content/telegraf/v1.0/introduction/installation.md
@@ -39,7 +39,7 @@ which is located at `/etc/telegraf/telegraf.conf` for default installations.
   For Ubuntu users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -47,7 +47,7 @@ which is located at `/etc/telegraf/telegraf.conf` for default installations.
   For Debian users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.1/introduction/installation.md
+++ b/content/telegraf/v1.1/introduction/installation.md
@@ -39,7 +39,7 @@ which is located at `/etc/telegraf/telegraf.conf` for default installations.
   For Ubuntu users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -47,7 +47,7 @@ which is located at `/etc/telegraf/telegraf.conf` for default installations.
   For Debian users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.2/introduction/installation.md
+++ b/content/telegraf/v1.2/introduction/installation.md
@@ -45,7 +45,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   For Ubuntu users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -53,7 +53,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   For Debian users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.3/introduction/installation.md
+++ b/content/telegraf/v1.3/introduction/installation.md
@@ -45,7 +45,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   For Ubuntu users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -53,7 +53,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   For Debian users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.4/introduction/installation.md
+++ b/content/telegraf/v1.4/introduction/installation.md
@@ -45,7 +45,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   For Ubuntu users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -53,7 +53,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   For Debian users, add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.5/introduction/installation.md
+++ b/content/telegraf/v1.5/introduction/installation.md
@@ -47,7 +47,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   **Ubuntu:** Add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -61,7 +61,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
 
   # Add the InfluxData key
 
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.6/introduction/installation.md
+++ b/content/telegraf/v1.6/introduction/installation.md
@@ -47,7 +47,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   **Ubuntu:** Add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -61,7 +61,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
 
   # Add the InfluxData key
 
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.7/introduction/installation.md
+++ b/content/telegraf/v1.7/introduction/installation.md
@@ -47,7 +47,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   **Ubuntu:** Add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -61,7 +61,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
 
   # Add the InfluxData key
 
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.8/introduction/installation.md
+++ b/content/telegraf/v1.8/introduction/installation.md
@@ -47,7 +47,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   **Ubuntu:** Add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -61,7 +61,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
 
   # Add the InfluxData key
 
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list

--- a/content/telegraf/v1.9/introduction/installation.md
+++ b/content/telegraf/v1.9/introduction/installation.md
@@ -47,7 +47,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
   **Ubuntu:** Add the InfluxData repository with the following commands:
 
   ```bash
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/lsb-release
   echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   ```
@@ -61,7 +61,7 @@ aren't synchronized with NTP, the timestamps on the data can be inaccurate.
 
   # Add the InfluxData key
 
-  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+  wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   source /etc/os-release
   test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
   test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list


### PR DESCRIPTION
On Linux, `wget` is more ubiquitous than `curl`. Most distros have `wget` pre-included, while `curl` needs to be installed afterwards.

So, it is better that the documentation tell user to use `wget` to download InfluxDB. They just copy the sample command and run, don't have to check if `curl` exist and install it first.

Other parts of documentation where `curl` is mentioned, I don't replace with `wget` because it seems not to be specific to Linux. Those commands seem to target both Linux and MacOS.