### PR TITLE
Update managing-security.md

### DIFF
--- a/content/chronograf/v1.7/administration/managing-security.md
+++ b/content/chronograf/v1.7/administration/managing-security.md
@@ -168,7 +168,8 @@ To support multiple organizations, use a comma-delimited list.
 export GH_ORGS=hill-valley-preservation-sociey,the-pinheads
 ```
 
-When logging in for the first time, make sure to grant access to the organization you configured. The OAuth application can only see membership in organizations it has been granted access to.
+> When logging in for the first time, make sure to grant access to the organization you configured. The OAuth application can only see membership in organizations it has been granted access to.
+
 
 ### Configuring Google authentication
 


### PR DESCRIPTION
From the github interface it might seem like the oauth app can see all your organizations memberships. Adding an explicit note about the necessity to grant the organization access, so noone gets confused like I did in https://github.com/influxdata/chronograf/issues/4575