### PR TITLE
Fix description for subscription-mode "cluster"

### DIFF
--- a/content/kapacitor/v1.5/administration/subscription-management.md
+++ b/content/kapacitor/v1.5/administration/subscription-management.md
@@ -74,12 +74,7 @@ Defines the subscription mode of Kapacitor.
 Available options:
 
 - `"server"`
-- `"cluster"` _(Coming)_
-
-<dt>
-The `cluster` subscription-mode is planned for future versions of Kapacitor and [Kapacitor Enterprise](/enterprise_kapacitor/).
-If used currently, subscription data will not be received.
-</dt>
+- `"cluster"`
 
 ### `subscription-protocol`
 Defines which protocol to use for subscriptions.


### PR DESCRIPTION
As of kapacitor OSS 1.5.2, "kapacitord config" output indicates that subscription-mode defaults to "cluster" mode.

NOTE: please consider also adding docs to the shipped configuration `/etc/kapacitor/kapacitor.conf`.   Currently the comment there (`Subscription mode is either "cluster" or "server"`) does not give much information on the actual effect of each option value.