### PR TITLE
kapacitor: Add unit info on fields added by state tracking node

### DIFF
--- a/content/kapacitor/v1.5/nodes/state_count_node.md
+++ b/content/kapacitor/v1.5/nodes/state_count_node.md
@@ -16,10 +16,9 @@ The state is defined via a lambda expression. For each consecutive point for
 which the expression evaluates as true, the state count will be incremented
 When a point evaluates as false, the state count is reset.
 
-The state count will be added as an additional field to each point. If the
-expression evaluates as false, the value will be -1. If the expression
-generates an error during evaluation, the point is discarded, and does not
-affect the state count.
+The state count will be added as an additional `int64` field to each point.
+If the expression evaluates as false, the value will be -1.
+If the expression generates an error during evaluation, the point is discarded, and does not affect the state count.
 
 Example:
 

--- a/content/kapacitor/v1.5/nodes/state_duration_node.md
+++ b/content/kapacitor/v1.5/nodes/state_duration_node.md
@@ -17,10 +17,9 @@ which the expression evaluates as `true`, the state duration will be
 incremented by the duration between points. When a point evaluates as `false`,
 the state duration is reset.
 
-The state duration will be added as an additional field to each point. If the
-expression evaluates as false, the value will be `-1`. If the expression
-generates an error during evaluation, the point is discarded, and does not
-affect the state duration.
+The state duration will be added as an additional `float64` field to each point.
+If the expression evaluates as false, the value will be `-1`.
+If the expression generates an error during evaluation, the point is discarded, and does not affect the state duration.
 
 Example:
 


### PR DESCRIPTION
The description text for stateDuration node seems to imply that the
additional field value will be of duration type while actually it's
float64 describing number of .unit()

While at it, also convert the paragraph to "semantic linefeeds" style