### PR TITLE
Fixed a typo in 'aggregate handler' doc page.

### DIFF
--- a/content/kapacitor/v1.5/event_handlers/aggregate.md
+++ b/content/kapacitor/v1.5/event_handlers/aggregate.md
@@ -44,7 +44,7 @@ CPU idle usage is less than 10% (or CPU usage is greater than 90%).
 stream
     |from()
       .measurement('cpu')
-      .groupby(*)
+      .groupBy(*)
     |alert()
       .crit(lambda: "usage_idle" < 10)
       .topic('cpu')


### PR DESCRIPTION
The current aggregate handler doc page uses the literal "groupby" instead of "groupBy" in the "cpu_alert.tick" script, which seems to be incorrect.