### PR TITLE
Fix broken links

### DIFF
--- a/content/platform/install-and-deploy/_index.md
+++ b/content/platform/install-and-deploy/_index.md
@@ -18,7 +18,7 @@ You can manually install and configure all of the InfluxData Platform OSS compon
 for use or install InfluxDB Enterprise clusters for production use.
 
 
-## [Deploy the InfluxData TICK stack in containers](/platform/install-and-deploy/deploy/)
+## [Deploy the InfluxData TICK stack in containers](/platform/install-and-deploy/deploying/)
 
 Use containers and container providers to simplify and ease the deployment of
 the InfluxData Platform.

--- a/content/platform/install-and-deploy/deploying/_index.md
+++ b/content/platform/install-and-deploy/deploying/_index.md
@@ -15,7 +15,7 @@ installation options meets your requirements.
 
 ## Deploy the InfluxData Platform in Docker containers
 
-You can [deploy the InfluxData Platform OSS (TICK stack) in Docker containers using the InfluxData Sandbox](/platform/install-and-deploy/deploy/sandbox-install) to quickly get up and running and ready for exploration
+You can [deploy the InfluxData Platform OSS (TICK stack) in Docker containers using the InfluxData Sandbox](/platform/install-and-deploy/deploying/sandbox-install) to quickly get up and running and ready for exploration
 and testing. The InfluxData Sandbox is not intended for production environments,
 but it is a quick way to start using the InfluxData Platform and work with Docker
 containers.
@@ -23,14 +23,14 @@ containers.
 ## Deploy InfluxData Platform components in Kubernetes
 
 To deploy InfluxData Platform OSS components in Kubernetes, see  
-[Deploy InfluxData Platform components in Kubernetes](/platform/install-and-deploy/deploy/kubernetes).
+[Deploy InfluxData Platform components in Kubernetes](/platform/install-and-deploy/deploying/kubernetes).
 
 ## Deploy an InfluxDB Enterprise cluster on Amazon Web Services
 
 To learn how to deploy InfluxDB Enterprise clusters on Amazon Web Services, see
-[Deploy an InfluxDB Enterprise cluster on Amazon Web Services](/platform/install-and-deploy/deploy/amazon-web-services)
+[Deploy an InfluxDB Enterprise cluster on Amazon Web Services](/platform/install-and-deploy/deploying/amazon-web-services)
 
 ## Deploy InfluxData Platform in Google Cloud Platform
 
 To learn about deploying InfluxDB Enterprise clusters on Google Cloud Platform (GCP),
-see [Deploy InfluxData Platform in Google Cloud Platform](/platform/install-and-deploy/google-cloud-platform).
+see [Deploy InfluxData Platform in Google Cloud Platform](/platform/install-and-deploy/deploying/google-cloud-platform).

--- a/content/platform/install-and-deploy/install/_index.md
+++ b/content/platform/install-and-deploy/install/_index.md
@@ -13,9 +13,9 @@ There are multiple ways to install and configure the InfluxData Platform (also k
 as the TICK stack). Included below are several installation options and relevant
 links for exploring the InfluxData Platform and its TICK stack components.
 
-## [Deploy the InfluxData Platform (TICK stack) in Docker containers](/platform/install-and-deploy/deploy/sandbox-install)
+## [Deploy the InfluxData Platform (TICK stack) in Docker containers](/platform/install-and-deploy/deploying/sandbox-install)
 
-The quickest way to install the InfluxData Platform is to [deploy the InfluxData Platform OSS (TICK stack) in Docker containers using the InfluxData Sandbox](/platform/install-and-deploy/deploy/sandbox-install) to quickly get up and running and ready for exploration
+The quickest way to install the InfluxData Platform is to [deploy the InfluxData Platform OSS (TICK stack) in Docker containers using the InfluxData Sandbox](/platform/install-and-deploy/deploying/sandbox-install) to quickly get up and running and ready for exploration
 and testing. The InfluxData Sandbox is not intended for production environments,
 but it is a quick way to start using the InfluxData Platform and work with Docker
 containers.

--- a/content/platform/install-and-deploy/install/oss-install.md
+++ b/content/platform/install-and-deploy/install/oss-install.md
@@ -41,4 +41,4 @@ walk through installing and configuring the open source version of Kapacitor.
 The [InfluxData Sandbox](https://github.com/influxdata/sandbox) is an alternative
 method for installing the OSS TICK stack that uses Docker and Docker Compose to build
 and network each component. For information about installing the Sandbox, view the
-[InfluxData Sandbox installation instructions](/platform/install-and-deploy/deploy/sandbox-install).
+[InfluxData Sandbox installation instructions](/platform/install-and-deploy/deploying/sandbox-install).


### PR DESCRIPTION
A number of pages had broken links pointing to /platform/install-and-deploy/deploy/ instead of /platform/install-and-deploy/deploying/ 