### PR TITLE
change clone to https - more universal

### DIFF
--- a/content/platform/install-and-deploy/deploying/sandbox-install.md
+++ b/content/platform/install-and-deploy/deploying/sandbox-install.md
@@ -36,7 +36,7 @@ To download it, use `git` to clone the source repository:
 
 ```bash
 # Clone the InfluxData Sandbox from Github
-git clone git@github.com:influxdata/sandbox.git
+git clone https://github.com/influxdata/sandbox.git
 ```
 
 The Sandbox repo includes a `sandbox` binary used to provision and manage the


### PR DESCRIPTION
Changed the clone url to https, which github recommends and is more universal - fewer proxy issues, no account required. 

See issue in sandbox

https://github.com/influxdata/sandbox/issues/63