### PR TITLE
Modify alert match format

### DIFF
--- a/content/kapacitor/v1.5/working/alerts.md
+++ b/content/kapacitor/v1.5/working/alerts.md
@@ -159,7 +159,7 @@ match: level() >= WARNING
 Send events with the tag "host" equal to `s001.example.com` to the handler:
 
 ```yaml
-match: "host" == 's001.example.com'
+match: "\"host\" == 's001.example.com'"
 ```
 
 #### Alert event data


### PR DESCRIPTION
If the entire `match` condition for checking tags is not wrapped in double quotes with escaped double quotes around the tag name, kapacitor complains due to an error converting YAML to JSON. I ran into this issue after consulting the docs, which do not properly reflect how this should be formatted. I confirmed that the format in this PR works through my own testing.

Others have also encountered this issue as well and found the same solution, per https://github.com/influxdata/kapacitor/issues/1621.