### PR TITLE
Fix 1.7.4 release notes

### DIFF
--- a/content/influxdb/v1.7/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.7/about_the_project/releasenotes-changelog.md
@@ -48,7 +48,7 @@ this release includes the fix for InfluxDB 1.7.5 servers that stopped responding
 
 ### Features
 
-- Allow TSI bitset cache to be configured. New `[data]` configuration setting `tsi-cache-size = 100`.
+- Allow TSI bitset cache to be configured. See: [InfluxDB Configuration `[data]`](/influxdb/v1.7/administration/config/#tsi-tsi1-index-settings)
 
 ### Bug fixes
 

--- a/content/influxdb/v1.7/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.7/about_the_project/releasenotes-changelog.md
@@ -48,7 +48,7 @@ this release includes the fix for InfluxDB 1.7.5 servers that stopped responding
 
 ### Features
 
-- Allow TSI bitset cache to be configured. New `[data]` configuration settings for `inmem` (`tsm-use-madv-willneed`) and `tsi1` (`max-index-log-file-size` and `series-id-set-cache-size`).
+- Allow TSI bitset cache to be configured. New `[data]` configuration setting `tsi-cache-size = 100`.
 
 ### Bug fixes
 


### PR DESCRIPTION
Looks like we didn't add the appropriate change to allow for the TSI bitset caching to be configured.
Correct config settings are: 
[data] 
    max-index-log-file-size = "1m"
    series-id-set-cache-size = 100

These are already doc'ed here: https://docs.influxdata.com/influxdb/v1.7/administration/config/#tsi-tsi1-index-settings

Provided a link to that in the release notes.