### PR TITLE
Updated InfluxDB Enterprise 1.7.6 release date

### DIFF
--- a/content/enterprise_influxdb/v1.7/about-the-project/release-notes-changelog.md
+++ b/content/enterprise_influxdb/v1.7/about-the-project/release-notes-changelog.md
@@ -8,7 +8,7 @@ menu:
     parent: About the project
 ---
 
-## v1.7.6 [2019-04-16]
+## v1.7.6 [2019-05-07]
 
 This InfluxDB Enterprise release builds on the InfluxDB OSS 1.7.6 release. For details on changes incorporated from the InfluxDB OSS release, see [InfluxDB OSS release notes](/influxdb/v1.7/about_the_project/releasenotes-changelog/).
 


### PR DESCRIPTION
Align with public release.  Original creation date was for deployment into Cloud.
Official GA is 5-7-2019.