### PR TITLE
add tutorial for JWT authentication

### DIFF
--- a/content/influxdb/v1.7/administration/authentication_and_authorization.md
+++ b/content/influxdb/v1.7/administration/authentication_and_authorization.md
@@ -155,7 +155,7 @@ This is currently only possible through the [InfluxDB HTTP API](/influxdb/v1.7/t
 
 #### 1. Add a shared secret in your InfluxDB configuration file
 InfluxDB uses the shared secret to encode the JWT signature.
-By default, ``shared-secret`` is set to an empty string, in which case no JWT authentication takes place.
+By default, `shared-secret` is set to an empty string, in which case no JWT authentication takes place.
 Add a custom shared secret in your [InfluxDB configuration file](/influxdb/v1.7/administration/config/#shared-secret).
 The longer the secret string, the more secure it is:
 
@@ -164,14 +164,11 @@ The longer the secret string, the more secure it is:
   shared-secret = "my super secret pass phrase"
 ```
 
-Alternatively, to avoid keeping your secret phrase as plain text in your InfluxDB configuration file, you can write the value in the corresponding environment variable:
+Alternatively, to avoid keeping your secret phrase as plain text in your InfluxDB configuration file, set the value with the `INFLUXDB_HTTP_SHARED_SECRET` environment variable.
 
-```
-INFLUXDB_HTTP_SHARED_SECRET
-```
 
 #### 2. Generate your token
-Use an authentication service to generate a secure token using your InfluxDB username, and expiration time, and your shared secret.
+Use an authentication service to generate a secure token using your InfluxDB username, an expiration time, and your shared secret.
 There are online tools, such as [https://jwt.io/](https://jwt.io/), that will do this for you.
 
 The payload (or claims) of the token must be in the following format:


### PR DESCRIPTION
Responding to issue https://github.com/influxdata/docs.influxdata.com/issues/2279

New section in the doc explaining how to authenticate with the use of JWT bearer tokens in the HTTP requests.
https://docs.influxdata.com/influxdb/v1.7/administration/authentication_and_authorization/#authentication