### PR TITLE
Update filecount description (telegraf plugin)

### DIFF
--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -416,7 +416,7 @@ input:
   - name: Filecount
     id: filecount
     description: |
-      The Filecount input plugin counts files in directories that match certain criteria.
+      The Filecount input plugin reports the number and total size of files in directories that match certain criteria.
     link: https://github.com/influxdata/telegraf/blob/release-1.11/plugins/inputs/filecount/README.md
     introduced: 1.8.0
     tags: [linux, macos, windows, systems]


### PR DESCRIPTION
The plugin now computes the total size of matching files. See [README for filecount plugin](https://github.com/influxdata/telegraf/blob/release-1.11/plugins/inputs/filecount/README.md).