### PR TITLE
fix swapped descriptions for output/processor plugins

### DIFF
--- a/content/telegraf/v1.10/plugins/_index.md
+++ b/content/telegraf/v1.10/plugins/_index.md
@@ -16,7 +16,7 @@ The [Telegraf input plugins](/telegraf/v1.10/plugins/inputs/) collect metrics fr
 
 ## [Telegraf output plugins](/telegraf/v1.10/plugins/outputs/)
 
-The [Telegraf output plugins](/telegraf/v1.10/plugins/outputs/) transform, decorate, and filter metrics.
+The [Telegraf output plugins](/telegraf/v1.10/plugins/outputs/) write metrics to various destinations.
 
 ## [Telegraf aggregator plugins](/telegraf/v1.10/plugins/aggregators/)
 
@@ -24,4 +24,4 @@ The [Telegraf aggregator plugins](/telegraf/v1.10/plugins/aggregators/) create a
 
 ## [Telegraf processor plugins](/telegraf/v1.10/plugins/processors/)
 
-The [Telegraf processor plugins](/telegraf/v1.10/plugins/processors/) write metrics to various destinations.
+The [Telegraf processor plugins](/telegraf/v1.10/plugins/processors/) transform, decorate, and filter metrics.

--- a/content/telegraf/v1.10/plugins/outputs.md
+++ b/content/telegraf/v1.10/plugins/outputs.md
@@ -1,6 +1,6 @@
 ---
 title: Telegraf output plugins
-descriptions: Use Telegraf output plugins to transform, decorate, and filter metrics. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
+descriptions: Use Telegraf output plugins to write metrics to various destinations. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
 menu:
   telegraf_1_10:
     name: Output

--- a/content/telegraf/v1.11/plugins/_index.md
+++ b/content/telegraf/v1.11/plugins/_index.md
@@ -16,10 +16,10 @@ View the full list of available Telegraf plugins.
 The [Telegraf input plugins](/telegraf/v1.11/plugins/inputs/) collect metrics from the system, services, or third party APIs.
 
 ### Telegraf output plugins
-The [Telegraf output plugins](/telegraf/v1.11/plugins/outputs/) transform, decorate, and filter metrics.
+The [Telegraf output plugins](/telegraf/v1.11/plugins/outputs/) write metrics to various destinations.
 
 ### Telegraf aggregator plugins
 The [Telegraf aggregator plugins](/telegraf/v1.11/plugins/aggregators/) create aggregate metrics (for example, mean, min, max, quantiles, etc.)
 
 ### Telegraf processor plugins
-The [Telegraf processor plugins](/telegraf/v1.11/plugins/processors/) write metrics to various destinations.
+The [Telegraf processor plugins](/telegraf/v1.11/plugins/processors/) transform, decorate, and filter metrics.

--- a/content/telegraf/v1.11/plugins/outputs.md
+++ b/content/telegraf/v1.11/plugins/outputs.md
@@ -1,6 +1,6 @@
 ---
 title: Telegraf output plugins
-descriptions: Use Telegraf output plugins to transform, decorate, and filter metrics. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
+descriptions: Use Telegraf output plugins to write metrics to various destinations. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
 menu:
   telegraf_1_11:
     name: Output

--- a/content/telegraf/v1.6/plugins/_index.md
+++ b/content/telegraf/v1.6/plugins/_index.md
@@ -16,7 +16,7 @@ The [Telegraf input plugins](/telegraf/v1.6/plugins/inputs/) collect metrics fro
 
 ## [Telegraf output plugins](/telegraf/v1.6/plugins/outputs/)
 
-The [Telegraf output plugins](/telegraf/v1.6/plugins/outputs/) transform, decorate, and filter metrics.
+The [Telegraf output plugins](/telegraf/v1.6/plugins/outputs/) write metrics to various destinations.
 
 ## [Telegraf aggregator plugins](/telegraf/v1.6/plugins/aggregators/)
 
@@ -24,4 +24,4 @@ The [Telegraf aggregator plugins](/telegraf/v1.6/plugins/aggregators/) create ag
 
 ## [Telegraf processor plugins](/telegraf/v1.6/plugins/processors/)
 
-The [Telegraf processor plugins](/telegraf/v1.6/plugins/processors/) write metrics to various destinations.
+The [Telegraf processor plugins](/telegraf/v1.6/plugins/processors/) transform, decorate, and filter metrics.

--- a/content/telegraf/v1.6/plugins/outputs.md
+++ b/content/telegraf/v1.6/plugins/outputs.md
@@ -1,6 +1,6 @@
 ---
 title: Telegraf output plugins
-descriptions: Telegraf output plugins are used with the InfluxData time series platform to transform, decorate, and filter metrics. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
+descriptions: Telegraf output plugins are used with the InfluxData time series platform to write metrics to various destinations. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
 menu:
   telegraf_1_6:
     name: Output

--- a/content/telegraf/v1.7/plugins/_index.md
+++ b/content/telegraf/v1.7/plugins/_index.md
@@ -16,7 +16,7 @@ The [Telegraf input plugins](/telegraf/v1.7/plugins/inputs/) collect metrics fro
 
 ## [Telegraf output plugins](/telegraf/v1.7/plugins/outputs/)
 
-The [Telegraf output plugins](/telegraf/v1.7/plugins/outputs/) transform, decorate, and filter metrics.
+The [Telegraf output plugins](/telegraf/v1.7/plugins/outputs/) write metrics to various destinations.
 
 ## [Telegraf aggregator plugins](/telegraf/v1.7/plugins/aggregators/)
 
@@ -24,4 +24,4 @@ The [Telegraf aggregator plugins](/telegraf/v1.7/plugins/aggregators/) create ag
 
 ## [Telegraf processor plugins](/telegraf/v1.7/plugins/processors/)
 
-The [Telegraf processor plugins](/telegraf/v1.7/plugins/processors/) write metrics to various destinations.
+The [Telegraf processor plugins](/telegraf/v1.7/plugins/processors/) transform, decorate, and filter metrics.

--- a/content/telegraf/v1.7/plugins/outputs.md
+++ b/content/telegraf/v1.7/plugins/outputs.md
@@ -1,6 +1,6 @@
 ---
 title: Telegraf output plugins
-descriptions: Telegraf output plugins are used with the InfluxData time series platform to transform, decorate, and filter metrics. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
+descriptions: Telegraf output plugins are used with the InfluxData time series platform to write metrics to various destinations. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
 menu:
   telegraf_1_7:
     name: Output

--- a/content/telegraf/v1.8/plugins/_index.md
+++ b/content/telegraf/v1.8/plugins/_index.md
@@ -16,7 +16,7 @@ The [Telegraf input plugins](/telegraf/v1.8/plugins/inputs/) collect metrics fro
 
 ## [Telegraf output plugins](/telegraf/v1.8/plugins/outputs/)
 
-The [Telegraf output plugins](/telegraf/v1.8/plugins/outputs/) transform, decorate, and filter metrics.
+The [Telegraf output plugins](/telegraf/v1.8/plugins/outputs/) write metrics to various destinations.
 
 ## [Telegraf aggregator plugins](/telegraf/v1.8/plugins/aggregators/)
 
@@ -24,4 +24,4 @@ The [Telegraf aggregator plugins](/telegraf/v1.8/plugins/aggregators/) create ag
 
 ## [Telegraf processor plugins](/telegraf/v1.8/plugins/processors/)
 
-The [Telegraf processor plugins](/telegraf/v1.8/plugins/processors/) write metrics to various destinations.
+The [Telegraf processor plugins](/telegraf/v1.8/plugins/processors/) transform, decorate, and filter metrics.

--- a/content/telegraf/v1.8/plugins/outputs.md
+++ b/content/telegraf/v1.8/plugins/outputs.md
@@ -1,6 +1,6 @@
 ---
 title: Telegraf output plugins
-descriptions: Use Telegraf output plugins to transform, decorate, and filter metrics. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
+descriptions: Use Telegraf output plugins to write metrics to various destinations. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
 menu:
   telegraf_1_8:
     name: Output

--- a/content/telegraf/v1.9/plugins/_index.md
+++ b/content/telegraf/v1.9/plugins/_index.md
@@ -16,7 +16,7 @@ The [Telegraf input plugins](/telegraf/v1.9/plugins/inputs/) collect metrics fro
 
 ## [Telegraf output plugins](/telegraf/v1.9/plugins/outputs/)
 
-The [Telegraf output plugins](/telegraf/v1.9/plugins/outputs/) transform, decorate, and filter metrics.
+The [Telegraf output plugins](/telegraf/v1.9/plugins/outputs/) write metrics to various destinations.
 
 ## [Telegraf aggregator plugins](/telegraf/v1.9/plugins/aggregators/)
 
@@ -24,4 +24,4 @@ The [Telegraf aggregator plugins](/telegraf/v1.9/plugins/aggregators/) create ag
 
 ## [Telegraf processor plugins](/telegraf/v1.9/plugins/processors/)
 
-The [Telegraf processor plugins](/telegraf/v1.9/plugins/processors/) write metrics to various destinations.
+The [Telegraf processor plugins](/telegraf/v1.9/plugins/processors/) transform, decorate, and filter metrics.

--- a/content/telegraf/v1.9/plugins/outputs.md
+++ b/content/telegraf/v1.9/plugins/outputs.md
@@ -1,6 +1,6 @@
 ---
 title: Telegraf output plugins
-descriptions: Use Telegraf output plugins to transform, decorate, and filter metrics. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
+descriptions: Use Telegraf output plugins to write metrics to various destinations. Supported output plugins include Datadog, Elasticsearch, Graphite, InfluxDB, Kafka, MQTT, Prometheus Client, Riemann, and Wavefront.
 menu:
   telegraf_1_9:
     name: Output


### PR DESCRIPTION
Addresses https://github.com/influxdata/docs.influxdata.com/issues/2321

I noticed that the descriptions for output and processor plugins seemed swapped in a bunch of places.

This change makes sure that:
1. Output plugins are always described as "write metrics to various destinations."
1. Processor plugins are always described as "transform, decorate, and filter metrics."