### PR TITLE
Fix issue #2329

### DIFF
--- a/content/chronograf/v1.7/administration/creating-connections.md
+++ b/content/chronograf/v1.7/administration/creating-connections.md
@@ -157,8 +157,8 @@ All `.kap` files should contain the following:
 
 ```json
 {
-  "id": 10000,
-  "srcID": 10000,
+  "id": "10000",
+  "srcID": "10000",
   "name": "My Kapacitor",
   "url": "http://localhost:9092",
   "active": true,
@@ -191,8 +191,8 @@ Environment variables can be loaded using the `"{{ .VARIABLE_KEY }}"` syntax:
 
 ```JSON
 {
-  "id": 10000,
-  "srcID": 10000,
+  "id": "10000",
+  "srcID": "10000",
   "name": "My Kapacitor",
   "url": "{{ .KAPACITOR_URL }}",
   "active": true,


### PR DESCRIPTION
Tracked at #2329

"Example code for creating a .kap file has ID & srcID as Int but it should be String"

Thanks :)