### PR TITLE
fix an incorrect description in docs since v1.0

### DIFF
--- a/content/influxdb/v1.0/query_language/data_exploration.md
+++ b/content/influxdb/v1.0/query_language/data_exploration.md
@@ -1238,7 +1238,7 @@ time                   count
 ```
 
 The query uses an InfluxQL [function](/influxdb/v1.0/query_language/functions/)
-to calculate the average `water_level`, grouping results into 12 minute
+to count the number of `water_level` points, grouping results into 12 minute
 time intervals, and offsetting the preset time boundaries by six minutes.
 
 The time boundaries and returned timestamps for the query **without** the `offset_interval` adhere to InfluxDB's preset time boundaries. Let's first examine the results without the offset:

--- a/content/influxdb/v1.1/query_language/data_exploration.md
+++ b/content/influxdb/v1.1/query_language/data_exploration.md
@@ -1251,7 +1251,7 @@ time                   count
 ```
 
 The query uses an InfluxQL [function](/influxdb/v1.1/query_language/functions/)
-to calculate the average `water_level`, grouping results into 12 minute
+to count the number of `water_level` points, grouping results into 12 minute
 time intervals, and offsetting the preset time boundaries by six minutes.
 
 The time boundaries and returned timestamps for the query **without** the `offset_interval` adhere to InfluxDB's preset time boundaries. Let's first examine the results without the offset:

--- a/content/influxdb/v1.2/query_language/data_exploration.md
+++ b/content/influxdb/v1.2/query_language/data_exploration.md
@@ -1302,7 +1302,7 @@ time                   count
 ```
 
 The query uses an InfluxQL [function](/influxdb/v1.2/query_language/functions/)
-to calculate the average `water_level`, grouping results into 12 minute
+to count the number of `water_level` points, grouping results into 12 minute
 time intervals, and offsetting the preset time boundaries by six minutes.
 
 The time boundaries and returned timestamps for the query **without** the `offset_interval` adhere to InfluxDB's preset time boundaries. Let's first examine the results without the offset:

--- a/content/influxdb/v1.3/query_language/data_exploration.md
+++ b/content/influxdb/v1.3/query_language/data_exploration.md
@@ -1302,7 +1302,7 @@ time                   count
 ```
 
 The query uses an InfluxQL [function](/influxdb/v1.3/query_language/functions/)
-to calculate the average `water_level`, grouping results into 12 minute
+to count the number of `water_level` points, grouping results into 12 minute
 time intervals, and offsetting the preset time boundaries by six minutes.
 
 The time boundaries and returned timestamps for the query **without** the `offset_interval` adhere to InfluxDB's preset time boundaries. Let's first examine the results without the offset:

--- a/content/influxdb/v1.4/query_language/data_exploration.md
+++ b/content/influxdb/v1.4/query_language/data_exploration.md
@@ -1302,7 +1302,7 @@ time                   count
 ```
 
 The query uses an InfluxQL [function](/influxdb/v1.4/query_language/functions/)
-to calculate the average `water_level`, grouping results into 12 minute
+to count the number of `water_level` points, grouping results into 12 minute
 time intervals, and offsetting the preset time boundaries by six minutes.
 
 The time boundaries and returned timestamps for the query **without** the `offset_interval` adhere to InfluxDB's preset time boundaries. Let's first examine the results without the offset:

--- a/content/influxdb/v1.5/query_language/data_exploration.md
+++ b/content/influxdb/v1.5/query_language/data_exploration.md
@@ -1298,7 +1298,7 @@ time                   count
 ```
 
 The query uses an InfluxQL [function](/influxdb/v1.5/query_language/functions/)
-to calculate the average `water_level`, grouping results into 12 minute
+to count the number of `water_level` points, grouping results into 12 minute
 time intervals, and offsetting the preset time boundaries by six minutes.
 
 The time boundaries and returned timestamps for the query **without** the `offset_interval` adhere to InfluxDB's preset time boundaries. Let's first examine the results without the offset:

--- a/content/influxdb/v1.6/query_language/data_exploration.md
+++ b/content/influxdb/v1.6/query_language/data_exploration.md
@@ -1265,7 +1265,7 @@ time                   count
 ```
 
 The query uses an InfluxQL [function](/influxdb/v1.6/query_language/functions/)
-to calculate the average `water_level`, grouping results into 12 minute
+to count the number of `water_level` points, grouping results into 12 minute
 time intervals, and offsetting the preset time boundaries by six minutes.
 
 The time boundaries and returned timestamps for the query **without** the `offset_interval` adhere to InfluxDB's preset time boundaries. Let's first examine the results without the offset:

--- a/content/influxdb/v1.7/query_language/data_exploration.md
+++ b/content/influxdb/v1.7/query_language/data_exploration.md
@@ -1279,7 +1279,7 @@ time                   count
 ```
 
 The query uses an InfluxQL [function](/influxdb/v1.7/query_language/functions/)
-to calculate the average `water_level`, grouping results into 12 minute
+to count the number of `water_level` points, grouping results into 12 minute
 time intervals, and offsetting the preset time boundaries by six minutes.
 
 The time boundaries and returned timestamps for the query **without** the `offset_interval` adhere to InfluxDB database's preset time boundaries. Let's first examine the results without the offset:


### PR DESCRIPTION
InfluxQL function in this example is `count()`, not `mean()`