### PR TITLE
Update upgrading procedures

### DIFF
--- a/content/enterprise_influxdb/v1.5/administration/upgrading.md
+++ b/content/enterprise_influxdb/v1.5/administration/upgrading.md
@@ -10,7 +10,7 @@ menu:
 
 ## Upgrading to InfluxDB Enterprise 1.5.4
 
-Version 1.5 includes the first official Time Series Index (TSI) release. Although you can install without enabling TSI, you are encouraged to begin leveraging the advantages the TSI disk-based indexing offers.
+Version 1.5 includes the first official Time Series Index (TSI) release. Although you can install without enabling TSI, you are encouraged to begin leveraging the advantages the TSI indexing offers.
 
 ## Upgrading InfluxDB Enterprise 1.3.x-1.5.x clusters to 1.5.4 (rolling upgrade)
 
@@ -178,7 +178,7 @@ The new configuration options are set to the default settings.
 
 2. Convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
 
-  - When TSI is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
+  - When TSI is enabled, new shards use the TSI index. Existing shards must be converted to support TSI.
   - Run the [`influx_inspect buildtsi`](/influxdb/v1.5/tools/influx_inspect#buildtsi) command to convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
 
 > **Note:** Run the `buildtsi` command using the user account that you are going to run the database as,

--- a/content/enterprise_influxdb/v1.6/administration/upgrading.md
+++ b/content/enterprise_influxdb/v1.6/administration/upgrading.md
@@ -140,7 +140,7 @@ sudo yum localinstall influxdb-data-1.6.5_c1.6.5.x86_64.rpm
 ### Step 4: Update the data node configuration file.
 
 > The first official Time Series Index (TSI) was released with InfluxDB v1.5.
-> Although you can install without enabling TSI, you are encouraged to begin leveraging the advantages the TSI disk-based indexing offers.
+> Although you can install without enabling TSI, you are encouraged to begin leveraging the advantages the TSI indexing offers.
 
 **Add:**
 
@@ -194,7 +194,7 @@ The new configuration options are set to the default settings.
 
 2. Convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
 
-  - When TSI is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
+  - When TSI is enabled, new shards use the TSI index. Existing shards must be converted to support TSI.
   - Run the [`influx_inspect buildtsi`](/influxdb/v1.6/tools/influx_inspect#buildtsi) command to convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
 
 > **Note:** Run the `buildtsi` command using the user account that you are going to run the database as,

--- a/content/enterprise_influxdb/v1.7/administration/upgrading.md
+++ b/content/enterprise_influxdb/v1.7/administration/upgrading.md
@@ -179,9 +179,11 @@ For more information about TSI, see [TSI overview](/influxdb/v1.7/concepts/time-
 
 Complete the following steps for Time Series Index (TSI) only.
 
-1. Delete all existing TSM-based shard `index` directories (by default, the `index` directories are located at `/<shard_ID>/index`).
+1. Delete all `_series` directories in the `/data` directory (by default, stored at `/data/<dbName>/_series`).
 
-2. If TSI is enabled, TSM-based shards must be converted to support TSI. Run the [`influx_inspect buildtsi`](/influxdb/v1.7/tools/influx_inspect#buildtsi)command to covert TSM-based shards to TSI shards or rebuild existing TSI shards.
+2. Delete all TSM-based shard `index` directories (by default, located at `/data/<dbName/<rpName>/<shardID>/index`).
+
+3. Use the [`influx_inspect buildtsi`](/influxdb/v1.7/tools/influx_inspect#buildtsi) utility to rebuild the TSI index. For example, run the following command: `influx_inspect buildtsi -datadir /yourDataDirectory -waldir /wal`, replacing `yourDataDirectory` with the name of your directory. Running this command converts TSM-based shards to TSI shards or rebuilds existing TSI shards.
 
     > **Note:** Run the `buildtsi` command using the user account that you are going to run the database as, or ensure that the permissions match afterward.
 
@@ -204,6 +206,8 @@ sudo systemctl restart influxdb
 ### Restart traffic to data nodes
 
 Restart routing read and write requests to the data node server (port 8086) through your load balancer.
+
+> **Note** Allow the hinted handoff queue (HHQ) to write all missed data to the updated node before upgrading the next data node.
 
 ### Confirm the data nodes upgrade
 

--- a/content/enterprise_influxdb/v1.7/administration/upgrading.md
+++ b/content/enterprise_influxdb/v1.7/administration/upgrading.md
@@ -15,14 +15,12 @@ To successfully upgrade InfluxDB Enterprise clusters to 1.7.7, complete the foll
 2. [Upgrade meta nodes](#upgrade-meta-nodes).
 3. [Upgrade data nodes](#upgrade-data-nodes).
 
-   > ***Note:*** To enable HTTPS, you must update the configuration files on each meta node (`influxdb-meta.conf`) and each data node (`influxdb.conf`). Details included in procedures below.
-
 ## Back up your cluster
 
 Before performing an upgrade, create a full backup of your InfluxDB Enterprise cluster. Also, if you create incremental backups, trigger a final incremental backup.
 
 > ***Note:*** For information on performing a final incremental backup or a full backup,
-> see [Backing up and restoring in InfluxDB Enterprise](/enterprise_influxdb/v1.7/administration/backup-and-restore/).
+> see [Back up and restore InfluxDB Enterprise clusters](/enterprise_influxdb/v1.7/administration/backup-and-restore/).
 
 ## Upgrade meta nodes
 
@@ -64,6 +62,8 @@ sudo yum localinstall influxdb-meta-1.7.7_c1.7.7.x86_64.rpm
 ```
 
 ### Update the meta node configuration file
+
+Migrate any custom settings from your previous meta node configuration file.
 
 To enable HTTPS, you must update the meta node configuration file (`influxdb-meta.conf`). For information, see [Enable HTTPS within the configuration file for each Meta Node](/enterprise_influxdb/v1.7/guides/https_setup/#step-3-enable-https-within-the-configuration-file-for-each-meta-node).
 
@@ -173,7 +173,7 @@ Migrate any custom settings from your previous data node configuration file.
     |[`[anti-entropy]`](/enterprise_influxdb/v1.7/administration/config-data-nodes#anti-entropy)| <ul><li>Add `enabled = true` <li>Add `check-interval = "30s"` <li>Add `max-fetch = 10`|
     |`[admin]`| Remove entire section.|
 
-For more information about TSI, see [TSI overview](/influxdb/v1.7/concepts/time-series-index/) and [TSI details](/influxdb/v1.7/concepts/tsi-details/).
+    For more information about TSI, see [TSI overview](/influxdb/v1.7/concepts/time-series-index/) and [TSI details](/influxdb/v1.7/concepts/tsi-details/).
 
 ### Prepare your data node to support TSI
 
@@ -183,9 +183,15 @@ Complete the following steps for Time Series Index (TSI) only.
 
 2. Delete all TSM-based shard `index` directories (by default, located at `/data/<dbName/<rpName>/<shardID>/index`).
 
-3. Use the [`influx_inspect buildtsi`](/influxdb/v1.7/tools/influx_inspect#buildtsi) utility to rebuild the TSI index. For example, run the following command: `influx_inspect buildtsi -datadir /yourDataDirectory -waldir /wal`, replacing `yourDataDirectory` with the name of your directory. Running this command converts TSM-based shards to TSI shards or rebuilds existing TSI shards.
+3. Use the [`influx_inspect buildtsi`](/influxdb/v1.7/tools/influx_inspect#buildtsi) utility to rebuild the TSI index. For example, run the following command:
 
-    > **Note:** Run the `buildtsi` command using the user account that you are going to run the database as, or ensure that the permissions match afterward.
+    ```js
+    influx_inspect buildtsi -datadir /yourDataDirectory -waldir /wal`
+    ``` 
+
+    Replacing `yourDataDirectory` with the name of your directory. Running this command converts TSM-based shards to TSI shards or rebuilds existing TSI shards.
+
+    > **Note:** Run the `buildtsi` command using the same system user that runs the `influxd` service, or a user with the same permissions.
 
 ### Restart the `influxdb` service
 
@@ -207,7 +213,7 @@ sudo systemctl restart influxdb
 
 Restart routing read and write requests to the data node server (port 8086) through your load balancer.
 
-> **Note** Allow the hinted handoff queue (HHQ) to write all missed data to the updated node before upgrading the next data node.
+> **Note:** Allow the hinted handoff queue (HHQ) to write all missed data to the updated node before upgrading the next data node. To review in-progress operations in the hinted handoff queue, run [`copy-shard-status`](/enterprise_influxdb/v1.7/administration/cluster-commands/#copy-shard-status).
 
 ### Confirm the data nodes upgrade
 

--- a/content/enterprise_influxdb/v1.7/administration/upgrading.md
+++ b/content/enterprise_influxdb/v1.7/administration/upgrading.md
@@ -9,24 +9,33 @@ menu:
     parent: Administration
 ---
 
-## Upgrading InfluxDB Enterprise 1.3.x-1.7.x clusters to 1.7.7 (rolling upgrade)
+To successfully upgrade InfluxDB Enterprise clusters to 1.7.7, complete the following steps:
 
-### Step 0: Back up your cluster before upgrading to version 1.7.7.
+1. [Back up your cluster](#back-up-your-cluster).
+2. [Upgrade meta nodes](#upgrade-meta-nodes).
+3. [Upgrade data nodes](#upgrade-data-nodes).
 
-Create a full backup of your InfluxDB Enterprise cluster before performing an upgrade.
-If you have incremental backups created as part of your standard operating procedures, make sure to
-trigger a final incremental backup before proceeding with the upgrade.
+   > ***Note:*** To enable HTTPS, you must update the configuration files on each meta node (`influxdb-meta.conf`) and each data node (`influxdb.conf`). Details included in procedures below.
+
+## Back up your cluster
+
+Before performing an upgrade, create a full backup of your InfluxDB Enterprise cluster. Also, if you create incremental backups, trigger a final incremental backup.
 
 > ***Note:*** For information on performing a final incremental backup or a full backup,
 > see [Backing up and restoring in InfluxDB Enterprise](/enterprise_influxdb/v1.7/administration/backup-and-restore/).
 
-## Upgrading meta nodes
+## Upgrade meta nodes
 
-Follow these steps to upgrade all meta nodes in your InfluxDB Enterprise cluster. Ensure that the meta cluster is healthy before proceeding to the data nodes.
+Complete the following steps to upgrade meta nodes:
 
-### Step 1: Download the 1.7.7 meta node package
+1. [Download the meta node package](#download-the-meta-node-package).
+2. [Install the meta node package](#install-the-meta-node-package).
+3. [Update the meta node configuration file](#update-the-meta-node-configuration-file).
+4. [Restart the `influxdb-meta` service](#restart-the-influxdb-meta-service).
+5. Repeat steps 1-4 for each meta node in your cluster.
+6. [Confirm the meta nodes upgrade](#confirm-the-meta-nodes-upgrade).
 
-#### Meta node package download
+### Download the meta node package
 
 ##### Ubuntu and Debian (64-bit)
 
@@ -40,9 +49,7 @@ wget https://dl.influxdata.com/enterprise/releases/influxdb-meta_1.7.7-c1.7.7_am
 wget https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.7.7_c1.7.7.x86_64.rpm
 ```
 
-### Step 2: Install the 1.7.7 meta nodes package
-
-#### Meta node package install
+### Install the meta node package
 
 ##### Ubuntu and Debian (64-bit)
 
@@ -56,15 +63,11 @@ sudo dpkg -i influxdb-meta_1.7.7-c1.7.7_amd64.deb
 sudo yum localinstall influxdb-meta-1.7.7_c1.7.7.x86_64.rpm
 ```
 
-### Step 3: Update the meta node configuration file
+### Update the meta node configuration file
 
-Migrate any custom settings from your previous meta node configuration file.
+To enable HTTPS, you must update the meta node configuration file (`influxdb-meta.conf`). For information, see [Enable HTTPS within the configuration file for each Meta Node](/enterprise_influxdb/v1.7/guides/https_setup/#step-3-enable-https-within-the-configuration-file-for-each-meta-node).
 
-To enable HTTPS, see [Enable HTTPS within the configuration file for each Meta Node](/enterprise_influxdb/v1.7/guides/https_setup/#step-3-enable-https-within-the-configuration-file-for-each-meta-node).
-
-### Step 4: Restart the `influxdb-meta` service
-
-#### Meta node restart
+### Restart the `influxdb-meta` service
 
 ##### sysvinit systems
 
@@ -78,9 +81,9 @@ service influxdb-meta restart
 sudo systemctl restart influxdb-meta
 ```
 
-### Step 5: Confirm the upgrade
+### Confirm the meta nodes upgrade
 
-After performing the upgrade on ALL meta nodes, check your node version numbers using the
+After upgrading _**all**_ meta nodes, check your node version numbers using the
 `influxd-ctl show` command.
 The [`influxd-ctl` utility](/enterprise_influxdb/v1.7/administration/cluster-commands/) is available on all meta nodes.
 
@@ -102,13 +105,23 @@ rk-upgrading-02:8091	1.7.7_c1.7.7
 rk-upgrading-03:8091	1.7.7_c1.7.7
 ```
 
-## Upgrading data nodes
+Ensure that the meta cluster is healthy before upgrading the data nodes.
 
-Repeat the following steps for each data node in your InfluxDB Enterprise cluster.
+## Upgrade data nodes
 
-### Step 1: Download the 1.7.7 data node package
+Complete the following steps to upgrade data nodes:
 
-#### Data node package download
+1. [Download the data node package](#download-the-data-node-package).
+2. [Stop traffic to data nodes](#stop-traffic-to-data-nodes).
+3. [Install the data node package](#install-the-data-node-package).
+4. [Update the data node configuration file](#update-the-data-node-configuration-file).
+5. For Time Series Index (TSI) only. [Prepare your data node to support TSI](#prepare-your-data-node-to-support-tsi).
+6. [Restart the `influxdb` service](#restart-the-influxdb-service).
+7. [Restart traffic to data nodes](#restart-traffic-to-data-nodes).
+8. Repeat steps 1-7 for each data node in your cluster.
+9. [Confirm the data nodes upgrade](#confirm-the-data-nodes-upgrade).
+
+### Download the data node package
 
 ##### Ubuntu and Debian (64-bit)
 
@@ -122,21 +135,16 @@ wget https://dl.influxdata.com/enterprise/releases/influxdb-data_1.7.7-c1.7.7_am
 wget https://dl.influxdata.com/enterprise/releases/influxdb-data-1.7.7_c1.7.7.x86_64.rpm
 ```
 
-### Step 2: Stop traffic to the data node
+### Stop traffic to the data node
 
-Your cluster's load balancer distributes read and write requests among data nodes in the cluster. If you have access to the load balancer configuration, stop routing read and write requests to the data node server (port 8086) via your load balancer **before** performing the remaining steps.
+- If you have access to the load balancer configuration, use your load balancer to stop routing read and write requests to the data node server (port 8086).
 
-If you cannot access the load balancer configuration, work with your networking team to prevent traffic to the data node server before continuing to upgrade.
+- If you cannot access the load balancer configuration, work with your networking team to prevent traffic to the data node server before continuing to upgrade.
 
-### Step 3: Install the 1.7.7 data node packages
+### Install the data node package
 
-#### Data node package install
+When you run the install command, you're prompted to keep or overwrite your current configuration file with the file for version 1.7.7. Enter `N` or `O` to keep your current configuration file. You'll make the configuration changes for version 1.7.7. in the next procedure, [Update the data node configuration file](#update-the-data-node-configuration-file).
 
-When you run the install command, your terminal asks if you want to keep your
-current configuration file or overwrite your current configuration file with the file for version 1.7.7.
-
-Keep your current configuration file by entering `N` or `O`.
-The configuration file will be updated with the necessary changes for version 1.7.7 in the next step.
 
 ##### Ubuntu and Debian (64-bit)
 
@@ -150,65 +158,36 @@ sudo dpkg -i influxdb-data_1.7.7-c1.7.7_amd64.deb
 sudo yum localinstall influxdb-data-1.7.7_c1.7.7.x86_64.rpm
 ```
 
-### Step 4: Update the data node configuration file
+### Update the data node configuration file
 
 Migrate any custom settings from your previous data node configuration file.
 
-To enable either HTTPS or Time Series Index (TSI), update the data node configuration file (`influxdb.conf`).
-
-#### To enable HTTPS
-
 - To enable HTTPS, see [Enable HTTPS within the configuration file for each Data Node](https://docs.influxdata.com/enterprise_influxdb/v1.7/guides/https_setup/#step-4-enable-https-within-the-configuration-file-for-each-data-node).
 
-#### To enable Time Series Index (TSI)
+- To enable TSI, open `/etc/influxdb/influxdb.conf`, and then adjust and save the settings shown in the following table.
 
-> The first official Time Series Index (TSI) was released with InfluxDB v1.5.
-> Although you can install without enabling TSI, you are encouraged to begin leveraging the advantages the TSI disk-based indexing offers.
+    | Section | Setting                                                   |
+    | --------| ----------------------------------------------------------|
+    | `[data]` |  <ul><li>To use Time Series Index (TSI) disk-based indexing, add [`index-version = "tsi1"`](/enterprise_influxdb/v1.7/administration/config-data-nodes#index-version-inmem) <li>To use TSM in-memory index, add [`index-version = "inmem"`](/enterprise_influxdb/v1.7/administration/config-data-nodes#index-version-inmem) <li>Add [`wal-fsync-delay = "0s"`](/enterprise_influxdb/v1.7/administration/config-data-nodes#wal-fsync-delay-0s) <li>Add [`max-concurrent-compactions = 0`](/enterprise_influxdb/v1.7/administration/config-data-nodes#max-concurrent-compactions-0)<li>Set[`cache-max-memory-size`](/enterprise_influxdb/v1.7/administration/config-data-nodes#cache-max-memory-size-1g) to `1073741824` |
+    | `[cluster]`| <ul><li>Add [`pool-max-idle-streams = 100`](/enterprise_influxdb/v1.7/administration/config-data-nodes#pool-max-idle-streams-100) <li>Add[`pool-max-idle-time = "1m0s"`](/enterprise_influxdb/v1.7/administration/config-data-nodes#pool-max-idle-time-60s) <li>Remove `max-remote-write-connections` 
+    |[`[anti-entropy]`](/enterprise_influxdb/v1.7/administration/config-data-nodes#anti-entropy)| <ul><li>Add `enabled = true` <li>Add `check-interval = "30s"` <li>Add `max-fetch = 10`|
+    |`[admin]`| Remove entire section.|
 
-**Add:**
+For more information about TSI, see [TSI overview](/influxdb/v1.7/concepts/time-series-index/) and [TSI details](/influxdb/v1.7/concepts/tsi-details/).
 
-* If enabling TSI: [index-version = "tsi1"](/enterprise_influxdb/v1.7/administration/config-data-nodes#index-version-inmem) to the `[data]` section.
-* If not enabling TSI: [index-version = "inmem"](/enterprise_influxdb/v1.7/administration/config-data-nodes#index-version-inmem) to the `[data]` section.
-  * Use 'tsi1' for the Time Series Index (TSI); set the value to `inmem` to use the TSM in-memory index.
-* [wal-fsync-delay = "0s"](/enterprise_influxdb/v1.7/administration/config-data-nodes#wal-fsync-delay-0s) to the `[data]` section
-* [max-concurrent-compactions = 0](/enterprise_influxdb/v1.7/administration/config-data-nodes#max-concurrent-compactions-0) to the `[data]` section
-* [pool-max-idle-streams = 100](/enterprise_influxdb/v1.7/administration/config-data-nodes#pool-max-idle-streams-100) to the `[cluster]` section
-* [pool-max-idle-time = "1m0s"](/enterprise_influxdb/v1.7/administration/config-data-nodes#pool-max-idle-time-60s) to the `[cluster]` section
-* the [[anti-entropy]](/enterprise_influxdb/v1.7/administration/config-data-nodes#anti-entropy) section:
+### Prepare your data node to support TSI
 
-```toml
-[anti-entropy]
-  enabled = true
-  check-interval = "30s"
-  max-fetch = 10
-```
+Complete the following steps for Time Series Index (TSI) only.
 
-**Remove:**
+1. Delete all existing TSM-based shard `index` directories (by default, the `index` directories are located at `/<shard_ID>/index`).
 
-* `max-remote-write-connections` from the `[cluster]` section
-* `[admin]` section
+2. If TSI is enabled, TSM-based shards must be converted to support TSI. Run the [`influx_inspect buildtsi`](/influxdb/v1.7/tools/influx_inspect#buildtsi)command to covert TSM-based shards to TSI shards or rebuild existing TSI shards.
 
-**Update:**
+    > **Note:** Run the `buildtsi` command using the user account that you are going to run the database as, or ensure that the permissions match afterward.
 
-* [cache-max-memory-size](/enterprise_influxdb/v1.7/administration/config-data-nodes#cache-max-memory-size-1g) to `1073741824` in the `[data]` section
+### Restart the `influxdb` service
 
-The new configuration options are set to the default settings.
-
-### Step 5: [For TSI Preview instances only] Prepare your node to support Time Series Index (TSI).
-
-1. Delete all existing TSM-based shard `index` directories (by default, located at `/<shard_ID>/index` for example, `/2/index`).
-
-2. Convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
-
-  - When TSI is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
-  - Run the [`influx_inspect buildtsi`](/influxdb/v1.7/tools/influx_inspect#buildtsi) command to convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
-
-> **Note:** Run the `buildtsi` command using the user account that you are going to run the database as,
-> or ensure that the permissions match afterward.
-
-### Step 6: Restart the `influxdb` service.
-
-#### Restart data node
+Restart the `influxdb` service to restart the data nodes.
 
 ##### sysvinit systems
 
@@ -222,18 +201,15 @@ service influxdb restart
 sudo systemctl restart influxdb
 ```
 
-### Step 7: Restart traffic to data node 
+### Restart traffic to data nodes
 
 Restart routing read and write requests to the data node server (port 8086) through your load balancer.
 
-If this is the last data node to be upgraded, continue to the next step.
-Otherwise, return to Step 1 of [Upgrading data nodes](#upgrading-data-nodes) and repeat the process for the remaining data nodes.
+### Confirm the data nodes upgrade
 
-### Step 8: Confirm the upgrade
-
-Your cluster is now upgraded to InfluxDB Enterprise 1.7.7.
-Check your node version numbers using the `influxd-ctl show` command.
-The [`influxd-ctl`](/enterprise_influxdb/v1.7/administration/cluster-commands/) utility is available on all meta nodes.
+After upgrading _**all**_ data nodes, check your node version numbers using the
+`influxd-ctl show` command.
+The [`influxd-ctl` utility](/enterprise_influxdb/v1.7/administration/cluster-commands/) is available on all meta nodes.
 
 ```bash
 ~# influxd-ctl show

--- a/content/enterprise_influxdb/v1.7/administration/upgrading.md
+++ b/content/enterprise_influxdb/v1.7/administration/upgrading.md
@@ -196,10 +196,7 @@ The new configuration options are set to the default settings.
 
 ### Step 5: [For TSI Preview instances only] Prepare your node to support Time Series Index (TSI).
 
-1. Delete all existing TSM-based shard `index` directories.
-
-  - Remove the existing `index` directories to ensure there are no incompatible index files.
-  - By default, the `index` directories are located at `/<shard_ID>/index` (e.g., `/2/index`).
+1. Delete all existing TSM-based shard `index` directories (by default, located at `/<shard_ID>/index` for example, `/2/index`).
 
 2. Convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
 

--- a/content/enterprise_influxdb/v1.7/administration/upgrading.md
+++ b/content/enterprise_influxdb/v1.7/administration/upgrading.md
@@ -198,13 +198,13 @@ The new configuration options are set to the default settings.
 
 1. Delete all existing TSM-based shard `index` directories.
 
-* Remove the existing `index` directories to ensure there are no incompatible index files.
-* By default, the `index` directories are located at `/<shard_ID>/index` (e.g., `/2/index`).
+  - Remove the existing `index` directories to ensure there are no incompatible index files.
+  - By default, the `index` directories are located at `/<shard_ID>/index` (e.g., `/2/index`).
 
 2. Convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
 
-* When TSI is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
-* Run the [`influx_inspect buildtsi`](/influxdb/v1.7/tools/influx_inspect#buildtsi) command to convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
+  - When TSI is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
+  - Run the [`influx_inspect buildtsi`](/influxdb/v1.7/tools/influx_inspect#buildtsi) command to convert existing TSM-based shards (or rebuild TSI Preview shards) to support TSI.
 
 > **Note:** Run the `buildtsi` command using the user account that you are going to run the database as,
 > or ensure that the permissions match afterward.

--- a/content/enterprise_influxdb/v1.7/administration/upgrading.md
+++ b/content/enterprise_influxdb/v1.7/administration/upgrading.md
@@ -213,7 +213,7 @@ sudo systemctl restart influxdb
 
 Restart routing read and write requests to the data node server (port 8086) through your load balancer.
 
-> **Note:** Allow the hinted handoff queue (HHQ) to write all missed data to the updated node before upgrading the next data node. To review in-progress operations in the hinted handoff queue, run [`copy-shard-status`](/enterprise_influxdb/v1.7/administration/cluster-commands/#copy-shard-status).
+> **Note:** Allow the hinted handoff queue (HHQ) to write all missed data to the updated node before upgrading the next data node. Once all data has been written, the disk space used in the hinted handoff queue should be 0. Check the disk space on your hh directory by running the [`du`] command, for example, `du /var/lib/influxdb/hh`.
 
 ### Confirm the data nodes upgrade
 

--- a/content/influxdb/v1.5/administration/upgrading.md
+++ b/content/influxdb/v1.5/administration/upgrading.md
@@ -81,7 +81,7 @@ Follow these steps to upgrade an earlier InfluxDB instance (versions 1.3 and 1.4
 
 5. Convert existing shards to support TSI.
 
-  - When Time Series Index (TSI) is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
+  - When Time Series Index (TSI) is enabled, new shards use the TSI index. Existing shards must be converted to support TSI.
   - Run the [influx_inspect buildtsi](/influxdb/v1.5/tools/influx_inspect/#influx-inspect-buildtsi) command to convert existing TSM-based shards to TSI-based shards.
 
 5. Restart the `influxdb` service.
@@ -102,9 +102,9 @@ Follow these steps to upgrade an earlier InfluxDB instance (versions 1.0 to 1.4)
 5. Restart the `influxdb` service.
 
 
-## Switching between TSM in-memory and TSI disk-based indexes
+## Switching between TSM and TSI indexes
 
-After installing and upgrading to InfluxDB 1.5, you can switch between using the TSM in-memory index and the TSI disk-based index if needed.
+After installing and upgrading to InfluxDB 1.5, you can switch between using the TSM index and the TSI index if needed.
 
 ### Switching from in-memory (TSM-based) index to disk (TSI-based) index:
 

--- a/content/influxdb/v1.5/tools/influx_inspect.md
+++ b/content/influxdb/v1.5/tools/influx_inspect.md
@@ -11,7 +11,7 @@ Influx Inspect is an InfluxDB disk utility that can be used to:
 
 * View detailed information about disk shards.
 * Exporting data from a shard to [line protocol](/influxdb/v1.5/concepts/glossary/#line-protocol) that can be inserted back into the database.
-* Converting TSM in-memory index shards to TSI disk-based shards.
+* Converting TSM index shards to TSI shards.
 
 ## `influx_inspect` utility
 

--- a/content/influxdb/v1.6/administration/upgrading.md
+++ b/content/influxdb/v1.6/administration/upgrading.md
@@ -82,7 +82,7 @@ Follow these steps to upgrade an earlier InfluxDB instance (versions 1.3 and 1.4
 
 5. Convert existing shards to support TSI.
 
--   When Time Series Index (TSI) is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
+-   When Time Series Index (TSI) is enabled, new shards use the TSI index. Existing shards must be converted to support TSI.
 -   Run the [influx_inspect buildtsi](/influxdb/v1.6/tools/influx_inspect/#buildtsi) command to convert existing TSM-based shards to TSI-based shards.
 
 5. Restart the `influxdb` service.
@@ -102,17 +102,17 @@ Follow these steps to upgrade an earlier InfluxDB instance (versions 1.0 to 1.4)
 
 5. Restart the `influxdb` service.
 
-## Switching between TSM in-memory and TSI disk-based indexes
+## Switching between TSM and TSI indexes
 
-After installing and upgrading to InfluxDB 1.6, you can switch between using the TSM in-memory index and the TSI disk-based index if needed.
+After installing and upgrading to InfluxDB 1.6, you can switch between using the TSM index and the TSI index if needed.
 
-### Switching from in-memory (TSM-based) index to disk (TSI-based) index:
+### Switching from TSM index to TSI index:
 
 1. Enable TSI.
 2. Convert TSM-based shards to TSI-based shards.
 3. Restart the `influxdb` service.
 
-### Switching from disk (TSI-based) index to in-memory (TSM-based) index:
+### Switching from disk TSI index to TSM index:
 
 1. Enable `inmem`.
 2. Delete all shard `index` directories.

--- a/content/influxdb/v1.6/tools/influx_inspect.md
+++ b/content/influxdb/v1.6/tools/influx_inspect.md
@@ -11,7 +11,7 @@ Influx Inspect is an InfluxDB disk utility that can be used to:
 
 * View detailed information about disk shards.
 * Exporting data from a shard to [line protocol](/influxdb/v1.6/concepts/glossary/#line-protocol) that can be inserted back into the database.
-* Converting TSM in-memory index shards to TSI disk-based index shards.
+* Converting TSM index shards to TSI index shards.
 
 ## `influx_inspect` utility
 

--- a/content/influxdb/v1.7/administration/upgrading.md
+++ b/content/influxdb/v1.7/administration/upgrading.md
@@ -9,10 +9,10 @@ menu:
 ---
 
 
-We recommend enabling Time Series Index (TSI). To learn more about TSI, see:
+We recommend enabling Time Series Index (TSI) (step 3 of Upgrade to InfluxDB 1.7.x). [Switch between TSM and TSI](#switch-between-tsm-and-tsi-indexes) as needed. To learn more about TSI, see:
 
--   [Time Series Index (TSI) overview](/influxdb/v1.7/concepts/time-series-index/)
--   [Time Series Index (TSI) details](/influxdb/v1.7/concepts/tsi-details/)
+- [Time Series Index (TSI) overview](/influxdb/v1.7/concepts/time-series-index/)
+- [Time Series Index (TSI) details](/influxdb/v1.7/concepts/tsi-details/)
 
 > **_Note:_** The default configuration continues to use TSM-based shards with in-memory indexes (as in earlier versions).
 
@@ -38,13 +38,13 @@ We recommend enabling Time Series Index (TSI). To learn more about TSI, see:
 
 ## Switch between TSM and TSI indexes
 
-After upgrading to InfluxDB 1.7.x, switch between using the TSM in-memory index and the TSI disk-based index as needed.
+After upgrading to InfluxDB 1.7.x, switch between using the TSM index and the TSI index as needed.
 
-### Switch from TSM to TSI
+### To switch from TSM to TSI
 
-Complete step 3 and 4 in the previous procedure.
+Complete step 3 and 4 in [Upgrade to InfluxDB 1.7.x](#upgrade-to-influxdb-1-7-x).
 
-### Switch from TSI to TSM
+### To switch from TSI to TSM
 
 1. In the InfluxDB configuration file, set `index-version = "inmem"`. 
 2. Delete all shard `index` directories (by default, located at `/<shard_ID>/index`).

--- a/content/influxdb/v1.7/administration/upgrading.md
+++ b/content/influxdb/v1.7/administration/upgrading.md
@@ -114,4 +114,4 @@ After installing and upgrading to InfluxDB 1.7.x, you can switch between using t
 
 ## Upgrading InfluxDB Enterprise clusters
 
-See [Upgrading InfluxDB Enterprise clusters](/enterprise_influxdb/v1.6/administration/upgrading/).
+See [Upgrading InfluxDB Enterprise clusters](/enterprise_influxdb/v1.7/administration/upgrading/).

--- a/content/influxdb/v1.7/administration/upgrading.md
+++ b/content/influxdb/v1.7/administration/upgrading.md
@@ -8,110 +8,48 @@ menu:
         parent: Administration
 ---
 
--   [Upgrading InfluxDB 1.3 / 1.4 (no TSI Preview) to 1.7.x (TSI enabled)](#upgrading-influxdb-1-3-1-4-no-tsi-preview-to-1-7-x-tsi-enabled)
--   [Upgrading InfluxDB 1.3 - 1.4 (TSI Preview enabled) to 1.7.x (TSI enabled)](#upgrading-influxdb-1-3-1-4-tsi-preview-enabled-to-1-7-x-tsi-enabled)
--   [Upgrading InfluxDB 1.0 - 1.4 to 1.7.x](#upgrading-influxdb-1-0-1-4-to-1-7-x)
--   [Upgrading InfluxDB Enterprise clusters](#upgrading-influxdb-enterprise-clusters)
 
-## Upgrading InfluxDB 1.3 / 1.4 (no TSI Preview) to 1.7.x (TSI enabled)
-
-Starting with the InfluxDB 1.6 release, enabling Time Series Index (TSI) is recommended for all customers. To learn more about TSI, see:
+We recommend enabling Time Series Index (TSI). To learn more about TSI, see:
 
 -   [Time Series Index (TSI) overview](/influxdb/v1.7/concepts/time-series-index/)
 -   [Time Series Index (TSI) details](/influxdb/v1.7/concepts/tsi-details/)
 
-The upgrade steps below guide you in upgrading InfluxDB OSS and InfluxDB Enterprise, enabling TSI functionality.
+> **_Note:_** The default configuration continues to use TSM-based shards with in-memory indexes (as in earlier versions).
 
-> **_Note:_** For the InfluxDB 1.7 release, the default continues to use TSM-based shards as in earlier versions, with in-memory indexes.
+## Upgrade to InfluxDB 1.7.x
 
-**To upgrade from 1.4 (no TSI Preview) to 1.7.x (TSI enabled):**
+1. [Download](https://portal.influxdata.com/downloads) InfluxDB version 1.7.x and [install the upgrade](/influxdb/v1.7/introduction/installation).
 
-Follow these steps to upgrade an earlier InfluxDB instance (versions 1.0 to 1.4) that did not enable the TSI Preview to an InfluxDB 1.7.x instance with Time Series Index (TSI) enabled.
+2. Migrate configuration file customizations from your existing configuration file to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/). Add or modify your environment variables as needed.
 
-1. [Download](https://portal.influxdata.com/downloads) InfluxDB version 1.7.x and install the upgrade.
+3. To enable TSI in InfluxDB 1.7.x, complete the following steps:
 
-2. Update your InfluxDB configuration.
+    a. If using the InfluxDB configuration file, find the `[data]` section, uncomment `index-version = "inmem"` and change the value to `tsi1`.
 
-    -   If using the InfluxDB configuration file, migrate your InfluxDB configuration file customizations to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/).
-    -   Add, or modify, your environment variables.
+    b. If using environment variables, set `INFLUXDB_DATA_INDEX_VERSION` to `tsi1`.
 
-    -   Migrate configuration file customizations in your InfluxDB 1.4 configuration file to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/)
-    -  Add environment variables, if desired.
+    c. Delete shard `index` directories (by default, located at `/<shard_ID>/index`).
 
-3. Enable the Time Series Index (TSI).
+    d. Convert TSM-based shards to TSI-based shards by running the [influx_inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi) command.
 
-    -   If using the InfluxDB configuration file, find the `[data]` section, uncomment `index-version = "inmem"` and change the value to `tsi1`.
+    > **Note** Run the buildtsi command using the user account that you are going to run the database as, or ensure that the permissions match afterward.
 
-    -   If using environment variables, set `INFLUXDB_DATA_INDEX_VERSION` to `tsi1`.
+4. Restart the `influxdb` service.
 
-4. Convert existing TSM-based shards to TSI-supported shards.
+## Switch between TSM and TSI indexes
 
-    -   Use [influx_inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi) for converting your TSM-based shards to TSI-based shards.
+After upgrading to InfluxDB 1.7.x, switch between using the TSM in-memory index and the TSI disk-based index as needed.
 
-5. Restart the `influxdb` service.
+### Switch from TSM to TSI
 
-## Upgrading InfluxDB 1.3 - 1.4 (TSI Preview enabled) to 1.7.x (TSI enabled)
+Complete step 3 and 4 in the previous procedure.
 
-Follow these steps to upgrade an earlier InfluxDB instance (versions 1.3 and 1.4) that had the TSI Preview enabled to an InfluxDB 1.7 instance with Time Series Index (TSI) enabled.
+### Switch from TSI to TSM
 
-1. [Download](https://portal.influxdata.com/downloads) InfluxDB version
-   1.7.x and install the upgrade.
-
-2. Update your InfluxDB configuration.
-
-    -   If using the InfluxDB configuration file, migrate your InfluxDB configuration file customizations to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/).
-    -   Add, or modify, your environment variables.
-
-3. Enable the Time Series Index (TSI).
-
-    -   If using the InfluxDB configuration file, find the `[data]` section, uncomment `index-version = "inmem"`, and change the value to `tsi1`. Example: `index-version = "tsi1"`
-
-    -   If using an environment variable, set `INFLUXDB_DATA_INDEX_VERSION` to `tsi1`. Example: `export INFLUXDB_DATA_INDEX_VERSION=tsi1`
-
-4. Delete all existing TSM-based shard `index` directories.
-
-    -   Removing the existing index directories ensures there are no incompatible index files.
-    -   By default, the index directories are located at `/<shard_ID>/index`.
-        Example: `/2/index`
-
-5. Convert existing shards to support TSI.
-
-    -   When Time Series Index (TSI) is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
-    -   Run the [influx_inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi) command to convert existing TSM-based shards to TSI-based shards.
-
-5. Restart the `influxdb` service.
-
-## Upgrading InfluxDB 1.0 - 1.4 to 1.7.x
-
-Follow these steps to upgrade an earlier InfluxDB instance (versions 1.0 to 1.4) using the default TSM in-memory indexing to an InfluxDB 1.7.x instance.
-
-1. [Download](https://portal.influxdata.com/downloads) InfluxDB 1.7.x.
-
-2. [Install](/influxdb/v1.7/introduction/installation) InfluxDB 1.7.x.
-
-3. Update your InfluxDB configuration.
-
-    -   If using the InfluxDB configuration file, migrate your InfluxDB configuration file customizations to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/).
-    -   Add, or modify, your environment variables.
-
-5. Restart the `influxdb` service.
-
-## Switching between TSM in-memory and TSI disk-based indexes
-
-After installing and upgrading to InfluxDB 1.7.x, you can switch between using the TSM in-memory index and the TSI disk-based index if needed.
-
-### Switching from in-memory (TSM-based) index to disk (TSI-based) index:
-
-1. Enable TSI.
-2. Convert TSM-based shards to TSI-based shards.
+1. In the InfluxDB configuration file, set `index-version = "inmem"`. 
+2. Delete all shard `index` directories (by default, located at `/<shard_ID>/index`).
 3. Restart the `influxdb` service.
 
-### Switching from disk (TSI-based) index to in-memory (TSM-based) index:
-
-1. Enable `inmem`.
-2. Delete all shard `index` directories.
-3. Restart the `influxdb` service.
-
-## Upgrading InfluxDB Enterprise clusters
+## Upgrade InfluxDB Enterprise clusters
 
 See [Upgrading InfluxDB Enterprise clusters](/enterprise_influxdb/v1.7/administration/upgrading/).

--- a/content/influxdb/v1.7/administration/upgrading.md
+++ b/content/influxdb/v1.7/administration/upgrading.md
@@ -32,24 +32,21 @@ Follow these steps to upgrade an earlier InfluxDB instance (versions 1.0 to 1.4)
 
 2. Update your InfluxDB configuration.
 
--   If using the InfluxDB configuration file, migrate your InfluxDB configuration file customizations to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/).
--   Add, or modify, your environment variables.
+    -   If using the InfluxDB configuration file, migrate your InfluxDB configuration file customizations to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/).
+    -   Add, or modify, your environment variables.
 
-*   Migrate configuration file customizations in your InfluxDB 1.4 configuration file to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/)
-*   Add environment variables, if desired.
+    -   Migrate configuration file customizations in your InfluxDB 1.4 configuration file to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/)
+    -  Add environment variables, if desired.
 
 3. Enable the Time Series Index (TSI).
 
--   If using the InfluxDB configuration file, find the `[data]` section, uncomment `index-version = "inmem"' and change the value to`tsi1`.
+    -   If using the InfluxDB configuration file, find the `[data]` section, uncomment `index-version = "inmem"` and change the value to `tsi1`.
 
-    -   Example: `index-version = "tsi1"'
-
--   If using environment variables, set `INFLUXDB_DATA_INDEX_VERSION` to `tsi1`.
-    -   Example: `export INFLUXDB_DATA_INDEX_VERSION="tsi1"`
+    -   If using environment variables, set `INFLUXDB_DATA_INDEX_VERSION` to `tsi1`.
 
 4. Convert existing TSM-based shards to TSI-supported shards.
 
--   Use [influx_inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi) for converting your TSM-based shards to TSI-based shards.
+    -   Use [influx_inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi) for converting your TSM-based shards to TSI-based shards.
 
 5. Restart the `influxdb` service.
 
@@ -62,28 +59,25 @@ Follow these steps to upgrade an earlier InfluxDB instance (versions 1.3 and 1.4
 
 2. Update your InfluxDB configuration.
 
--   If using the InfluxDB configuration file, migrate your InfluxDB configuration file customizations to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/).
--   Add, or modify, your environment variables.
+    -   If using the InfluxDB configuration file, migrate your InfluxDB configuration file customizations to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/).
+    -   Add, or modify, your environment variables.
 
 3. Enable the Time Series Index (TSI).
 
--   If using the InfluxDB configuration file, find the `[data]` section, uncomment `index-version = "inmem"`, and change the value to `tsi1`.
+    -   If using the InfluxDB configuration file, find the `[data]` section, uncomment `index-version = "inmem"`, and change the value to `tsi1`. Example: `index-version = "tsi1"`
 
-    -   Example: `index-version = "tsi1"`
-
--   If using an environment variable, set `INFLUXDB_DATA_INDEX_VERSION` to `tsi1`.
-    -   Example: `export INFLUXDB_DATA_INDEX_VERSION=tsi1`
+    -   If using an environment variable, set `INFLUXDB_DATA_INDEX_VERSION` to `tsi1`. Example: `export INFLUXDB_DATA_INDEX_VERSION=tsi1`
 
 4. Delete all existing TSM-based shard `index` directories.
 
--   Removing the existing index directories ensures there are no incompatible index files.
--   By default, the index directories are located at `/<shard_ID>/index`.
-    -   Example: `/2/index`
+    -   Removing the existing index directories ensures there are no incompatible index files.
+    -   By default, the index directories are located at `/<shard_ID>/index`.
+        Example: `/2/index`
 
 5. Convert existing shards to support TSI.
 
--   When Time Series Index (TSI) is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
--   Run the [influx_inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi) command to convert existing TSM-based shards to TSI-based shards.
+    -   When Time Series Index (TSI) is enabled, new shards use the TSI disk-based indexing. Existing shards must be converted to support TSI.
+    -   Run the [influx_inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi) command to convert existing TSM-based shards to TSI-based shards.
 
 5. Restart the `influxdb` service.
 
@@ -97,8 +91,8 @@ Follow these steps to upgrade an earlier InfluxDB instance (versions 1.0 to 1.4)
 
 3. Update your InfluxDB configuration.
 
--   If using the InfluxDB configuration file, migrate your InfluxDB configuration file customizations to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/).
--   Add, or modify, your environment variables.
+    -   If using the InfluxDB configuration file, migrate your InfluxDB configuration file customizations to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/).
+    -   Add, or modify, your environment variables.
 
 5. Restart the `influxdb` service.
 

--- a/content/influxdb/v1.7/tools/influx_inspect.md
+++ b/content/influxdb/v1.7/tools/influx_inspect.md
@@ -11,7 +11,7 @@ Influx Inspect is an InfluxDB disk utility that can be used to:
 
 * View detailed information about disk shards.
 * Exporting data from a shard to [InfluxDB line protocol](/influxdb/v1.7/concepts/glossary/#line-protocol) that can be inserted back into the database.
-* Converting TSM in-memory index shards to TSI disk-based index shards.
+* Converting TSM index shards to TSI index shards.
 
 ## `influx_inspect` utility
 


### PR DESCRIPTION
- Add TSI steps to "Upgrading InfluxDB Enterprise clusters" per DAR #43. Note, this content is also included in the "Rebuild the TSI index" procedure.
- Fix numbering and remove duplicate steps in "Upgrading InfluxDB 1.7.x"
- Add overviews to "Upgrading InfluxDB Enterprise clusters" clean up steps
