### PR TITLE
Tag keys shard duration

### DIFF
--- a/content/influxdb/v1.7/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.7/concepts/schema_and_data_layout.md
@@ -175,7 +175,7 @@ For example, if your RP has a duration of one day, InfluxDB will drop an hour's 
 
 ## Shard group duration recommendations
 
-The default shard group durations works well for most cases. However, high-throughput or long-running instances will benefit from using longer shard group durations.
+The default shard group durations work well for most cases. However, high-throughput or long-running instances will benefit from using longer shard group durations.
 Here are some recommendations for longer shard group durations:
 
 | RP Duration  | Shard Group Duration  |

--- a/content/influxdb/v1.7/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.7/concepts/schema_and_data_layout.md
@@ -171,7 +171,7 @@ A shard group will only be removed once a shard group's duration *end time* is o
 
 For example, if your RP has a duration of one day, InfluxDB will drop an hour's worth of data every hour and will always have 25 shard groups. One for each hour in the day and an extra shard group that is partially expiring, but isn't removed until the whole shard group is older than 24 hours.
 
->**Note:** A special use case to consider: filtering queries on schema data (such as tags, series, measurements) by time. For example, if you want to filter schema data within a one hour interval, you must set the shard group duration to 1h. For more information, see [filter schema data by time](/influxdb/v1.7/query_language/schema_exploration/#filter-schema-data-by-time).
+>**Note:** A special use case to consider: filtering queries on schema data (such as tags, series, measurements) by time. For example, if you want to filter schema data within a one hour interval, you must set the shard group duration to 1h. For more information, see [filter schema data by time](/influxdb/v1.7/query_language/schema_exploration/#filter-meta-queries-by-time).
 
 ## Shard group duration recommendations
 

--- a/content/influxdb/v1.7/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.7/concepts/schema_and_data_layout.md
@@ -173,6 +173,8 @@ A shard group will only be removed once a shard group's *end time* is older than
 
 For example, if your RP has a duration of one day, InfluxDB will drop an hour's worth of data every hour and will always have 25 shard groups. One for each hour in the day and an extra shard group that is partially expiring, but will not be removed until the whole shard group is older than 24 hours.
 
+Another use case to consider: [finding tag keys in a specified time interval](#find-tag-keys-within-shard-duration-precision). Specify a short shard group duration, for example, 1h, to find tag keys within a one hour interval.
+
 ## Shard group duration recommendations
 
 The default shard group durations works well for most cases.

--- a/content/influxdb/v1.7/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.7/concepts/schema_and_data_layout.md
@@ -138,10 +138,9 @@ While both queries are similar, the use of multiple tags in Schema 2 avoids the 
 ## Shard group duration overview
 
 InfluxDB stores data in shard groups.
-Shard groups are organized by [retention policy](/influxdb/v1.7/concepts/glossary/#retention-policy-rp) (RP) and store data with timestamps that fall within a specific time interval.
-The length of that time interval is called the [shard group duration](/influxdb/v1.7/concepts/glossary/#shard-duration).
+Shard groups are organized by [retention policy](/influxdb/v1.7/concepts/glossary/#retention-policy-rp) (RP) and store data with timestamps that fall within a specific time interval called the [shard duration](/influxdb/v1.7/concepts/glossary/#shard-duration).
 
-If no shard group duration is provided, the shard group duration is determined by the RP's [duration](/influxdb/v1.7/concepts/glossary/#duration) at the time the RP is created. The default values are:
+If no shard duration is provided, the shard duration is determined by the RP's [duration](/influxdb/v1.7/concepts/glossary/#duration) at the time the RP is created. The default values are:
 
 | RP Duration  | Shard Group Duration  |
 |---|---|
@@ -149,9 +148,8 @@ If no shard group duration is provided, the shard group duration is determined b
 | >= 2 days and <= 6 months  | 1 day  |
 | > 6 months  | 7 days  |
 
-The shard group duration is also configurable per RP.
-See [Retention Policy Management](/influxdb/v1.7/query_language/database_management/#retention-policy-management) for how to configure the
-shard group duration.
+The shard duration is also configurable per RP.
+To configure the shard group duration, see [Retention Policy Management](/influxdb/v1.7/query_language/database_management/#retention-policy-management).
 
 ## Shard group duration tradeoffs
 
@@ -162,18 +160,18 @@ Determining the optimal shard group duration requires finding the balance betwee
 
 ### Long shard group duration
 
-Longer shard group durations allow InfluxDB to store more data in the same logical location.
+Longer shard durations allow InfluxDB to store more data in the same logical location.
 This reduces data duplication, improves compression efficiency, and allows faster queries in some cases.
 
-### Short shard group duration
+### Short shard duration
 
-Shorter shard group durations allow the system to more efficiently drop data and record incremental backups.
+Shorter shard durations allow the system to more efficiently drop data and record incremental backups.
 When InfluxDB enforces an RP it drops entire shard groups, not individual data points, even if the points are older than the RP duration.
-A shard group will only be removed once a shard group's *end time* is older than the RP duration.
+A shard group will only be removed once a shard group's duration *end time* is older than the RP duration.
 
-For example, if your RP has a duration of one day, InfluxDB will drop an hour's worth of data every hour and will always have 25 shard groups. One for each hour in the day and an extra shard group that is partially expiring, but will not be removed until the whole shard group is older than 24 hours.
+For example, if your RP has a duration of one day, InfluxDB will drop an hour's worth of data every hour and will always have 25 shard groups. One for each hour in the day and an extra shard group that is partially expiring, but isn't removed until the whole shard group is older than 24 hours.
 
-Another use case to consider: [finding tag keys in a specified time interval](#find-tag-keys-within-shard-duration-precision). Specify a short shard group duration, for example, 1h, to find tag keys within a one hour interval.
+Another use case to consider: [finding tag keys within a specified time interval](#find-tag-keys-within-shard-duration). Specify a short shard group duration, for example, 1h, to find tag keys within a one hour interval.
 
 ## Shard group duration recommendations
 
@@ -198,10 +196,102 @@ Here are some other factors to take into consideration when determining shard gr
 * Shard groups should each contain more than 100,000 [points](/influxdb/v1.7/concepts/glossary/#point) per shard group
 * Shard groups should each contain more than 1,000 points per [series](/influxdb/v1.7/concepts/glossary/#series)
 
-### Shard group duration for backfilling
+### Shard duration for backfilling
 
 Bulk insertion of historical data covering a large time range in the past will trigger the creation of a large number of shards at once.
 The concurrent access and overhead of writing to hundreds or thousands of shards can quickly lead to slow performance and memory exhaustion.
 
-When writing historical data, we highly recommend temporarily setting a longer shard group duration so fewer shards are created.
-Typically, a shard group duration of 52 weeks works well for backfilling.
+When writing historical data, we highly recommend temporarily setting a longer shard duration so fewer shards are created. Typically, a shard duration of 52 weeks works well for backfilling.
+
+### Find tag keys within shard duration
+
+To find tag keys within a specified time interval, specify a shard duration in the same time interval.
+
+1. Specify a shard duration on a new database or [alter an existing shard duration](/influxdb/v1.7/query_language/database_management/#modify-retention-policies-with-alter-retention-policy). To specify a 1h shard duration on a new database, run the following command:
+```js
+> CREATE database mydb with duration 7d REPLICATION 1 SHARD DURATION 1h name myRP;
+```
+
+     > **Note:** The minimum shard duration is 1h.
+
+2. Verify the shard duration has the correct time interval (precision) by running the `show shards` command. The example below shows a shard duration with an hour precision.
+```js
+> show shards
+name: mydb
+id database retention_policy shard_group start_time end_time expiry_time owners
+-- -------- ---------------- ----------- ---------- -------- ----------- ------
+> precision h
+```  
+
+3. (Optional) Insert sample tag keys. This step is for demonstration purposes. If you already have tag keys to search for, skip this step.
+
+    ```js
+    // Insert a sample tag called "test_key" into the "test" measurement, and then check the timestamp:
+    > INSERT test,test_key=hello value=1
+
+    > select * from test
+    name: test
+    time test_key value
+    ---- -------- -----
+    434820 hello 1
+
+    // Add new tag keys with timestamps one, two, and three hours earlier:
+
+    > INSERT test,test_key_1=hello value=1 434819
+    > INSERT test,test_key_2=hello value=1 434819
+    > INSERT test,test_key_3_=hello value=1 434818
+    > INSERT test,test_key_4=hello value=1 434817
+    > INSERT test,test_key_5_=hello value=1 434817
+    ```
+
+4. To find tag keys within a shard duration, run one of the following commands:
+   
+    `SHOW TAG KEYS ON database-name <WHERE time clause>` 
+    OR 
+    `SELECT * FROM measurement <WHERE time clause>`
+  
+    The examples below use test data from step 3.
+    ```js
+    //Using data from Step 3, show tag keys between now and an hour ago
+    > SHOW TAG KEYS ON mydb where time > now() -1h and time < now()
+    name: test
+    tagKey
+    ------
+    test_key
+    test_key_1
+    test_key_2
+
+    // Find tag keys between one and two hours ago
+    > SHOW TAG KEYS ON mydb where > time > now() -2h and time < now()-1h
+    name: test
+    tagKey
+    ------
+    test_key_1
+    test_key_2
+    test_key_3
+
+    // Find tag keys between two and three hours ago
+    > SHOW TAG KEYS ON mydb where > time > now() -3h and time < now()-2h
+    name: test
+    tagKey
+    ------
+    test_key_3
+    test_key_4
+    test_key_5
+
+    // For a specified measurement, find tag keys in a given shard by specifying the time boundaries of the shard
+      > SELECT * FROM test WHERE time >= '2019-08-09T00:00:00Z' and time < '2019-08-09T10:00:00Z'
+      name: test
+      time test_key_4 test_key_5 value
+      ---- ------------ ------------ -----
+      434817 hello 1
+      434817 hello 1
+
+      // For a specified database, find tag keys in a given shard by specifying the time boundaries of the shard
+      > SHOW TAG KEYS ON mydb WHERE time >= '2019-08-09T00:00:00Z' and time < '2019-08-09T10:00:00Z'
+      name: test
+      tagKey
+      ------
+      test_key_4
+      test_key_5
+    ```

--- a/content/influxdb/v1.7/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.7/concepts/schema_and_data_layout.md
@@ -171,7 +171,7 @@ A shard group will only be removed once a shard group's duration *end time* is o
 
 For example, if your RP has a duration of one day, InfluxDB will drop an hour's worth of data every hour and will always have 25 shard groups. One for each hour in the day and an extra shard group that is partially expiring, but isn't removed until the whole shard group is older than 24 hours.
 
->**Note:** A special use case to consider: filtering queries on schema data (such as tags, series, measurements) by time. For example, if you want to filter schema data within a one hour interval, you must set the shard group duration to 1h. For more information, see [filter schema data by time](#filter-schema-data-by-time).
+>**Note:** A special use case to consider: filtering queries on schema data (such as tags, series, measurements) by time. For example, if you want to filter schema data within a one hour interval, you must set the shard group duration to 1h. For more information, see [filter schema data by time](/influxdb/v1.7/query_language/schema_exploration/#filter-schema-data-by-time).
 
 ## Shard group duration recommendations
 

--- a/content/influxdb/v1.7/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.7/concepts/schema_and_data_layout.md
@@ -171,7 +171,7 @@ A shard group will only be removed once a shard group's duration *end time* is o
 
 For example, if your RP has a duration of one day, InfluxDB will drop an hour's worth of data every hour and will always have 25 shard groups. One for each hour in the day and an extra shard group that is partially expiring, but isn't removed until the whole shard group is older than 24 hours.
 
-Another use case to consider, [filtering meta queries to get results for a specified time period](#run-a-show-tag-keys-query-filtering-by-time-period). For example, to find tag keys within a one hour interval, specify a shard group duration of 1h.
+>**Note:** A special use case to consider: filtering queries on schema data (such as tags, series, measurements) by time. For example, if you want to filter schema data within a one hour interval, you must set the shard group duration to 1h. For more information, see [filter schema data by time](#filter-schema-data-by-time).
 
 ## Shard group duration recommendations
 
@@ -194,8 +194,6 @@ Other factors to consider before setting shard group duration:
 * Shard groups should be twice as long as the longest time range of the most frequent queries
 * Shard groups should each contain more than 100,000 [points](/influxdb/v1.7/concepts/glossary/#point) per shard group
 * Shard groups should each contain more than 1,000 points per [series](/influxdb/v1.7/concepts/glossary/#series)
-
->**Note:** A special use case to consider: filtering queries on schema data (such as tags, series, measurements) by time. For example, if you want to filter schema data within a one hour interval, you must set the shard group duration to 1h. For more information, see [filter schema data by time](#filter-schema-data-by-time).
 
 ### Shard group duration for backfilling
 

--- a/content/influxdb/v1.7/concepts/schema_and_data_layout.md
+++ b/content/influxdb/v1.7/concepts/schema_and_data_layout.md
@@ -163,9 +163,9 @@ Determining the optimal shard group duration requires finding the balance betwee
 Longer shard group durations allow InfluxDB to store more data in the same logical location.
 This reduces data duplication, improves compression efficiency, and allows faster queries in some cases.
 
-### Short shard duration
+### Short shard group duration
 
-Shorter shard durations allow the system to more efficiently drop data and record incremental backups.
+Shorter shard group durations allow the system to more efficiently drop data and record incremental backups.
 When InfluxDB enforces an RP it drops entire shard groups, not individual data points, even if the points are older than the RP duration.
 A shard group will only be removed once a shard group's duration *end time* is older than the RP duration.
 
@@ -202,4 +202,4 @@ Other factors to consider before setting shard group duration:
 Bulk insertion of historical data covering a large time range in the past will trigger the creation of a large number of shards at once.
 The concurrent access and overhead of writing to hundreds or thousands of shards can quickly lead to slow performance and memory exhaustion.
 
-When writing historical data, we highly recommend temporarily setting a longer shard duration so fewer shards are created. Typically, a shard duration of 52 weeks works well for backfilling.
+When writing historical data, we highly recommend temporarily setting a longer shard group duration so fewer shards are created. Typically, a shard group duration of 52 weeks works well for backfilling.

--- a/content/influxdb/v1.7/query_language/schema_exploration.md
+++ b/content/influxdb/v1.7/query_language/schema_exploration.md
@@ -1142,7 +1142,7 @@ For more information, see the
 
 When you filter meta queries by time, you may see results outside of your specified time. Meta query results are filtered at the shard level, so results can be approximately as granular as your shard group duration. If your time filter spans multiple shards, you'll get results from all shards with points in the specified time range. To review your shards and timestamps on points in the shard, run `SHOW SHARDS`. To learn more about shards and their duration, see [recommended shard groups durations](/influxdb/v1.7/concepts/schema_and_data_layout/#shard-group-duration-recommendations).
 
-The example below shows how to filter `SHOW TAG KEYS` approximately by one hour using a 1h shard group duration. To filter other meta data, replace `SHOW TAG KEYS` with `SHOW TAG VALUES`, `SHOW SERIES`, `SHOW MEASUREMENTS`, `SHOW FIELD KEYS`, and so on.
+The example below shows how to filter `SHOW TAG KEYS` by approximately one hour using a 1h shard group duration. To filter other meta data, replace `SHOW TAG KEYS` with `SHOW TAG VALUES`, `SHOW SERIES`, `SHOW MEASUREMENTS`, `SHOW FIELD KEYS`, and so on.
 
 #### Example filtering `SHOW TAG KEYS` by time
 

--- a/content/influxdb/v1.7/query_language/schema_exploration.md
+++ b/content/influxdb/v1.7/query_language/schema_exploration.md
@@ -765,9 +765,6 @@ The `FROM`, `WHERE`, `LIMIT`, and `OFFSET` clauses are optional.
 The `WHERE` clause supports tag comparisons; field comparisons are not
 valid for the `SHOW TAG KEYS` query.
 
->** Note:** 
-To [find tag keys within a specified time interval](#find-tag-keys-within-shard-duration), you must specify a shard duration in the same time interval.
-
 Supported operators in the `WITH` and `WHERE` clauses:
 `=`&emsp;&nbsp;&thinsp;equal to
 `<>`&emsp;not equal to

--- a/content/influxdb/v1.7/query_language/schema_exploration.md
+++ b/content/influxdb/v1.7/query_language/schema_exploration.md
@@ -23,7 +23,7 @@ The following sections cover useful query syntax for exploring your [schema](/in
   </tr>
   <tr>
     <td><a href="#show-field-keys">SHOW FIELD KEYS</a></td>
-    <td><a href="#filter-schema-data-by-time">Filter schema data by time</a></td>
+    <td><a href="#filter-meta-queries-by-time">Filter meta queries by time</a></td>
     <td></td>
   </tr>
 </table>

--- a/content/influxdb/v1.7/query_language/schema_exploration.md
+++ b/content/influxdb/v1.7/query_language/schema_exploration.md
@@ -1147,24 +1147,26 @@ The example below shows how to filter `SHOW TAG KEYS` within a one hour time per
 #### Example filtering `SHOW TAG KEYS` by time
 
 1. Specify a shard duration on a new database or [alter an existing shard duration](/influxdb/v1.7/query_language/database_management/#modify-retention-policies-with-alter-retention-policy). To specify a 1h shard duration when creating a new database, run the following command:
-```js
-> CREATE database mydb with duration 7d REPLICATION 1 SHARD DURATION 1h name myRP;
-```
 
-     > **Note:** The minimum shard duration is 1h.
+    ```sh
+    > CREATE database mydb with duration 7d REPLICATION 1 SHARD DURATION 1h name myRP;
+    ```
 
-2. Verify the shard duration has the correct time interval (precision) by running the `show shards` command. The example below shows a shard duration with an hour precision.
-```js
-> show shards
-name: mydb
-id database retention_policy shard_group start_time end_time expiry_time owners
--- -------- ---------------- ----------- ---------- -------- ----------- ------
-> precision h
-```  
+    > **Note:** The minimum shard duration is 1h.
+
+2. Verify the shard duration has the correct time interval (precision) by running the `SHOW SHARDS` command. The example below shows a shard duration with an hour precision.
+
+    ```sh
+    > SHOW SHARDS
+    name: mydb
+    id database retention_policy shard_group start_time end_time expiry_time owners
+    -- -------- ---------------- ----------- ---------- -------- ----------- ------
+    > precision h
+    ```  
 
 3. (Optional) Insert sample tag keys. This step is for demonstration purposes. If you already have tag keys (or other meta data) to search for, skip this step.
 
-    ```js
+    ```sh
     // Insert a sample tag called "test_key" into the "test" measurement, and then check the timestamp:
     > INSERT test,test_key=hello value=1
 
@@ -1190,7 +1192,7 @@ id database retention_policy shard_group start_time end_time expiry_time owners
     `SELECT * FROM measurement <WHERE time clause>`
   
     The examples below use test data from step 3.
-    ```js
+    ```sh
     //Using data from Step 3, show tag keys between now and an hour ago
     > SHOW TAG KEYS ON mydb where time > now() -1h and time < now()
     name: test

--- a/content/influxdb/v1.7/query_language/schema_exploration.md
+++ b/content/influxdb/v1.7/query_language/schema_exploration.md
@@ -765,6 +765,9 @@ The `FROM`, `WHERE`, `LIMIT`, and `OFFSET` clauses are optional.
 The `WHERE` clause supports tag comparisons; field comparisons are not
 valid for the `SHOW TAG KEYS` query.
 
+>** Note:** 
+To [find tag keys within a specified time interval](#find-tag-keys-within-shard-duration), you must specify a shard duration in the same time interval.
+
 Supported operators in the `WITH` and `WHERE` clauses:
 `=`&emsp;&nbsp;&thinsp;equal to
 `<>`&emsp;not equal to

--- a/content/influxdb/v1.7/query_language/schema_exploration.md
+++ b/content/influxdb/v1.7/query_language/schema_exploration.md
@@ -1138,11 +1138,11 @@ Note that `SHOW FIELD KEYS` handles field type discrepancies differently from
 For more information, see the
 [How does InfluxDB handle field type discrepancies across shards?](/influxdb/v1.7/troubleshooting/frequently-asked-questions/#how-does-influxdb-handle-field-type-discrepancies-across-shards).
 
-### Filter schema data by time
+### Filter meta queries by time
 
-To filter queries on schema (also known as meta queries) by a specified time period, say one hour, you must have a shard group duration of the same period (1h). This happens because meta queries return all data in a shard (not individual datapoints). If a shard includes a datapoint with a timestamp in a specified time period, the meta query returns results from that shard.
+When you filter meta queries by time, you may see results outside of your specified time. Meta query results are filtered at the shard level, so results can be approximately as granular as your shard group duration. If your time filter spans multiple shards, you'll get results from all shards with points in the specified time range. To review your shards and timestamps on points in the shard, run `SHOW SHARDS`. To learn more about shards and their duration, see [recommended shard groups durations](/influxdb/v1.7/concepts/schema_and_data_layout/#shard-group-duration-recommendations).
 
-The example below shows how to filter `SHOW TAG KEYS` within a one hour time period. To filter other schema data, replace `SHOW TAG KEYS` with `SHOW TAG VALUES`, `SHOW SERIES`, `SHOW MEASUREMENTS`, `SHOW FIELD KEYS`, and so on.
+The example below shows how to filter `SHOW TAG KEYS` approximately by one hour using a 1h shard group duration. To filter other meta data, replace `SHOW TAG KEYS` with `SHOW TAG VALUES`, `SHOW SERIES`, `SHOW MEASUREMENTS`, `SHOW FIELD KEYS`, and so on.
 
 #### Example filtering `SHOW TAG KEYS` by time
 

--- a/content/influxdb/v1.7/tools/_index.md
+++ b/content/influxdb/v1.7/tools/_index.md
@@ -47,7 +47,7 @@ The list of client libraries for interacting with the InfluxDB API.
 
 Influx Inspect is a tool designed to view detailed information about on disk shards, as well as export data from a shard to line protocol that can be inserted back into the database.
 
-## [Graphs and dashboards]
+## Graphs and dashboards
 
 Use [Chronograf](https://docs.influxdata.com/chronograf/) or [Grafana](http://docs.grafana.org/datasources/influxdb/) dashboards to visualize your time series data.
 

--- a/content/influxdb/v1.7/tools/_index.md
+++ b/content/influxdb/v1.7/tools/_index.md
@@ -49,9 +49,9 @@ Influx Inspect is a tool designed to view detailed information about on disk sha
 
 ## Graphs and dashboards
 
-Use [Chronograf](https://docs.influxdata.com/chronograf/) or [Grafana](http://docs.grafana.org/datasources/influxdb/) dashboards to visualize your time series data.
+Use [Chronograf](/chronograf/latest/) or [Grafana](http://docs.grafana.org/datasources/influxdb/) dashboards to visualize your time series data.
 
-> **Tip:** Use template variables in your dashboards to filter meta query results by a specified period of time.
+> **Tip:** Use template variables in your dashboards to filter meta query results by a specified period of time (see example below).
 
 ### Filter meta query results using template variables
 
@@ -71,4 +71,4 @@ WHERE time > now() - 1h GROUP BY time(1h), host, team, status, location END;
 SHOW TAG VALUES FROM "your.system"."host_info" WITH KEY = “host”
 ```
 
-> **Note:** In Chronograf, you can also filter meta query results for a specified time range by [creating a `custom meta query` template variable](https://docs.influxdata.com/chronograf/v1.7/guides/dashboard-template-variables/#create-custom-template-variables) and adding a time range filter.
+> **Note:** In Chronograf, you can also filter meta query results for a specified time range by [creating a `custom meta query` template variable](/chronograf/latest/guides/dashboard-template-variables/#create-custom-template-variables) and adding a time range filter.

--- a/content/influxdb/v1.7/tools/_index.md
+++ b/content/influxdb/v1.7/tools/_index.md
@@ -47,26 +47,28 @@ The list of client libraries for interacting with the InfluxDB API.
 
 Influx Inspect is a tool designed to view detailed information about on disk shards, as well as export data from a shard to line protocol that can be inserted back into the database.
 
-## [Grafana graphs and dashboards](http://docs.grafana.org/datasources/influxdb/)
+## [Graphs and dashboards]
 
-Grafana is a convenient dashboard tool for visualizing time series data.
-It was originally built for Graphite, modeled after Kibana, and since been updated to support InfluxDB.
+Use [Chronograf](https://docs.influxdata.com/chronograf/) or [Grafana](http://docs.grafana.org/datasources/influxdb/) dashboards to visualize your time series data.
 
-> **Tip:** If you use Grafana template variables, you can limit results (for example, a list of hosts) by a specified period of time.
+> **Tip:** Use template variables in your dashboards to filter meta query results by a specified period of time.
 
-### Limit results for Grafana template variables
+### Filter meta query results using template variables
 
-Use the WHERE clause to limit results for a specified time period. The example below shows how to limit hosts retrieving data for a specified period.
+The example below shows how to filter hosts retrieving data in the past hour.
 
-##### Example limiting results for Grafana
+##### Example
 
+```sh
+# Create a retention policy.
+CREATE RETENTION POLICY "lookup" ON "prod" DURATION 1d REPLICATION 1
+
+# Create a continuous query that groups by the tags you want to use in your template variables.
+CREATE CONTINUOUS QUERY "lookupquery" ON "prod" BEGIN SELECT mean(value) as value INTO "your.system"."host_info" FROM "cpuload"
+WHERE time > now() - 1h GROUP BY time(1h), host, team, status, location END;
+
+# In your Grafana or Chronograf templates, include your tag values.
+SHOW TAG VALUES FROM "your.system"."host_info" WITH KEY = “host”
 ```
-// Create a retention policy for a specified duration.
-CREATE RETENTION POLICY "lookup" ON "prod" DURATION 2d REPLICATION 1
 
-// Obtain a distinct list of hosts currently retrieving data, and then add information to "group by" into a measurement.
-CREATE CONTINUOUS QUERY "lookupquery" ON "prod" BEGIN SELECT mean(value) as value INTO "your.system"."host_info" FROM "cpuload" WHERE time > now() - 1h GROUP BY time(1h), host, team, status, location END;
-
-// In your Grafana templates, include your tag values.
-SHOW TAG VALUES FROM "your.system"."host_info" WITH KEY = “host” 
-```
+> **Note:** In Chronograf, you can also filter meta query results for a specified time range by [creating a `customer meta query` template variable](https://docs.influxdata.com/chronograf/v1.7/guides/dashboard-template-variables/#create-custom-template-variables) and adding a time range filter.

--- a/content/influxdb/v1.7/tools/_index.md
+++ b/content/influxdb/v1.7/tools/_index.md
@@ -52,5 +52,21 @@ Influx Inspect is a tool designed to view detailed information about on disk sha
 Grafana is a convenient dashboard tool for visualizing time series data.
 It was originally built for Graphite, modeled after Kibana, and since been updated to support InfluxDB.
 
-<dt> Because of the [changes](/influxdb/v0.11/concepts/010_vs_011/#breaking-api-changes) to the `SHOW SERIES` and `SHOW TAG VALUES` formats in InfluxDB 0.11, InfluxDB 1.3+ will not work with the Query Editor in Grafana 2.6.
-This issue does not affect existing queries and dashboards or users working with Grafana 3.0. </dt>
+> **Tip:** If you use Grafana template variables, you can limit results (for example, a list of hosts) by a specified period of time.
+
+### Limit results for Grafana template variables
+
+Use the WHERE clause to limit results for a specified time period. The example below shows how to limit hosts retrieving data for a specified period.
+
+##### Example limiting results for Grafana
+
+```
+// Create a retention policy for a specified duration.
+CREATE RETENTION POLICY "lookup" ON "prod" DURATION 2d REPLICATION 1
+
+// Obtain a distinct list of hosts currently retrieving data, and then add information to "group by" into a measurement.
+CREATE CONTINUOUS QUERY "lookupquery" ON "prod" BEGIN SELECT mean(value) as value INTO "your.system"."host_info" FROM "cpuload" WHERE time > now() - 1h GROUP BY time(1h), host, team, status, location END;
+
+// In your Grafana templates, include your tag values.
+SHOW TAG VALUES FROM "your.system"."host_info" WITH KEY = “host” 
+```

--- a/content/influxdb/v1.7/tools/_index.md
+++ b/content/influxdb/v1.7/tools/_index.md
@@ -71,4 +71,4 @@ WHERE time > now() - 1h GROUP BY time(1h), host, team, status, location END;
 SHOW TAG VALUES FROM "your.system"."host_info" WITH KEY = “host”
 ```
 
-> **Note:** In Chronograf, you can also filter meta query results for a specified time range by [creating a `customer meta query` template variable](https://docs.influxdata.com/chronograf/v1.7/guides/dashboard-template-variables/#create-custom-template-variables) and adding a time range filter.
+> **Note:** In Chronograf, you can also filter meta query results for a specified time range by [creating a `custom meta query` template variable](https://docs.influxdata.com/chronograf/v1.7/guides/dashboard-template-variables/#create-custom-template-variables) and adding a time range filter.


### PR DESCRIPTION
- Addresses #2366 (unclear in documentation : Show tag keys with where time clause uses shard duration as finest granularity)
- Add how to filter schema data (meta queries) by time using the shard group duration.
- Add how to filter results for Grafana template variables.
- Minor edits.