### PR TITLE
Wrong prometheus metrics endpoint #2

### DIFF
--- a/content/influxdb/v1.6/supported_protocols/prometheus.md
+++ b/content/influxdb/v1.6/supported_protocols/prometheus.md
@@ -37,7 +37,7 @@ CREATE DATABASE "prometheus"
 ### Configuration
 
 To enable the use of Prometheus' remote read and write APIs with InfluxDB, add URL
-values to the following settings in the [Prometheus configuration file](https://prometheus.io/docs/prometheus/latest/configuration/configuration/):
+values to the following settings in the [Prometheus configuration file](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file):
 
 - [`remote_write`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#%3Cremote_write%3E)
 - [`remote_read`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#%3Cremote_read%3E)

--- a/content/influxdb/v1.6/supported_protocols/prometheus.md
+++ b/content/influxdb/v1.6/supported_protocols/prometheus.md
@@ -22,7 +22,8 @@ HTTP endpoints to InfluxDB:
 
 * `/api/v1/prom/read`
 * `/api/v1/prom/write`
-* `/api/v1/prom/metrics`
+
+Additionally, there is a [`/metrics` endpoint](/influxdb/v1.6/administration/server_monitoring/#influxdb-metrics-http-endpoint) configured to produce default Go metrics in Prometheus metrics format.
 
 ### Create a target database
 Create a database in your InfluxDB instance to house data sent from Prometheus.

--- a/content/influxdb/v1.7/supported_protocols/prometheus.md
+++ b/content/influxdb/v1.7/supported_protocols/prometheus.md
@@ -38,7 +38,7 @@ CREATE DATABASE "prometheus"
 ### Configuration
 
 To enable the use of the Prometheus remote read and write APIs with InfluxDB, add URL
-values to the following settings in the [Prometheus configuration file](https://prometheus.io/docs/prometheus/latest/configuration/configuration/):
+values to the following settings in the [Prometheus configuration file](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file):
 
 * [`remote_write`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#%3Cremote_write%3E)
 * [`remote_read`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#%3Cremote_read%3E)

--- a/content/influxdb/v1.7/supported_protocols/prometheus.md
+++ b/content/influxdb/v1.7/supported_protocols/prometheus.md
@@ -22,7 +22,8 @@ HTTP endpoints to InfluxDB:
 
 * `/api/v1/prom/read`
 * `/api/v1/prom/write`
-* `/api/v1/prom/metrics`
+
+Additionally, there is a [`/metrics` endpoint](/influxdb/v1.7/administration/server_monitoring/#influxdb-metrics-http-endpoint) configured to produce default Go metrics in Prometheus metrics format.
 
 ### Create a target database
 


### PR DESCRIPTION
According to https://github.com/influxdata/docs.influxdata.com/issues/1658 I found the same problem for 1.7 docs version. I checked this for 1.7 only but the problem for 1.6 should be the same. You can also check the other versions of the documentation.

**URL for relevant page?**
https://docs.influxdata.com/influxdb/v1.6/supported_protocols/prometheus/#prometheus-remote-read-and-write-api-support
https://docs.influxdata.com/influxdb/v1.7/supported_protocols/prometheus/#prometheus-remote-read-and-write-api-support

What products and version are you using?
InfluxDB v1.7.8 from Docker Hub

Where did you look before opening the issue?
InfluxDB Docs

Description:
According to handler.go the metrics endpoint is /metrics, not /api/v1/prom/metrics.