### PR TITLE
Fix hardware sizing guide being under wrong parent

### DIFF
--- a/content/influxdb/v1.7/guides/hardware_sizing.md
+++ b/content/influxdb/v1.7/guides/hardware_sizing.md
@@ -3,7 +3,7 @@ title: Hardware sizing guidelines
 menu:
   influxdb_1_7:
     weight: 40
-    parent: guides
+    parent: Guides
 ---
 
 This guide offers test general hardware recommendations for InfluxDB and addresses some frequently asked questions about hardware sizing. These recommendations are only for the [Time Structured Merge](/influxdb/v1.7/concepts/storage_engine/#the-new-influxdb-storage-engine-from-lsm-tree-to-b-tree-and-back-again-to-create-the-time-structured-merge-tree) tree (`TSM`) storage engine. 


### PR DESCRIPTION
The hardware sizing guide is currently under a separate section named "guides", while the other guides are under a section named "Guides". It would appear that the `parent` value is case-sensitive.

This PR corrects the `parent` value of the hardware sizing guide.

> ![image](https://user-images.githubusercontent.com/21111572/65697118-0de59c80-e083-11e9-9743-9ef49ab4ef1d.png)
