### PR TITLE
Fixed incorrect example TICKScript

### DIFF
--- a/content/kapacitor/v1.5/event_handlers/opsgenie/v1.md
+++ b/content/kapacitor/v1.5/event_handlers/opsgenie/v1.md
@@ -85,8 +85,8 @@ options:
 |alert()
   // ...
   .opsGenie()
-    .teamsList('team1', 'team2')
-    .recipientsList('recipient1', 'recipient2')
+    .teams('team1', 'team2')
+    .recipients('recipient1', 'recipient2')
 ```
 
 ## OpsGenie Setup
@@ -129,7 +129,7 @@ stream
     .crit(lambda: 'usage_idle' < 10)
     .message('Hey, check your CPU')
     .opsGenie()
-      .teamsList('engineering', 'support')
+      .teams('engineering', 'support')
 ```
 
 ### Send alerts to OpsGenie from a defined handler

--- a/content/kapacitor/v1.5/event_handlers/opsgenie/v2.md
+++ b/content/kapacitor/v1.5/event_handlers/opsgenie/v2.md
@@ -88,8 +88,8 @@ options:
 |alert()
   // ...
   .opsGenie2()
-    .teamsList('team1', 'team2')
-    .recipientsList('recipient1', 'recipient2')
+    .teams('team1', 'team2')
+    .recipients('recipient1', 'recipient2')
 ```
 
 ## OpsGenie Setup
@@ -132,7 +132,7 @@ stream
     .crit(lambda: 'usage_idle' < 10)
     .message('Hey, check your CPU')
     .opsGenie2()
-      .teamsList('engineering', 'support')
+      .teams('engineering', 'support')
 ```
 
 ### Send alerts to OpsGenie from a defined handler


### PR DESCRIPTION
Executing the example code on Kapacitor results in error. This is because the property names in the example are wrong.