### PR TITLE
fix(dashboards): remove source from enterprise monitor dash

### DIFF
--- a/static/downloads/influxdb-enterprise-monitor-dashboard.json
+++ b/static/downloads/influxdb-enterprise-monitor-dashboard.json
@@ -1151,7 +1151,7 @@
 							"range": null,
 							"shifts": null
 						},
-						"source": "/chronograf/v1/sources/1",
+						"source": "",
 						"type": "influxql"
 					},
 					{
@@ -1171,7 +1171,7 @@
 							"range": null,
 							"shifts": null
 						},
-						"source": "/chronograf/v1/sources/1",
+						"source": "",
 						"type": "influxql"
 					}
 				],


### PR DESCRIPTION
this makes all cells dynamic sources and removes this first reconcile block:

![image](https://user-images.githubusercontent.com/4805997/68166680-f28a6e80-ff17-11e9-9634-9519cb3a7314.png)
