### PR TITLE
Add docs for Kapacitor now() function

### DIFF
--- a/content/kapacitor/v1.5/tick/expr.md
+++ b/content/kapacitor/v1.5/tick/expr.md
@@ -205,6 +205,8 @@ This returns `TRUE` if `myfield` is a valid identifier and `FALSE` otherwise.
 
 #### Time functions
 
+##### The `time` field
+
 Within each expression the `time` field contains the time of the current data point.
 The following functions can be used on the `time` field.
 Each function returns an int64.
@@ -227,6 +229,20 @@ lambda: hour("time") >= 9 AND hour("time") < 19
 
 The above expression evaluates to `true` if the hour of the day for the data
 point falls between 0900 hours and 1900 hours.
+
+##### Now
+
+Returns the current time.
+
+```js
+now() time
+```
+
+Example usage:
+
+```js
+lambda: "expiration" < unixNano(now())
+```
 
 
 #### Math functions


### PR DESCRIPTION
I recently came upon Kapacitor's `now()` function via [this discussion](https://community.influxdata.com/t/solved-compare-a-date-field-with-now-in-kapacitor/1746), and would like to see it reflected in the docs.

This is my first PR against this repo; I tried to sign the [CLA](https://www.influxdata.com/legal/cla/) but the bottom half of the page is blank ~~and there seems to be no way to sign it~~.  Never mind, I think I got it.