### PR TITLE
Add info about duplicate keys

### DIFF
--- a/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
@@ -604,7 +604,7 @@ The most common reasons why your query returns no data or partial data:
 
 ### Querying wrong retention policies
 
-InfluxDB automatically queries data in a database’s `DEFAULT` retention policies](/influxdb/v1.7/concepts/glossary/#retention-policy-rp) (RP). If your data is stored in another RP, you must specify the RP in your query to get results.
+InfluxDB automatically queries data in a database’s `DEFAULT` retention policy](/influxdb/v1.7/concepts/glossary/#retention-policy-rp) (RP). If your data is stored in another RP, you must specify the RP in your query to get results.
 
 ### No field key in the SELECT clause
 
@@ -618,7 +618,7 @@ If your `SELECT` query includes a [`GROUP BY time()` clause](/influxdb/v1.7/quer
 
 ### Tag and field key with the same name
 
-Avoid using the same name for a tag and field key. Adding a duplicate key name will rename the original key by appending the key name with `_1`. Queries to the renamed key don't return results. For example, if you have a tag key named `cpu` and write a field key named `cpu` to the same measurement, the tag key is renamed `cpu_1` and cannot be queried.
+Avoid using the same name for a tag and field key. If you inadvertently add the same name for a tag and field key, and then query both keys together, query results show the second key returned (tag or field) appended with `_1` (also visible as the column header in Chronograf). Additionally, queries to the tag key don't return tag values. For example, if you have a tag key named `cpu` and write a field key named `cpu` to the same measurement, the tag key is renamed `cpu_1` and cannot be queried.
 
 > **Warning:** If you inadvertently add a duplicate key name, follow the steps below in "Remove a duplicate key." Because of memory requirements, if you have large amounts of data, we recommend chunking your data (while selecting it) by a specified interval (for example, date range) to fit the allotted memory.
 

--- a/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
@@ -595,7 +595,7 @@ time                    sunflowers                 time                  mean
 
 ## Why do my queries return no data or partial data?
 
-The most common reasons why your query returns partial or no data:
+The most common reasons why your query returns no data or partial data:
 
 - Querying the wrong retention policy (no data returned)
 - No field key in the SELECT clause (no data returned)
@@ -618,9 +618,9 @@ If your `SELECT` query includes a [`GROUP BY time()` clause](/influxdb/v1.7/quer
 
 ### Tag and field key with the same name
 
-Avoid using the same name for a tag and field key. Adding a duplicate key name will rename the original key by appending the key name with `_1`. Queries to the renamed key don't return results. For example, if you have a tag key named `cpu` and write a field key named `cpu` to the same measurement,the tag key is renamed `cpu_1` and cannot be queried.
+Avoid using the same name for a tag and field key. Adding a duplicate key name will rename the original key by appending the key name with `_1`. Queries to the renamed key don't return results. For example, if you have a tag key named `cpu` and write a field key named `cpu` to the same measurement, the tag key is renamed `cpu_1` and cannot be queried.
 
-**Warning** If you inadvertently add a duplicate key name, follow the steps in "To remove duplicate keys." Because of memory requirements, if you have large amounts of data, we recommend chunking your data (while selecting it) by a specified interval (for example, date range) to fit the allotted memory.
+> **Warning:** If you inadvertently add a duplicate key name, follow the steps in "To remove duplicate keys." Because of memory requirements, if you have large amounts of data, we recommend chunking your data (while selecting it) by a specified interval (for example, date range) to fit the allotted memory.
 
 #### Remove a duplicate key
 

--- a/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
@@ -597,10 +597,10 @@ time                    sunflowers                 time                  mean
 
 The most common reasons why your query returns no data or partial data:
 
-- Querying the wrong retention policy (no data returned)
-- No field key in the SELECT clause (no data returned)
-- SELECT query includes `GROUP BY time()` (partial data before `now()` returned)
-- Tag and field key with the same name
+- [Querying the wrong retention policy](#querying-wrong-retention-policies) (no data returned)
+- [No field key in the SELECT clause](#no-field-key-in-the-select-clause) (no data returned)
+- [SELECT query includes `GROUP BY time()`](#select-query-includes-group-by-time) (partial data before `now()` returned)
+- [Tag and field key with the same name](#tag-and-field-key-with-the-same-name)
 
 ### Querying wrong retention policies
 
@@ -620,7 +620,7 @@ If your `SELECT` query includes a [`GROUP BY time()` clause](/influxdb/v1.7/quer
 
 Avoid using the same name for a tag and field key. Adding a duplicate key name will rename the original key by appending the key name with `_1`. Queries to the renamed key don't return results. For example, if you have a tag key named `cpu` and write a field key named `cpu` to the same measurement, the tag key is renamed `cpu_1` and cannot be queried.
 
-> **Warning:** If you inadvertently add a duplicate key name, follow the steps in "To remove duplicate keys." Because of memory requirements, if you have large amounts of data, we recommend chunking your data (while selecting it) by a specified interval (for example, date range) to fit the allotted memory.
+> **Warning:** If you inadvertently add a duplicate key name, follow the steps below in "Remove a duplicate key." Because of memory requirements, if you have large amounts of data, we recommend chunking your data (while selecting it) by a specified interval (for example, date range) to fit the allotted memory.
 
 #### Remove a duplicate key
 

--- a/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
@@ -595,29 +595,26 @@ time                    sunflowers                 time                  mean
 
 ## Why do my queries return no data or partial data?
 
-There are several possible explanations for why a query returns no data or partial data.
-We list some of the most frequent cases below:
+The most common reasons why your query returns partial or no data:
 
-### Retention policies
+- Querying the wrong retention policy (no data returned)
+- No field key in the SELECT clause (no data returned)
+- SELECT query includes `GROUP BY time()` (partial data before `now()` returned)
+- Identifier names
 
-The first and most common explanation involves [retention policies](/influxdb/v1.7/concepts/glossary/#retention-policy-rp) (RP).
-InfluxDB automatically queries data in a database’s `DEFAULT` RP.
-If your data is stored in an RP other than the `DEFAULT` RP, InfluxDB won’t return any results unless you specify the alternative RP.
+### Querying wrong retention policies
 
-### Tag keys in the SELECT clause
+InfluxDB automatically queries data in a database’s `DEFAULT` retention policies](/influxdb/v1.7/concepts/glossary/#retention-policy-rp) (RP). If your data is stored in another RP, you must specify the RP in your query to get results.
 
-A query requires at least one [field key](/influxdb/v1.7/concepts/glossary/#field-key)
-in the `SELECT` clause to return data.
-If the `SELECT` clause only includes a single [tag key](/influxdb/v1.7/concepts/glossary/#tag-key) or several tag keys, the
-query returns an empty response.
-For more information, see [Data exploration](/influxdb/v1.7/query_language/data_exploration/#common-issues-with-the-select-statement).
+### No field key in the SELECT clause
 
-### Query time range
+A query requires at least one [field key](/influxdb/v1.7/concepts/glossary/#field-key) in the `SELECT` clause. If the `SELECT` clause includes only [tag keys](/influxdb/v1.7/concepts/glossary/#tag-key), the query returns an empty response. For more information, see [Data exploration](/influxdb/v1.7/query_language/data_exploration/#common-issues-with-the-select-statement).
 
-Another possible explanation has to do with your query’s time range.
-By default, most [`SELECT` queries](/influxdb/v1.7/query_language/data_exploration/#the-basic-select-statement) cover the time range between `1677-09-21 00:12:43.145224194` and `2262-04-11T23:47:16.854775806Z` UTC. `SELECT` queries that also include a [`GROUP BY time()` clause](/influxdb/v1.7/query_language/data_exploration/#group-by-time-intervals), however, cover the time range between `1677-09-21 00:12:43.145224194` and [`now()`](/influxdb/v1.7/concepts/glossary/#now).
-If any of your data occur after `now()` a `GROUP BY time()` query will not cover those data points.
-Your query will need to provide [an alternative upper bound](/influxdb/v1.7/query_language/data_exploration/#time-syntax) for the time range if the query includes a `GROUP BY time()` clause and if any of your data occur after `now()`.
+### SELECT query includes `GROUP BY time()`
+
+If your `SELECT` query includes a [`GROUP BY time()` clause](/influxdb/v1.7/query_language/data_exploration/#group-by-time-intervals), only data points between `1677-09-21 00:12:43.145224194` and [`now()`](/influxdb/v1.7/concepts/glossary/#now) are returned. Therefore, if any of your data points occur after `now()`, specify [an alternative upper bound](/influxdb/v1.7/query_language/data_exploration/#time-syntax) in your time interval.
+
+(By default, most [`SELECT` queries](/influxdb/v1.7/query_language/data_exploration/#the-basic-select-statement) query data with timestamps between `1677-09-21 00:12:43.145224194` and `2262-04-11T23:47:16.854775806Z` UTC.)
 
 ### Identifier names
 

--- a/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
@@ -618,7 +618,7 @@ If your `SELECT` query includes a [`GROUP BY time()` clause](/influxdb/v1.7/quer
 
 ### Tag and field key with the same name
 
-Avoid using the same name for a tag and field key. If you inadvertently add the same name for a tag and field key, and then query both keys together, the query results show the second key queried (tag or field) appended with `_1` (also visible as the column header in Chronograf). To query a tag or field key appended with `_1`, drop the appended `_1` and include the syntax `::tag` or `::field`.
+Avoid using the same name for a tag and field key. If you inadvertently add the same name for a tag and field key, and then query both keys together, the query results show the second key queried (tag or field) appended with `_1` (also visible as the column header in Chronograf). To query a tag or field key appended with `_1`, you **must drop** the appended `_1` **and include** the syntax `::tag` or `::field`.
 
 #### Example
 

--- a/content/influxdb/v1.7/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.7/write_protocols/line_protocol_reference.md
@@ -278,8 +278,8 @@ For a complete example of this behavior and how to avoid it, see
 
 ### Duplicate keys
 
-If you have a tag key called `location` and write a field key called `location` to the same measurement, the `location` tag key is **renamed** `location_1`. To retrieve data from the renamed tag key `location_1`, you **must** use the InfluxQL `::tag` syntax in your query, for example:
+If you have a tag key and field key with the same name in a measurement, one of the keys will return appended with a `_1` in query results (and as a column header in Chronograf). For example, `location` and `location_1`. To query a duplicate key, drop the `_1` and use the InfluxQL `::tag` or `::field` syntax in your query, for example:
 
 ```sql
-  SELECT "<location_1>"::tag
+  SELECT "location"::tag, "location"::field FROM "database_name"."retention_policy"."measurement"
 ```

--- a/content/influxdb/v1.7/write_protocols/line_protocol_reference.md
+++ b/content/influxdb/v1.7/write_protocols/line_protocol_reference.md
@@ -9,26 +9,21 @@ menu:
     parent: Write protocols
 ---
 
+InfluxDB line protocol is a text based format for writing points to InfluxDB.
 
-The InfluxDB line protocol is a text based format for writing points to InfluxDB.
-
-## InfluxDB line protocol
-
-### Syntax
+## Line protocol syntax
 
 ```
 <measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]
 ```
 
-Lines separated by the newline character `\n` represent a single point
-in InfluxDB. Line protocol is whitespace-sensitive.
+Line protocol accepts the newline character `\n` and is whitespace-sensitive.
 
->**Note** Line protocol does not support the newline character `\n` within tag values or field values.
+>**Note** Line protocol does not support the newline character `\n` in tag values or field values.
 
-### Description of syntax
+### Syntax description
 
-InfluxDB line protocol informs InfluxDB of the data's measurement, tag set, field set,
-and timestamp.
+InfluxDB line protocol informs InfluxDB of the data's measurement, tag set, field set, and timestamp.
 
 | Element | Optional/Required | Description | Type<br>(See [data types](#data-types) for more information.) |
 | :-------| :---------------- |:----------- |:----------------
@@ -37,18 +32,12 @@ and timestamp.
 | [Field set](/influxdb/v1.7/concepts/glossary/#field-set) | Required. Points must have at least one field. | All field key-value pairs for the point. | [Field keys](/influxdb/v1.7/concepts/glossary/#field-key) are strings. [Field values](/influxdb/v1.7/concepts/glossary/#field-value) can be floats, integers, strings, or Booleans.
 | [Timestamp](/influxdb/v1.7/concepts/glossary/#timestamp) | Optional. InfluxDB uses the server's local nanosecond timestamp in UTC if the timestamp is not included with the point. | The timestamp for the data point. InfluxDB accepts one timestamp per point. | Unix nanosecond timestamp. Specify alternative precisions with the [InfluxDB API](/influxdb/v1.7/tools/api/#write-http-endpoint).
 
-> #### Performance and Setup Tips:
+> #### Performance tips:
 >
-* Sort tags by key before sending them to the database.
-The sort should match the results from the
+- Before sending data to InfluxDB, sort by tag key to match the results from the
 [Go bytes.Compare function](http://golang.org/pkg/bytes/#Compare).
-* Use the coarsest
-[precision](/influxdb/v1.7/tools/api/#write-http-endpoint) possible for timestamps.
-This can result in significant improvements in compression.
-* Use the Network Time Protocol (NTP) to synchronize time between hosts.
-InfluxDB uses a host's local time in UTC to assign timestamps to data; if
-hosts' clocks aren't synchronized with NTP, the timestamps on the data written
-to InfluxDB can be inaccurate.
+- To significantly improve compression, use the coarsest [precision](/influxdb/v1.7/tools/api/#write-http-endpoint) possible for timestamps.
+- Use the Network Time Protocol (NTP) to synchronize time between hosts. InfluxDB uses a host's local time in UTC to assign timestamps to data. If a host's clock isn't synchronized with NTP, the data that the host writes to InfluxDB may have inaccurate timestamps.
 
 ## Data types
 
@@ -68,15 +57,23 @@ For more information, see
 
 #### Field type discrepancies
 
-Within a measurement, a field's type cannot differ within a
-[shard](/influxdb/v1.7/concepts/glossary/#shard), but it can differ across
+In a measurement, a field's type cannot differ in a [shard](/influxdb/v1.7/concepts/glossary/#shard), but can differ across
 shards.
-For how field value type discrepancies can affect `SELECT *` queries, see
+
+To learn how field value type discrepancies can affect `SELECT *` queries, see
 [How does InfluxDB handle field type discrepancies across shards?](/influxdb/v1.7/troubleshooting/frequently-asked-questions/#how-does-influxdb-handle-field-type-discrepancies-across-shards).
 
 ### Examples
 
-#### Write the field value `1.0` as a float to InfluxDB
+#### Write the field value `-1.234456e+78` as a float to InfluxDB
+
+```sql
+> INSERT mymeas value=-1.234456e+78
+```
+
+InfluxDB supports field values specified in scientific notation.
+
+#### Write a field value `1.0` as a float to InfluxDB
 
 ```sql
 > INSERT mymeas value=1.0
@@ -87,14 +84,6 @@ For how field value type discrepancies can affect `SELECT *` queries, see
 ```sql
 > INSERT mymeas value=1
 ```
-
-#### Write the field value `-1.234456e+78` as a float to InfluxDB
-
-```sql
-> INSERT mymeas value=-1.234456e+78
-```
-
-InfluxDB supports field values specified in scientific notation.
 
 #### Write the field value `1` as an integer to InfluxDB
 
@@ -274,18 +263,23 @@ In those cases, `time` does not require double quotes in queries.
 InfluxDB rejects writes with `time` as a field key or tag key and returns an error.
 See [Frequently Asked Questions](/influxdb/v1.7/troubleshooting/frequently-asked-questions/#time) for more information.
 
-## InfluxDB line protocol in Practice
+## InfluxDB line protocol in practice
 
-See the [Tools](/influxdb/v1.7/tools/) section for how to
-write line protocol to the database.
+To learn how to write line protocol to the database, see [Tools](/influxdb/v1.7/tools/).
 
 ### Duplicate points
 
-A point is uniquely identified by the measurement name, tag set, and timestamp.
-If you submit line protocol with the same measurement, tag set, and timestamp,
-but with a different field set, the field set becomes the union of the old
-field set and the new field set, where any conflicts favor the new field set.
+A point is uniquely identified by the measurement name, tag set, field set, and timestamp
+
+If you write a point to a series with a timestamp that matches an existing point, the field set becomes a union of the old and new field set, and conflicts favor the new field set.
 
 For a complete example of this behavior and how to avoid it, see
 [How does InfluxDB handle duplicate points?](/influxdb/v1.7/troubleshooting/frequently-asked-questions/#how-does-influxdb-handle-duplicate-points)
 
+### Duplicate keys
+
+If you have a tag key called `location` and write a field key called `location` to the same measurement, the `location` tag key is **renamed** `location_1`. To retrieve data from the renamed tag key `location_1`, you **must** use the InfluxQL `::tag` syntax in your query, for example:
+
+```sql
+  SELECT "<location_1>"::tag
+```


### PR DESCRIPTION
- To address [duplicate field/tag keys issue](https://github.com/influxdata/docs.influxdata.com/issues/2498), add content to "Tag and field key with the same name" (line 619). 
- Other updates in this PR:

   -  Rewrote intro for "Why do my queries return no data or partial data?"
   -  Updated subheadings
   - Renamed "Identifier names" to "Tag and field key with the same name"
   - Reworded info about querying the wrong RP