### PR TITLE
add new info about duplicate keys

### DIFF
--- a/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
@@ -604,9 +604,7 @@ The most common reasons why your query returns no data or partial data:
 
 ### Querying the wrong retention policy
 
-The first and most common explanation involves [retention policies](/influxdb/v1.7/concepts/glossary/#retention-policy-rp) (RP).
-InfluxDB automatically queries data in a database’s `DEFAULT` RP.
-If your data is stored in an RP other than the `DEFAULT` RP, InfluxDB won’t return any results unless you specify the alternative RP.
+InfluxDB automatically queries data in a database’s `DEFAULT` retention policies](/influxdb/v1.7/concepts/glossary/#retention-policy-rp) (RP). If your data is stored in another RP, you must specify the RP in your query to get results.
 
 ### No field key in the SELECT clause
 

--- a/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
+++ b/content/influxdb/v1.7/troubleshooting/frequently-asked-questions.md
@@ -595,16 +595,20 @@ time                    sunflowers                 time                  mean
 
 ## Why do my queries return no data or partial data?
 
-There are several possible explanations for why a query returns no data or partial data.
-We list some of the most frequent cases below:
+The most common reasons why your query returns no data or partial data:
 
-### Retention policies
+- [Querying the wrong retention policy](#querying-wrong-retention-policies) (no data returned)
+- [No field key in the SELECT clause](#no-field-key-in-the-select-clause) (no data returned)
+- [SELECT query includes `GROUP BY time()`](#select-query-includes-group-by-time) (partial data before `now()` returned)
+- [Tag and field key with the same name](#tag-and-field-key-with-the-same-name)
+
+### Querying the wrong retention policy
 
 The first and most common explanation involves [retention policies](/influxdb/v1.7/concepts/glossary/#retention-policy-rp) (RP).
 InfluxDB automatically queries data in a database’s `DEFAULT` RP.
 If your data is stored in an RP other than the `DEFAULT` RP, InfluxDB won’t return any results unless you specify the alternative RP.
 
-### Tag keys in the SELECT clause
+### No field key in the SELECT clause
 
 A query requires at least one [field key](/influxdb/v1.7/concepts/glossary/#field-key)
 in the `SELECT` clause to return data.
@@ -612,7 +616,7 @@ If the `SELECT` clause only includes a single [tag key](/influxdb/v1.7/concepts/
 query returns an empty response.
 For more information, see [Data exploration](/influxdb/v1.7/query_language/data_exploration/#common-issues-with-the-select-statement).
 
-### Query time range
+### SELECT query includes `GROUP BY time()`
 
 Another possible explanation has to do with your query’s time range.
 By default, most [`SELECT` queries](/influxdb/v1.7/query_language/data_exploration/#the-basic-select-statement) cover the time range between `1677-09-21 00:12:43.145224194` and `2262-04-11T23:47:16.854775806Z` UTC. `SELECT` queries that also include a [`GROUP BY time()` clause](/influxdb/v1.7/query_language/data_exploration/#group-by-time-intervals), however, cover the time range between `1677-09-21 00:12:43.145224194` and [`now()`](/influxdb/v1.7/concepts/glossary/#now).


### PR DESCRIPTION
- To address duplicate field/tag keys issue, add content to "Tag and field key with the same name" (line 626). Please note, a couple questions:

    - Are you able to query data in the "renamed duplicate key" after moving said data to the "target" measurement? I am not able to, but may be doing something incorrectly....
    - Is the `::tag` and `::field` syntax still valid? If so, how do you create a duplicate key/field name....given the original key name gets appended with _1? (Perhaps if the data is written in some other than the CLI?)


- Other updates in this PR:

   - Rewrote intro for "Why do my queries return no data or partial data?" 
   - Updated subheadings
   - Renamed "Identifier names" to "Tag and field key with the same name"
   -Reworded info about querying the wrong RP
