### PR TITLE
Update logging docs

### DIFF
--- a/content/influxdb/v1.7/administration/logs.md
+++ b/content/influxdb/v1.7/administration/logs.md
@@ -43,32 +43,32 @@ influxd 2>$HOME/my_log_file
 {{% tab-content %}}
 #### systemd
 
-InfluxDB uses the system-configured default for logging (usually `journald`).
-On most Linux systems, the logs will be directed to the `systemd` journal and can be accessed with the command:
+Most Linux systems direct logs to the `systemd` journal.
+To access these logs, use this command:
 
-```
+```sh
 sudo journalctl -u influxdb.service
 ```
 
-See the manual pages for `systemd` and `journald` for more information about configuring `journald`.
+For more information about configuring `journald`, see its [manual page](https://www.freedesktop.org/software/systemd/man/journald.conf.html).
 {{% /tab-content %}}
 <!--------------------------- END systemd  --------------------->
 <!--------------------------- BEGIN sysvinit  ------------------>
 {{% tab-content %}}
 #### sysvinit
 
-On older Linux sytems, all log data (and `stdedrr`) will be written to `/var/log/influxdb/influxd.log`. 
-You can override this location by setting the environment variable `STDERR` in the InfluxDB configuration file `/etc/default/influxdb`.
+On Linux sytems not using systemd, InfluxDB writes all log data and `stderr` to `/var/log/influxdb/influxd.log`.
+You can override this location by setting the environment variable `STDERR` in the InfluxDB configuration file (`/etc/default/influxdb`).
 
 For example, if `/etc/default/influxdb` contains:
 
-```
+```sh
 STDERR=/dev/null
 ```
 
-all log data will be discarded.
+all log data is discarded.
 Likewise, you can direct output to `stdout` by setting `STDOUT` in the same file.
-Output to `stdout` is sent to `/dev/null` by default when InfluxDB is launched as a service.
+`stdout` is sent to `/dev/null` by default when InfluxDB is launched as a service.
 
 InfluxDB must be restarted to use any changes to `/etc/default/influxdb`.
 {{% /tab-content %}}
@@ -77,7 +77,8 @@ InfluxDB must be restarted to use any changes to `/etc/default/influxdb`.
 {{< /tab-labels >}}
 <!--------------------------- END TABS  ------------------------>
 
->**Note:** macOS logs are stored, by default, in the file `/usr/local/var/log/influxdb.log`.
+> #### macOS log location
+> macOS logs are stored by default at `/usr/local/var/log/influxdb.log`.
 
 ### Using logrotate
 

--- a/content/influxdb/v1.7/administration/logs.md
+++ b/content/influxdb/v1.7/administration/logs.md
@@ -32,6 +32,31 @@ influxd 2>$HOME/my_log_file
 
 ### Launched as a service
 
+<!--------------------------- BEGIN TABS  ---------------------->
+{{< tab-labels >}}
+{{% tabs %}}
+[systemd](#)
+[sysinit](#)
+{{% /tabs %}}
+{{< tab-content-container >}}
+<!--------------------------- BEGIN systemd  ------------------->
+{{% tab-content %}}
+#### systemd
+
+Starting with version 1.0, InfluxDB on `systemd` systems will no longer
+write files to `/var/log/influxdb` by default, and will now use the
+system configured default for logging (usually `journald`).  On most
+Linux systems, the logs will be directed to the `systemd` journal and can be accessed with the command:
+
+```
+sudo journalctl -u influxdb.service
+```
+
+See the `systemd` `journald` documentation about configuring `journald`.
+{{% /tab-content %}}
+<!--------------------------- END systemd  --------------------->
+<!--------------------------- BEGIN sysvinit  ------------------>
+{{% tab-content %}}
 #### sysvinit
 
 If InfluxDB was installed using a prebuilt package, and then launched
@@ -51,19 +76,11 @@ all log data will be discarded.  Likewise, you can direct output to
 sent to `/dev/null` by default when InfluxDB is launched as a service.
 
 InfluxDB must be restarted to use any changes to `/etc/default/influxdb`.
-
-#### systemd
-
-Starting with version 1.0, InfluxDB on `systemd` systems will no longer
-write files to `/var/log/influxdb` by default, and will now use the
-system configured default for logging (usually `journald`).  On most
-Linux systems, the logs will be directed to the `systemd` journal and can be accessed with the command:
-
-```
-sudo journalctl -u influxdb.service
-```
-
-See the `systemd` `journald` documentation about configuring `journald`.
+{{% /tab-content %}}
+<!--------------------------- END sysvinit --------------------->
+{{< /tab-content-container >}}
+{{< /tab-labels >}}
+<!--------------------------- END TABS  ------------------------>
 
 ### Using logrotate
 

--- a/content/influxdb/v1.7/administration/logs.md
+++ b/content/influxdb/v1.7/administration/logs.md
@@ -58,8 +58,8 @@ For more information, see the [`journald.conf` manual page](https://www.freedesk
 #### sysvinit
 
 On Linux sytems not using systemd, InfluxDB writes all log data and `stderr` to `/var/log/influxdb/influxd.log`.
-You can override this location by setting the environment variable `STDERR` in `/etc/default/influxdb`.
-(If this file doesn't exist you need to create it.)
+You can override this location by setting the environment variable `STDERR` in a start-up script at `/etc/default/influxdb`.
+(If this file doesn't exist, you need to create it.)
 
 For example, if `/etc/default/influxdb` contains:
 
@@ -78,8 +78,8 @@ InfluxDB must be restarted to use any changes to `/etc/default/influxdb`.
 {{< /tab-labels >}}
 <!--------------------------- END TABS  ------------------------>
 
-> #### macOS log location
-> macOS logs are stored by default at `/usr/local/var/log/influxdb.log`.
+> #### Log location on macOS
+> On macOs, InfluxDB stores logs at `/usr/local/var/log/influxdb.log` by default.
 
 ### Using logrotate
 

--- a/content/influxdb/v1.7/administration/logs.md
+++ b/content/influxdb/v1.7/administration/logs.md
@@ -50,7 +50,7 @@ To access these logs, use this command:
 sudo journalctl -u influxdb.service
 ```
 
-For more information about configuring `journald`, see its [manual page](https://www.freedesktop.org/software/systemd/man/journald.conf.html).
+For more information, see the [`journald.conf` manual page](https://www.freedesktop.org/software/systemd/man/journald.conf.html).
 {{% /tab-content %}}
 <!--------------------------- END systemd  --------------------->
 <!--------------------------- BEGIN sysvinit  ------------------>
@@ -58,7 +58,8 @@ For more information about configuring `journald`, see its [manual page](https:/
 #### sysvinit
 
 On Linux sytems not using systemd, InfluxDB writes all log data and `stderr` to `/var/log/influxdb/influxd.log`.
-You can override this location by setting the environment variable `STDERR` in the InfluxDB configuration file (`/etc/default/influxdb`).
+You can override this location by setting the environment variable `STDERR` in `/etc/default/influxdb`.
+(If this file doesn't exist you need to create it.)
 
 For example, if `/etc/default/influxdb` contains:
 

--- a/content/influxdb/v1.7/administration/logs.md
+++ b/content/influxdb/v1.7/administration/logs.md
@@ -43,27 +43,22 @@ influxd 2>$HOME/my_log_file
 {{% tab-content %}}
 #### systemd
 
-Starting with version 1.0, InfluxDB on `systemd` systems will no longer
-write files to `/var/log/influxdb` by default, and will now use the
-system configured default for logging (usually `journald`).  On most
-Linux systems, the logs will be directed to the `systemd` journal and can be accessed with the command:
+InfluxDB uses the system-configured default for logging (usually `journald`).
+On most Linux systems, the logs will be directed to the `systemd` journal and can be accessed with the command:
 
 ```
 sudo journalctl -u influxdb.service
 ```
 
-See the `systemd` `journald` documentation about configuring `journald`.
+See the manual pages for `systemd` and `journald` for more information about configuring `journald`.
 {{% /tab-content %}}
 <!--------------------------- END systemd  --------------------->
 <!--------------------------- BEGIN sysvinit  ------------------>
 {{% tab-content %}}
 #### sysvinit
 
-If InfluxDB was installed using a prebuilt package, and then launched
-as a service, `stderr` is redirected to `/var/log/influxdb/influxd.log` and all log data will be written to that file.
+On older Linux sytems, all log data (and `stdedrr`) will be written to `/var/log/influxdb/influxd.log`. 
 You can override this location by setting the environment variable `STDERR` in the InfluxDB configuration file `/etc/default/influxdb`.
-
->**Note:** macOS logs are stored, by default, in the file `/usr/local/var/log/influxdb.log`.
 
 For example, if `/etc/default/influxdb` contains:
 
@@ -71,9 +66,9 @@ For example, if `/etc/default/influxdb` contains:
 STDERR=/dev/null
 ```
 
-all log data will be discarded.  Likewise, you can direct output to
-`stdout` by setting `STDOUT` in the same file.  Output to `stdout` is
-sent to `/dev/null` by default when InfluxDB is launched as a service.
+all log data will be discarded.
+Likewise, you can direct output to `stdout` by setting `STDOUT` in the same file.
+Output to `stdout` is sent to `/dev/null` by default when InfluxDB is launched as a service.
 
 InfluxDB must be restarted to use any changes to `/etc/default/influxdb`.
 {{% /tab-content %}}
@@ -81,6 +76,8 @@ InfluxDB must be restarted to use any changes to `/etc/default/influxdb`.
 {{< /tab-content-container >}}
 {{< /tab-labels >}}
 <!--------------------------- END TABS  ------------------------>
+
+>**Note:** macOS logs are stored, by default, in the file `/usr/local/var/log/influxdb.log`.
 
 ### Using logrotate
 


### PR DESCRIPTION
This PR updates the docs to prioritize `systemd` as the logging system for most new installations.

Addresses #2508.