### PR TITLE
updates per DAR 66

### DIFF
--- a/content/chronograf/v1.7/administration/creating-connections.md
+++ b/content/chronograf/v1.7/administration/creating-connections.md
@@ -70,7 +70,7 @@ The following dashboards are available:
 
 ## Managing InfluxDB connections using .src files
 
-Chronograf stores InfluxDB connection details `.src` files that can also be created manually.
+Manually create `.src` files to store InfluxDB connection details.
 `.src` files are simple JSON files that contain key-value paired connection details.
 The location of `.src` files is defined by the [`--resources-path`](/chronograf/v1.7/administration/config-options/#resources-path)
 command line option, which is, by default, the same as the [`--canned-path`](/chronograf/v1.7/administration/config-options/#canned-path-c).
@@ -178,7 +178,7 @@ To create a Kapacitor connection using the Chronograf UI:
 
 ## Managing Kapacitor connections using .kap files
 
-Chronograf stores Kapacitor connection details `.kap` files that can also be created manually.
+Manually create `.kap` files to store Kapacitor connection details.
 `.kap` files are simple JSON files that contain key-value paired connection details.
 The location of `.kap` files is defined by the `--resources-path` command line option, which is, by default, the same as the [`--canned-path`](/chronograf/v1.7/administration/config-options/#canned-path-c).
 A `.kap` files contains the details for a single InfluxDB connection.

--- a/content/chronograf/v1.7/administration/creating-connections.md
+++ b/content/chronograf/v1.7/administration/creating-connections.md
@@ -10,6 +10,8 @@ menu:
 
 Connections to InfluxDB and Kapacitor can be configured through the Chronograf user interface (UI) or with JSON configuration files.
 
+> Note: Connection details are stored in Chronograf’s internal database `chronograf-v1.db` `.src`. Typically, the only time you'll need to administer the internal database is when you're [restoring a Chronograf database](/chronograf/v1.7/administration/restoring-chronograf-db/).
+
 ## Managing InfluxDB connections using the Chronograf UI
 
 To create an InfluxDB connection in the Chronograf UI:
@@ -67,6 +69,7 @@ The following dashboards are available:
 - Ping
 
 ## Managing InfluxDB connections using .src files
+
 Chronograf stores InfluxDB connection details `.src` files that can also be created manually.
 `.src` files are simple JSON files that contain key-value paired connection details.
 The location of `.src` files is defined by the [`--resources-path`](/chronograf/v1.7/administration/config-options/#resources-path)


### PR DESCRIPTION
added note about internal Chronograf database and clarified language re .src and .kap files to indicate they're created manually and not a storage mechanism