### PR TITLE
Short-term warning in OSS/Enterprise migration guide

### DIFF
--- a/content/enterprise_influxdb/v1.5/guides/migration.md
+++ b/content/enterprise_influxdb/v1.5/guides/migration.md
@@ -9,6 +9,19 @@ menu:
     parent: Guides
 ---
 
+{{% warn %}}
+## IMPORTANT
+Due to a known issue in InfluxDB, attempts to upgrade an InfluxDB OSS instance to
+InfluxDB Enterprise will fail.
+A fix is in place and will be released with InfluxDB v1.7.10.
+Until InfluxDB v1.7.10 is released, **DO NOT** attempt to migrate an InfluxDB OSS
+instance to InfluxDB Enterprise by following the steps in this guide.
+
+We will update this guide to reflect the new upgrade process after the release of InfluxDB 1.7.10.
+{{% /warn %}}
+
+---
+
 The following guide has step-by-step instructions for migrating an InfluxDB OSS
 instance into an InfluxDB Enterprise cluster.
 

--- a/content/enterprise_influxdb/v1.5/guides/migration.md
+++ b/content/enterprise_influxdb/v1.5/guides/migration.md
@@ -20,9 +20,7 @@ instance to InfluxDB Enterprise by following the steps in this guide.
 We will update this guide to reflect the new upgrade process after the release of InfluxDB 1.7.10.
 {{% /warn %}}
 
----
-
-The following guide has step-by-step instructions for migrating an InfluxDB OSS
+<!-- The following guide has step-by-step instructions for migrating an InfluxDB OSS
 instance into an InfluxDB Enterprise cluster.
 
 {{% warn %}}
@@ -213,4 +211,4 @@ replication factor for existing shards.
 Finally, if you were using [Chronograf](/chronograf/latest/), you can
 add your Enterprise instance as a new data source.  If you were not using
 [Chronograf](/chronograf/latest/introduction/installation/), we recommend going through
-the installation instructions and using it as your primary management UI for the instance.
+the installation instructions and using it as your primary management UI for the instance. -->

--- a/content/enterprise_influxdb/v1.6/guides/migration.md
+++ b/content/enterprise_influxdb/v1.6/guides/migration.md
@@ -9,6 +9,19 @@ menu:
     parent: Guides
 ---
 
+{{% warn %}}
+## IMPORTANT
+Due to a known issue in InfluxDB, attempts to upgrade an InfluxDB OSS instance to
+InfluxDB Enterprise will fail.
+A fix is in place and will be released with InfluxDB v1.7.10.
+Until InfluxDB v1.7.10 is released, **DO NOT** attempt to migrate an InfluxDB OSS
+instance to InfluxDB Enterprise by following the steps in this guide.
+
+We will update this guide to reflect the new upgrade process after the release of InfluxDB 1.7.10.
+{{% /warn %}}
+
+---
+
 The following guide has step-by-step instructions for migrating an InfluxDB OSS
 instance into an InfluxDB Enterprise cluster.
 

--- a/content/enterprise_influxdb/v1.6/guides/migration.md
+++ b/content/enterprise_influxdb/v1.6/guides/migration.md
@@ -20,9 +20,7 @@ instance to InfluxDB Enterprise by following the steps in this guide.
 We will update this guide to reflect the new upgrade process after the release of InfluxDB 1.7.10.
 {{% /warn %}}
 
----
-
-The following guide has step-by-step instructions for migrating an InfluxDB OSS
+<!-- The following guide has step-by-step instructions for migrating an InfluxDB OSS
 instance into an InfluxDB Enterprise cluster.
 
 {{% warn %}}
@@ -213,4 +211,4 @@ replication factor for existing shards.
 Finally, if you were using [Chronograf](/chronograf/latest/), you can
 add your Enterprise instance as a new data source.  If you were not using
 [Chronograf](/chronograf/latest/introduction/installation/), we recommend going through
-the installation instructions and using it as your primary management UI for the instance.
+the installation instructions and using it as your primary management UI for the instance. -->

--- a/content/enterprise_influxdb/v1.7/guides/migration.md
+++ b/content/enterprise_influxdb/v1.7/guides/migration.md
@@ -20,9 +20,7 @@ instance to InfluxDB Enterprise by following the steps in this guide.
 We will update this guide to reflect the new upgrade process after the release of InfluxDB 1.7.10.
 {{% /warn %}}
 
----
-
-The following guide has step-by-step instructions for migrating an InfluxDB open source (OSS)
+<!-- The following guide has step-by-step instructions for migrating an InfluxDB open source (OSS)
 instance into an InfluxDB Enterprise cluster.
 
 {{% warn %}}
@@ -234,4 +232,4 @@ replication factor for existing shards.
 Finally, if you were using [Chronograf](/chronograf/latest/), you can
 add your Enterprise instance as a new data source.  If you were not using
 [Chronograf](/chronograf/latest/introduction/installation/), we recommend going through
-the installation instructions and using it as your primary management UI for the instance.
+the installation instructions and using it as your primary management UI for the instance. -->

--- a/content/enterprise_influxdb/v1.7/guides/migration.md
+++ b/content/enterprise_influxdb/v1.7/guides/migration.md
@@ -9,6 +9,19 @@ menu:
     parent: Guides
 ---
 
+{{% warn %}}
+## IMPORTANT
+Due to a known issue in InfluxDB, attempts to upgrade an InfluxDB OSS instance to
+InfluxDB Enterprise will fail.
+A fix is in place and will be released with InfluxDB v1.7.10.
+Until InfluxDB v1.7.10 is released, **DO NOT** attempt to migrate an InfluxDB OSS
+instance to InfluxDB Enterprise by following the steps in this guide.
+
+We will update this guide to reflect the new upgrade process after the release of InfluxDB 1.7.10.
+{{% /warn %}}
+
+---
+
 The following guide has step-by-step instructions for migrating an InfluxDB open source (OSS)
 instance into an InfluxDB Enterprise cluster.
 


### PR DESCRIPTION
This is a short-term warning to prevent users from using the current OSS to Enterprise migration guide until InfluxDB 1.7.10 is available. Once it becomes available, we'll remove this warning and update the guide to reflect the new upgrade process.