### PR TITLE
Revise Enterprise TLS docs

### DIFF
--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -7,16 +7,14 @@ menu:
     parent: Guides
 ---
 
-Enabling HTTPS encrypts the communication between clients and the InfluxDB Enterprise server,
-and between nodes in the cluster.
+Enabling HTTPS encrypts the communication between clients and the InfluxDB Enterprise server, and between nodes in the cluster.
 When configured with a signed certificate, HTTPS can also verify the authenticity of the InfluxDB Enterprise server to connecting clients.
+
+This pages outlines how to set up HTTPS with InfluxDB Enterprise using either a signed or self-signed certificate.
 
 <dt>
 InfluxData **strongly recommends** enabling HTTPS, especially if you plan on sending requests to InfluxDB Enterprise over a network.
 </dt>
-
-The following two sections outline how to set up HTTPS with InfluxDB Enterprise
-using either a CA-signed or self-signed certificate.
 
 {{% note %}}
 These steps have been tested on Debian-based Linux distributions.
@@ -92,7 +90,6 @@ that combine the private key file and the signed certificate file into a single 
 
 4. **Enable HTTPS within the configuration file for each Meta Node**
 
-    HTTPS is disabled by default.
     Enable HTTPS for each Meta Node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
 
     * `https-enabled` to `true`
@@ -120,7 +117,7 @@ that combine the private key file and the signed certificate file into a single 
 
 5. **Enable HTTPS within the configuration file for each Data Node**
 
-    Enable HTTPS by making the following changes in `/etc/influxdb/influxdb.conf`.
+    Make the following sets of changes in the configuration file at `/etc/influxdb/influxdb.conf` on each Data Node:
 
     1. Enable HTTPS for each Data Node within the `[http]` section of the configuration file by setting:
 

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -73,10 +73,11 @@ that combine the private key file and the signed certificate file into a single 
 
     In subsequent steps, you will need to copy the certificate to each node in the cluster.
 
-2. **Install the SSL/TLS certificate in each Meta Node**
+2. **Install the SSL/TLS certificate in each Node**
 
     Place the private key file (`.key`) and the signed certificate file (`.crt`)
-    or the single bundled file (`.pem`) in the `/etc/ssl` directory of each Meta Node and Data Node.
+    or the single bundled file (`.pem`)
+    in the `/etc/ssl` directory of each Meta Node and Data Node.
 
 3. **Ensure file permissions for each Node**
    

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -182,15 +182,16 @@ that combine the private key file and the signed certificate file into a single 
           #for self-signed key
           meta-insecure-tls = true
       ```
+
 6. **Restart InfluxDB Enterprise**
 
-    Restart the InfluxDB Enterprise meta node processes for the configuration changes to take effect:
+    Restart the InfluxDB Enterprise Meta Node processes for the configuration changes to take effect:
 
     ```sh
     sudo systemctl start influxdb-meta
     ```
 
-    Restart the InfluxDB Enterprise data node processes for the configuration changes to take effect:
+    Restart the InfluxDB Enterprise Data Node processes for the configuration changes to take effect:
 
     ```sh
     sudo systemctl restart influxdb
@@ -204,8 +205,15 @@ that combine the private key file and the signed certificate file into a single 
     influxd-ctl -bind-tls show
     ```
 
+    If using a self-signed certificate, use
+
+    ```sh
+    influxd-ctl -bind-tls -k show
+    ```
+
     {{% warn %}}
-Once you have enabled HTTPS, you MUST use `-bind-tls` in order for influxd-ctl to connect to the meta node.
+Once you have enabled HTTPS, you must use `-bind-tls` in order for `influxd-ctl` to connect to the Meta Node.
+With a self-signed certificate, you must also use the `-k` option to skip certificate verification.
     {{% /warn %}}
 
     A successful connection returns output which should resemble the following:
@@ -231,48 +239,8 @@ Once you have enabled HTTPS, you MUST use `-bind-tls` in order for influxd-ctl t
     influx -ssl -host <domain_name>.com
     ```
 
-    A successful connection returns the following:
-
-    ```sh
-    Connected to https://<domain_name>.com:8086 version 1.x.y
-    InfluxDB shell version: 1.x.y
-    >
-    ```
-
-    That's it! You've successfully set up HTTPS with InfluxDB Enterprise.
-
-    ---
-
-    Verify that HTTPS is working on the meta nodes by using `influxd-ctl`.
-
-    ```sh
-    influxd-ctl -bind-tls -k show
-    ```
+    If using a self-signed certificate, use
     
-    {{% warn %}}
-Once you have enabled HTTPS, you MUST use `-bind-tls` in order for influxd-ctl to connect to the meta node.  Because the cert is self-signed, you MUST also use the `-k` option.  This skips certificate verification.
-    {{% /warn %}}
-
-    A successful connection returns output which should resemble the following:
-
-    ```
-    Data Nodes
-    ==========
-    ID   TCP Address               Version
-    4    enterprise-data-01:8088   1.x.y-c1.x.y
-    5    enterprise-data-02:8088   1.x.y-c1.x.y
-    
-    Meta Nodes
-    ==========
-    TCP Address               Version
-    enterprise-meta-01:8091   1.x.y-c1.x.z
-    enterprise-meta-02:8091   1.x.y-c1.x.z
-    enterprise-meta-03:8091   1.x.y-c1.x.z
-    ```
-
-
-    Next, verify that HTTPS is working by connecting to InfluxDB Enterprise with the [CLI tool](/influxdb/latest/tools/shell/):
-
     ```sh
     influx -ssl -unsafeSsl -host <domain_name>.com
     ```

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -51,7 +51,9 @@ that combine the private key file and the signed certificate file into a single 
 
 ## Setup HTTPS in an InfluxDB Enterprise cluster
 
-1. **Generate a self-signed certificate** (optional)
+1. **Download or generate certificate files**
+
+    If using a certificate provided by a CA, follow their instructions to download the certificate files.
 
     If using a self-signed certificate, use the `openssl` utility to create a certificate.
     The following command generates a private key file (`.key`) and a self-signed
@@ -77,6 +79,11 @@ that combine the private key file and the signed certificate file into a single 
     or the single bundled file (`.pem`)
     in the `/etc/ssl/` directory of each meta node and data node.
 
+    {{% note %}}
+Some Certificate Authorities provide certificate files with other extensions.
+Consult your CA if you are unsure about how to use these files.
+    {{% /note %}}
+
 3. **Ensure file permissions for each Node**
    
     Certificate files require read and write access by the `root` user.
@@ -90,7 +97,7 @@ that combine the private key file and the signed certificate file into a single 
 
 4. **Enable HTTPS within the configuration file for each meta node**
 
-    Enable HTTPS for each meta node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
+    Enable HTTPS for each meta node within the `[meta]` section of the meta node configuration file (`influxdb-meta.conf`) by setting:
 
     ```toml
     [meta]
@@ -112,7 +119,7 @@ that combine the private key file and the signed certificate file into a single 
 
 5. **Enable HTTPS within the configuration file for each data node**
 
-    Make the following sets of changes in the configuration file at `/etc/influxdb/influxdb.conf` on each data node:
+    Make the following sets of changes in the configuration file (`influxdb.conf`) on each data node:
 
     1. Enable HTTPS for each data node within the `[http]` section of the configuration file by setting:
 

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -53,13 +53,13 @@ that combine the private key file and the signed certificate file into a single 
 
 1. **Generate a self-signed certificate** (optional)
 
-    If using a self-signed certificate, use the `openssl` utility (preinstalled on many OSes) to create a certificate.
+    If using a self-signed certificate, use the `openssl` utility to create a certificate.
     The following command generates a private key file (`.key`) and a self-signed
     certificate file (`.crt`) which remain valid for the specified `NUMBER_OF_DAYS`.
     It outputs those files to `/etc/ssl/` and gives them the required permissions.
     (Other paths will also work.)
 
-    ```
+    ```sh
     sudo openssl req -x509 -nodes -newkey rsa:2048 \
       -keyout /etc/ssl/influxdb-selfsigned.key \
       -out /etc/ssl/influxdb-selfsigned.crt \
@@ -75,22 +75,22 @@ that combine the private key file and the signed certificate file into a single 
 
     Place the private key file (`.key`) and the signed certificate file (`.crt`)
     or the single bundled file (`.pem`)
-    in the `/etc/ssl/` directory of each Meta Node and Data Node.
+    in the `/etc/ssl/` directory of each meta node and data node.
 
 3. **Ensure file permissions for each Node**
    
     Certificate files require read and write access by the `root` user.
-    Ensure that you have the correct file permissions in each Meta Node and Data Node by running the following commands:
+    Ensure that you have the correct file permissions in each meta node and data node by running the following commands:
 
-    ```
+    ```sh
     sudo chown root:root /etc/ssl/<CA-certificate-file>
     sudo chmod 644 /etc/ssl/<CA-certificate-file>
     sudo chmod 600 /etc/ssl/<private-key-file>
     ```
 
-4. **Enable HTTPS within the configuration file for each Meta Node**
+4. **Enable HTTPS within the configuration file for each meta node**
 
-    Enable HTTPS for each Meta Node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
+    Enable HTTPS for each meta node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
 
     ```toml
     [meta]
@@ -110,11 +110,11 @@ that combine the private key file and the signed certificate file into a single 
       https-insecure-tls = true
     ```
 
-5. **Enable HTTPS within the configuration file for each Data Node**
+5. **Enable HTTPS within the configuration file for each data node**
 
-    Make the following sets of changes in the configuration file at `/etc/influxdb/influxdb.conf` on each Data Node:
+    Make the following sets of changes in the configuration file at `/etc/influxdb/influxdb.conf` on each data node:
 
-    1. Enable HTTPS for each Data Node within the `[http]` section of the configuration file by setting:
+    1. Enable HTTPS for each data node within the `[http]` section of the configuration file by setting:
 
       ```toml
       [http]
@@ -133,7 +133,7 @@ that combine the private key file and the signed certificate file into a single 
         https-private-key = "influxdb.key"
       ```
 
-   2. Configure the Data Nodes to use HTTPS when communicating with other Data Nodes.
+   2. Configure the data nodes to use HTTPS when communicating with other data nodes.
       In the `[cluster]` section of the configuration file, set the following:
 
       ```toml
@@ -151,7 +151,7 @@ that combine the private key file and the signed certificate file into a single 
         https-private-key = "influxdb.key"
       ```
 
-   3. Configure the Data Nodes to use HTTPS when communicating with the Meta Nodes.
+   3. Configure the data nodes to use HTTPS when communicating with the meta nodes.
       In the `[meta]` section of the configuration file, set the following:
 
       ```toml
@@ -172,7 +172,7 @@ that combine the private key file and the signed certificate file into a single 
     sudo systemctl start influxdb-meta
     ```
 
-    Restart the InfluxDB Enterprise Data Node processes for the configuration changes to take effect:
+    Restart the InfluxDB Enterprise data node processes for the configuration changes to take effect:
 
     ```sh
     sudo systemctl restart influxdb
@@ -193,7 +193,7 @@ that combine the private key file and the signed certificate file into a single 
     ```
 
     {{% warn %}}
-Once you have enabled HTTPS, you must use `-bind-tls` in order for `influxd-ctl` to connect to the Meta Node.
+Once you have enabled HTTPS, you must use `-bind-tls` in order for `influxd-ctl` to connect to the meta node.
 With a self-signed certificate, you must also use the `-k` option to skip certificate verification.
     {{% /warn %}}
 
@@ -214,7 +214,7 @@ With a self-signed certificate, you must also use the `-k` option to skip certif
     enterprise-meta-03:8091   1.x.y-c1.x.z
     ```
 
-    Next, verify that HTTPS is working by connecting to InfluxDB Enterprise with the [CLI tool](/influxdb/v1.7/tools/shell/):
+    Next, verify that HTTPS is working by connecting to InfluxDB Enterprise with the [`influx` command line interface](/influxdb/v1.7/tools/shell/):
 
     ```sh
     influx -ssl -host <domain_name>.com
@@ -246,8 +246,8 @@ edit the `urls` setting to indicate `https` instead of `http`.
 Also change `localhost` to the relevant domain name.
 
 The best practice in terms of security is to transfer the certificate to the client and make it trusted
-(either by putting in the OS's trusted certificate system or using the `ssl_ca` option).
-The alternative is to sign the cert using an internal CA and then trust the CA cert.
+(either by putting in the operating system's trusted certificate system or using the `ssl_ca` option).
+The alternative is to sign the certificate using an internal CA and then trust the CA certificate.
 
 If you're using a self-signed certificate,
 uncomment the `insecure_skip_verify` setting and set it to `true`.

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -75,7 +75,7 @@ that combine the private key file and the signed certificate file into a single 
 
     Place the private key file (`.key`) and the signed certificate file (`.crt`)
     or the single bundled file (`.pem`)
-    in the `/etc/ssl` directory of each Meta Node and Data Node.
+    in the `/etc/ssl/` directory of each Meta Node and Data Node.
 
 3. **Ensure file permissions for each Node**
    

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -120,130 +120,68 @@ that combine the private key file and the signed certificate file into a single 
 
 5. **Enable HTTPS within the configuration file for each Data Node**
 
-    HTTPS is disabled by default. There are two sets of configuration changes required.
+    Enable HTTPS by making the following changes in `/etc/influxdb/influxdb.conf`.
 
-    First, enable HTTPS for each Data Node within the `[http]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
+    1. Enable HTTPS for each Data Node within the `[http]` section of the configuration file by setting:
 
-    * `https-enabled` to `true`
-    * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-    * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+      * `https-enabled` to `true`
+      * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+      * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
 
-    ```toml
-    [http]
+      ```toml
+      [http]
 
-      [...]
+        [...]
 
-      # Determines whether HTTPS is enabled.
-      https-enabled = true
+        # Determines whether HTTPS is enabled.
+        https-enabled = true
 
-      [...]
+        [...]
 
-      # The SSL certificate to use when HTTPS is enabled.
-      https-certificate = "<bundled-certificate-file>.pem"
+        # The SSL certificate to use when HTTPS is enabled.
+        https-certificate = "<bundled-certificate-file>.pem"
 
-      # Use a separate private key location.
-      https-private-key = "<bundled-certificate-file>.pem"
-    ```
+        # Use a separate private key location.
+        https-private-key = "<bundled-certificate-file>.pem"
+      ```
 
-    Second, configure the Data Nodes to use HTTPS when communicating with other Data Nodes.
-    Update the following settings within the `[cluster]` section of the configuration file (`/etc/influxdb/influxdb.conf`):
+   2. Configure the Data Nodes to use HTTPS when communicating with other Data Nodes.
+      In the `[cluster]` section of the configuration file, set the following:
 
-    * `https-enabled` to `true`
-    * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-    * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+      * `https-enabled` to `true`
+      * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+      * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
 
-    ```toml
-    [cluster]
+      ```toml
+      [cluster]
 
-      [...]
+        [...]
 
-      # Determines whether data nodes use HTTPS to communicate with each other.
-      https-enabled = true
+        # Determines whether data nodes use HTTPS to communicate with each other.
+        https-enabled = true
 
-      # The SSL certificate to use when HTTPS is enabled.
-      https-certificate = "<bundled-certificate-file>.pem"
+        # The SSL certificate to use when HTTPS is enabled.
+        https-certificate = "<bundled-certificate-file>.pem"
 
-      # Use a separate private key location.
-      https-private-key = "<bundled-certificate-file>.pem"
-    ```
+        # Use a separate private key location.
+        https-private-key = "<bundled-certificate-file>.pem"
+      ```
 
-    Third, configure the Data Nodes to use HTTPS when communicating with the Meta Nodes
-    within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
+   3. Configure the Data Nodes to use HTTPS when communicating with the Meta Nodes.
+      In the `[meta]` section of the configuration file, set the following:
 
-    * `meta-tls-enabled` to `true`
+      * `meta-tls-enabled` to `true`
+      * `meta-insecure-tls` to `true` (if using a self-signed key)
 
-    ```toml
-    [meta]
+      ```toml
+      [meta]
 
-      [...]
-        meta-tls-enabled = true
-    ```
+        [...]
+          meta-tls-enabled = true
 
-    ---
-
-    HTTPS is disabled by default.  There are two sets of configuration changes required.
-
-    First, enable HTTPS for each Data Node within the `[http]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
-
-    * `https-enabled` to `true`
-    * `http-certificate` to `/etc/ssl/influxdb-selfsigned.crt`
-    * `http-private-key` to `/etc/ssl/influxdb-selfsigned.key`
-
-    ```toml
-    [http]
-
-      [...]
-
-      # Determines whether HTTPS is enabled.
-      https-enabled = true
-
-      [...]
-
-      # The SSL certificate to use when HTTPS is enabled.
-      https-certificate = "/etc/ssl/influxdb-selfsigned.crt"
-
-      # Use a separate private key location.
-      https-private-key = "/etc/ssl/influxdb-selfsigned.key"
-    ```
-
-    Second, configure the Data Nodes to use HTTPS when communicating with other Data Nodes.
-    Update the following settings within the `[cluster]` section of the configuration file (`/etc/influxdb/influxdb.conf`):
-
-    * `https-enabled` to `true`
-    * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-    * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-
-    ```toml
-    [cluster]
-
-      [...]
-
-      # Determines whether data nodes use HTTPS to communicate with each other.
-      https-enabled = true
-
-      # The SSL certificate to use when HTTPS is enabled.
-      https-certificate = "<bundled-certificate-file>.pem"
-
-      # Use a separate private key location.
-      https-private-key = "<bundled-certificate-file>.pem"
-    ```
-
-    Third, configure the Data Nodes to use HTTPS when communicating with the Meta Nodes
-    within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
-
-    * `meta-tls-enabled` to `true`
-    * `meta-insecure-tls` to `true` to indicate a self-signed key
-
-    ```toml
-    [meta]
-
-      [...]
-        meta-tls-enabled = true
-
-        #for self-signed key
-        meta-insecure-tls = true
-    ```
-
+          #for self-signed key
+          meta-insecure-tls = true
+      ```
 6. **Restart InfluxDB Enterprise**
 
     Restart the InfluxDB Enterprise meta node processes for the configuration changes to take effect:

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -66,10 +66,10 @@ that combine the private key file and the signed certificate file into a single 
       -days <NUMBER_OF_DAYS>
     ```
 
-    When you execute the command, it will prompt you for more information.
-    You can choose to fill out that information or leave it blank; both actions generate valid certificate files.
+    The command will prompt you for more information.
+    You can choose to fill out these fields or leave them blank; both actions generate valid certificate files.
 
-    In subsequent steps, you will need to copy the certificate to each node in the cluster.
+    In subsequent steps, you will need to copy the certificate and key (or `.pem` file) to each node in the cluster.
 
 2. **Install the SSL/TLS certificate in each Node**
 

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -254,18 +254,19 @@ With a self-signed certificate, you must also use the `-k` option to skip certif
 
 ## Connect Telegraf to a secured InfluxDB Enterprise instance
 
-Connecting [Telegraf](/telegraf/latest/) to an InfluxDB Enterprise instance that's using
-HTTPS requires some additional steps.
+Connecting [Telegraf](/telegraf/latest/)
+to an HTTPS-enabled InfluxDB Enterprise instance requires some additional steps.
 
-In Telegraf's configuration file (`/etc/telegraf/telegraf.conf`), under the OUTPUT PLUGINS section, edit the `urls`
-setting to indicate `https` instead of `http` and change `localhost` to the
-relevant domain name.
->
-The best practice in terms of security is to transfer the cert to the client and make it trusted (e.g. by putting in OS cert repo or using `ssl_ca` option).  The alternative is to sign the cert using an internal CA and then trust the CA cert.
+In Telegraf's configuration file (`/etc/telegraf/telegraf.conf`), under the OUTPUT PLUGINS section,
+edit the `urls` setting to indicate `https` instead of `http`.
+Also change `localhost` to the relevant domain name.
 
+The best practice in terms of security is to transfer the certificate to the client and make it trusted
+(either by putting in the OS's trusted certificate system or using the `ssl_ca` option).
+The alternative is to sign the cert using an internal CA and then trust the CA cert.
 
-If you're using a self-signed certificate, uncomment the `insecure_skip_verify`
-setting and set it to `true`.
+If you're using a self-signed certificate,
+uncomment the `insecure_skip_verify` setting and set it to `true`.
 
 ```toml
 ###############################################################################

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -92,11 +92,6 @@ that combine the private key file and the signed certificate file into a single 
 
     Enable HTTPS for each Meta Node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
 
-    * `https-enabled` to `true`
-    * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-    * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-    * `https-insecure-tls` to `true` (if using a self-signed key)
-
     ```toml
     [meta]
 
@@ -106,11 +101,15 @@ that combine the private key file and the signed certificate file into a single 
       https-enabled = true
 
       # The SSL certificate to use when HTTPS is enabled.
-      https-certificate = "<bundled-certificate-file>.pem"
+      https-certificate = "influxdb.crt"
 
       # Use a separate private key location.
-      https-private-key = "<bundled-certificate-file>.pem"
-      
+      https-private-key = "influxdb.key"
+    ```
+
+    If using a self-signed certificate, also set:
+
+    ```
       # For self-signed key
       https-insecure-tls = true
     ```

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -98,6 +98,7 @@ that combine the private key file and the signed certificate file into a single 
     * `https-enabled` to `true`
     * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
     * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+    * `https-insecure-tls` to `true` (if using a self-signed key)
 
     ```toml
     [meta]
@@ -106,41 +107,13 @@ that combine the private key file and the signed certificate file into a single 
 
       # Determines whether HTTPS is enabled.
       https-enabled = true
-    [...]
 
       # The SSL certificate to use when HTTPS is enabled.
       https-certificate = "<bundled-certificate-file>.pem"
 
       # Use a separate private key location.
       https-private-key = "<bundled-certificate-file>.pem"
-    ```
-
-    ---
-
-    HTTPS is disabled by default.
-    Enable HTTPS for each Meta Node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
-
-    * `https-enabled` to `true`
-    * `https-certificate` to `/etc/ssl/influxdb-selfsigned.crt`
-    * `https-private-key` to `/etc/ssl/influxdb-selfsigned.key`
-    * `https-insecure-tls` to `true` to indicate a self-signed key
-
-    ```toml
-    [meta]
-
-      [...]
-
-      # Determines whether HTTPS is enabled.
-      https-enabled = true
-
-      [...]
-
-      # The SSL certificate to use when HTTPS is enabled.
-      https-certificate = "/etc/ssl/influxdb-selfsigned.crt"
-
-      # Use a separate private key location.
-      https-private-key = "/etc/ssl/influxdb-selfsigned.key"
-
+      
       # For self-signed key
       https-insecure-tls = true
     ```

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -54,323 +54,324 @@ a private key file (`.key`) and a signed certificate file (`.crt`) file pair, as
 that combine the private key file and the signed certificate file into a single bundled file (`.pem`).
 
 ## Setup HTTPS in an InfluxDB Enterprise cluster
-#### Step 1: Generate a self-signed certificate
 
-The following command generates a private key file (`.key`) and a self-signed
-certificate file (`.crt`) which remain valid for the specified `NUMBER_OF_DAYS`.
-It outputs those files to InfluxDB Enterprise's default certificate file paths and gives them
-the required permissions.
+1. **Generate a self-signed certificate** (optional)
 
-```sh
-sudo openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/ssl/influxdb-selfsigned.key -out /etc/ssl/influxdb-selfsigned.crt -days <NUMBER_OF_DAYS>
-```
+    The following command generates a private key file (`.key`) and a self-signed
+    certificate file (`.crt`) which remain valid for the specified `NUMBER_OF_DAYS`.
+    It outputs those files to InfluxDB Enterprise's default certificate file paths and gives them
+    the required permissions.
 
-When you execute the command, it will prompt you for more information.
-You can choose to fill out that information or leave it blank;
-both actions generate valid certificate files.
+    ```sh
+    sudo openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/ssl/influxdb-selfsigned.key -out /etc/ssl/influxdb-selfsigned.crt -days <NUMBER_OF_DAYS>
+    ```
 
-#### Step 1: Install the SSL/TLS certificate in each Data Node
+    When you execute the command, it will prompt you for more information.
+    You can choose to fill out that information or leave it blank;
+    both actions generate valid certificate files.
 
-Place the private key file (`.key`) and the signed certificate file (`.crt`)
-or the single bundled file (`.pem`) in the `/etc/ssl` directory of each Data Node.
+2. **Install the SSL/TLS certificate in each Data Node**
 
-#### Step 2: Ensure file permissions for each Data Node
-Certificate files require read and write access by the `root` user.
-Ensure that you have the correct file permissions in each Data Node by running the following
-commands:
+    Place the private key file (`.key`) and the signed certificate file (`.crt`)
+    or the single bundled file (`.pem`) in the `/etc/ssl` directory of each Data Node.
 
-```
-sudo chown root:root /etc/ssl/<CA-certificate-file>
-sudo chmod 644 /etc/ssl/<CA-certificate-file>
-sudo chmod 600 /etc/ssl/<private-key-file>
-```
-#### Step 3: Enable HTTPS within the configuration file for each Meta Node
+3. **Ensure file permissions for each Data Node**
+   
+    Certificate files require read and write access by the `root` user.
+    Ensure that you have the correct file permissions in each Data Node by running the following
+    commands:
 
-HTTPS is disabled by default.
-Enable HTTPS for each Meta Node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
+    ```
+    sudo chown root:root /etc/ssl/<CA-certificate-file>
+    sudo chmod 644 /etc/ssl/<CA-certificate-file>
+    sudo chmod 600 /etc/ssl/<private-key-file>
+    ```
 
-* `https-enabled` to `true`
-* `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-* `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+4. **Enable HTTPS within the configuration file for each Meta Node**
 
-```toml
-[meta]
+    HTTPS is disabled by default.
+    Enable HTTPS for each Meta Node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
 
- [...]
+    * `https-enabled` to `true`
+    * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+    * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
 
-  # Determines whether HTTPS is enabled.
-  https-enabled = true
-[...]
+    ```toml
+    [meta]
 
-  # The SSL certificate to use when HTTPS is enabled.
-  https-certificate = "<bundled-certificate-file>.pem"
+     [...]
 
-  # Use a separate private key location.
-  https-private-key = "<bundled-certificate-file>.pem"
-```
+      # Determines whether HTTPS is enabled.
+      https-enabled = true
+    [...]
 
----
+      # The SSL certificate to use when HTTPS is enabled.
+      https-certificate = "<bundled-certificate-file>.pem"
 
-HTTPS is disabled by default.
-Enable HTTPS for each Meta Node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
+      # Use a separate private key location.
+      https-private-key = "<bundled-certificate-file>.pem"
+    ```
 
-* `https-enabled` to `true`
-* `https-certificate` to `/etc/ssl/influxdb-selfsigned.crt`
-* `https-private-key` to `/etc/ssl/influxdb-selfsigned.key`
-* `https-insecure-tls` to `true` to indicate a self-signed key
+    ---
 
+    HTTPS is disabled by default.
+    Enable HTTPS for each Meta Node within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb-meta.conf`) by setting:
 
-```toml
-[meta]
+    * `https-enabled` to `true`
+    * `https-certificate` to `/etc/ssl/influxdb-selfsigned.crt`
+    * `https-private-key` to `/etc/ssl/influxdb-selfsigned.key`
+    * `https-insecure-tls` to `true` to indicate a self-signed key
 
-  [...]
+    ```toml
+    [meta]
 
-  # Determines whether HTTPS is enabled.
-  https-enabled = true
+      [...]
 
-  [...]
+      # Determines whether HTTPS is enabled.
+      https-enabled = true
 
-  # The SSL certificate to use when HTTPS is enabled.
-  https-certificate = "/etc/ssl/influxdb-selfsigned.crt"
+      [...]
 
-  # Use a separate private key location.
-  https-private-key = "/etc/ssl/influxdb-selfsigned.key"
+      # The SSL certificate to use when HTTPS is enabled.
+      https-certificate = "/etc/ssl/influxdb-selfsigned.crt"
 
-  # For self-signed key
-  https-insecure-tls = true
-```
+      # Use a separate private key location.
+      https-private-key = "/etc/ssl/influxdb-selfsigned.key"
 
-#### Step 4: Enable HTTPS within the configuration file for each Data Node
+      # For self-signed key
+      https-insecure-tls = true
+    ```
 
-HTTPS is disabled by default. There are two sets of configuration changes required.
+5. **Enable HTTPS within the configuration file for each Data Node**
 
-First, enable HTTPS for each Data Node within the `[http]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
+    HTTPS is disabled by default. There are two sets of configuration changes required.
 
-* `https-enabled` to `true`
-* `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-* `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+    First, enable HTTPS for each Data Node within the `[http]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
 
-```toml
-[http]
+    * `https-enabled` to `true`
+    * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+    * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
 
-  [...]
+    ```toml
+    [http]
 
-  # Determines whether HTTPS is enabled.
-  https-enabled = true
+      [...]
 
-  [...]
+      # Determines whether HTTPS is enabled.
+      https-enabled = true
 
-  # The SSL certificate to use when HTTPS is enabled.
-  https-certificate = "<bundled-certificate-file>.pem"
+      [...]
 
-  # Use a separate private key location.
-  https-private-key = "<bundled-certificate-file>.pem"
-```
+      # The SSL certificate to use when HTTPS is enabled.
+      https-certificate = "<bundled-certificate-file>.pem"
 
-Second, configure the Data Nodes to use HTTPS when communicating with other Data Nodes.
-Update the following settings within the `[cluster]` section of the configuration file (`/etc/influxdb/influxdb.conf`):
+      # Use a separate private key location.
+      https-private-key = "<bundled-certificate-file>.pem"
+    ```
 
-* `https-enabled` to `true`
-* `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-* `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+    Second, configure the Data Nodes to use HTTPS when communicating with other Data Nodes.
+    Update the following settings within the `[cluster]` section of the configuration file (`/etc/influxdb/influxdb.conf`):
 
-```toml
-[cluster]
+    * `https-enabled` to `true`
+    * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+    * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
 
-  [...]
+    ```toml
+    [cluster]
 
-  # Determines whether data nodes use HTTPS to communicate with each other.
-  https-enabled = true
+      [...]
 
-  # The SSL certificate to use when HTTPS is enabled.
-  https-certificate = "<bundled-certificate-file>.pem"
+      # Determines whether data nodes use HTTPS to communicate with each other.
+      https-enabled = true
 
-  # Use a separate private key location.
-  https-private-key = "<bundled-certificate-file>.pem"
-```
+      # The SSL certificate to use when HTTPS is enabled.
+      https-certificate = "<bundled-certificate-file>.pem"
 
+      # Use a separate private key location.
+      https-private-key = "<bundled-certificate-file>.pem"
+    ```
 
-Third, configure the Data Nodes to use HTTPS when communicating with the Meta Nodes
-within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
+    Third, configure the Data Nodes to use HTTPS when communicating with the Meta Nodes
+    within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
 
-* `meta-tls-enabled` to `true`
+    * `meta-tls-enabled` to `true`
 
-```toml
-[meta]
+    ```toml
+    [meta]
 
-  [...]
-    meta-tls-enabled = true
-```
+      [...]
+        meta-tls-enabled = true
+    ```
 
----
+    ---
 
-HTTPS is disabled by default.  There are two sets of configuration changes required.
+    HTTPS is disabled by default.  There are two sets of configuration changes required.
 
-First, enable HTTPS for each Data Node within the `[http]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
+    First, enable HTTPS for each Data Node within the `[http]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
 
-* `https-enabled` to `true`
-* `http-certificate` to `/etc/ssl/influxdb-selfsigned.crt`
-* `http-private-key` to `/etc/ssl/influxdb-selfsigned.key`
+    * `https-enabled` to `true`
+    * `http-certificate` to `/etc/ssl/influxdb-selfsigned.crt`
+    * `http-private-key` to `/etc/ssl/influxdb-selfsigned.key`
 
-```toml
-[http]
+    ```toml
+    [http]
 
-  [...]
+      [...]
 
-  # Determines whether HTTPS is enabled.
-  https-enabled = true
+      # Determines whether HTTPS is enabled.
+      https-enabled = true
 
-  [...]
+      [...]
 
-  # The SSL certificate to use when HTTPS is enabled.
-  https-certificate = "/etc/ssl/influxdb-selfsigned.crt"
+      # The SSL certificate to use when HTTPS is enabled.
+      https-certificate = "/etc/ssl/influxdb-selfsigned.crt"
 
-  # Use a separate private key location.
-  https-private-key = "/etc/ssl/influxdb-selfsigned.key"
-```
+      # Use a separate private key location.
+      https-private-key = "/etc/ssl/influxdb-selfsigned.key"
+    ```
 
-Second, configure the Data Nodes to use HTTPS when communicating with other Data Nodes.
-Update the following settings within the `[cluster]` section of the configuration file (`/etc/influxdb/influxdb.conf`):
+    Second, configure the Data Nodes to use HTTPS when communicating with other Data Nodes.
+    Update the following settings within the `[cluster]` section of the configuration file (`/etc/influxdb/influxdb.conf`):
 
-* `https-enabled` to `true`
-* `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-* `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+    * `https-enabled` to `true`
+    * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
+    * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
 
-```toml
-[cluster]
+    ```toml
+    [cluster]
 
-  [...]
+      [...]
 
-  # Determines whether data nodes use HTTPS to communicate with each other.
-  https-enabled = true
+      # Determines whether data nodes use HTTPS to communicate with each other.
+      https-enabled = true
 
-  # The SSL certificate to use when HTTPS is enabled.
-  https-certificate = "<bundled-certificate-file>.pem"
+      # The SSL certificate to use when HTTPS is enabled.
+      https-certificate = "<bundled-certificate-file>.pem"
 
-  # Use a separate private key location.
-  https-private-key = "<bundled-certificate-file>.pem"
-```
+      # Use a separate private key location.
+      https-private-key = "<bundled-certificate-file>.pem"
+    ```
 
+    Third, configure the Data Nodes to use HTTPS when communicating with the Meta Nodes
+    within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
 
-Third, configure the Data Nodes to use HTTPS when communicating with the Meta Nodes
-within the `[meta]` section of the configuration file (`/etc/influxdb/influxdb.conf`) by setting:
+    * `meta-tls-enabled` to `true`
+    * `meta-insecure-tls` to `true` to indicate a self-signed key
 
-* `meta-tls-enabled` to `true`
-* `meta-insecure-tls` to `true` to indicate a self-signed key
+    ```toml
+    [meta]
 
-```toml
-[meta]
+      [...]
+        meta-tls-enabled = true
 
-  [...]
-    meta-tls-enabled = true
+        #for self-signed key
+        meta-insecure-tls = true
+    ```
 
-    #for self-signed key
-    meta-insecure-tls = true
-```
+6. **Restart InfluxDB Enterprise**
 
-#### Step 5: Restart InfluxDB Enterprise
+    Restart the InfluxDB Enterprise meta node processes for the configuration changes to take effect:
 
-Restart the InfluxDB Enterprise meta node processes for the configuration changes to take effect:
+    ```sh
+    sudo systemctl start influxdb-meta
+    ```
 
-```sh
-sudo systemctl start influxdb-meta
-```
+    Restart the InfluxDB Enterprise data node processes for the configuration changes to take effect:
 
-Restart the InfluxDB Enterprise data node processes for the configuration changes to take effect:
+    ```sh
+    sudo systemctl restart influxdb
+    ```
 
-```sh
-sudo systemctl restart influxdb
-```
+7. **Verify the HTTPS Setup**
 
-#### Step 6: Verify the HTTPS Setup
+    Verify that HTTPS is working on the meta nodes by using `influxd-ctl`.
 
-Verify that HTTPS is working on the meta nodes by using `influxd-ctl`.
+    ```sh
+    influxd-ctl -bind-tls show
+    ```
 
-```sh
-influxd-ctl -bind-tls show
-```
-{{% warn %}}
-   Once you have enabled HTTPS, you MUST use `-bind-tls` in order for influxd-ctl to connect to the meta node.
-{{% /warn %}}
+    {{% warn %}}
+Once you have enabled HTTPS, you MUST use `-bind-tls` in order for influxd-ctl to connect to the meta node.
+    {{% /warn %}}
 
-A successful connection returns output which should resemble the following:
+    A successful connection returns output which should resemble the following:
 
-```
-Data Nodes
-==========
-ID   TCP Address               Version
-4    enterprise-data-01:8088   1.x.y-c1.x.y
-5    enterprise-data-02:8088   1.x.y-c1.x.y
+    ```
+    Data Nodes
+    ==========
+    ID   TCP Address               Version
+    4    enterprise-data-01:8088   1.x.y-c1.x.y
+    5    enterprise-data-02:8088   1.x.y-c1.x.y
+    
+    Meta Nodes
+    ==========
+    TCP Address               Version
+    enterprise-meta-01:8091   1.x.y-c1.x.z
+    enterprise-meta-02:8091   1.x.y-c1.x.z
+    enterprise-meta-03:8091   1.x.y-c1.x.z
+    ```
 
-Meta Nodes
-==========
-TCP Address               Version
-enterprise-meta-01:8091   1.x.y-c1.x.z
-enterprise-meta-02:8091   1.x.y-c1.x.z
-enterprise-meta-03:8091   1.x.y-c1.x.z
-```
+    Next, verify that HTTPS is working by connecting to InfluxDB Enterprise with the [CLI tool](/influxdb/v1.7/tools/shell/):
 
+    ```sh
+    influx -ssl -host <domain_name>.com
+    ```
 
-Next, verify that HTTPS is working by connecting to InfluxDB Enterprise with the [CLI tool](/influxdb/v1.7/tools/shell/):
+    A successful connection returns the following:
 
-```sh
-influx -ssl -host <domain_name>.com
-```
+    ```sh
+    Connected to https://<domain_name>.com:8086 version 1.x.y
+    InfluxDB shell version: 1.x.y
+    >
+    ```
 
-A successful connection returns the following:
+    That's it! You've successfully set up HTTPS with InfluxDB Enterprise.
 
-```sh
-Connected to https://<domain_name>.com:8086 version 1.x.y
-InfluxDB shell version: 1.x.y
->
-```
+    ---
 
-That's it! You've successfully set up HTTPS with InfluxDB Enterprise.
+    Verify that HTTPS is working on the meta nodes by using `influxd-ctl`.
 
----
+    ```sh
+    influxd-ctl -bind-tls -k show
+    ```
+    
+    {{% warn %}}
+Once you have enabled HTTPS, you MUST use `-bind-tls` in order for influxd-ctl to connect to the meta node.  Because the cert is self-signed, you MUST also use the `-k` option.  This skips certificate verification.
+    {{% /warn %}}
 
-Verify that HTTPS is working on the meta nodes by using `influxd-ctl`.
+    A successful connection returns output which should resemble the following:
 
-```sh
-influxd-ctl -bind-tls -k show
-```
-{{% warn %}}
-   Once you have enabled HTTPS, you MUST use `-bind-tls` in order for influxd-ctl to connect to the meta node.  Because the cert is self-signed, you MUST also use the `-k` option.  This skips certificate verification.
-{{% /warn %}}
+    ```
+    Data Nodes
+    ==========
+    ID   TCP Address               Version
+    4    enterprise-data-01:8088   1.x.y-c1.x.y
+    5    enterprise-data-02:8088   1.x.y-c1.x.y
+    
+    Meta Nodes
+    ==========
+    TCP Address               Version
+    enterprise-meta-01:8091   1.x.y-c1.x.z
+    enterprise-meta-02:8091   1.x.y-c1.x.z
+    enterprise-meta-03:8091   1.x.y-c1.x.z
+    ```
 
-A successful connection returns output which should resemble the following:
 
-```
-Data Nodes
-==========
-ID   TCP Address               Version
-4    enterprise-data-01:8088   1.x.y-c1.x.y
-5    enterprise-data-02:8088   1.x.y-c1.x.y
+    Next, verify that HTTPS is working by connecting to InfluxDB Enterprise with the [CLI tool](/influxdb/latest/tools/shell/):
 
-Meta Nodes
-==========
-TCP Address               Version
-enterprise-meta-01:8091   1.x.y-c1.x.z
-enterprise-meta-02:8091   1.x.y-c1.x.z
-enterprise-meta-03:8091   1.x.y-c1.x.z
-```
+    ```sh
+    influx -ssl -unsafeSsl -host <domain_name>.com
+    ```
 
+    A successful connection returns the following:
 
-Next, verify that HTTPS is working by connecting to InfluxDB Enterprise with the [CLI tool](/influxdb/latest/tools/shell/):
+    ```sh
+    Connected to https://<domain_name>.com:8086 version 1.x.y
+    InfluxDB shell version: 1.x.y
+    >
+    ```
 
-```sh
-influx -ssl -unsafeSsl -host <domain_name>.com
-```
-
-A successful connection returns the following:
-
-```sh
-Connected to https://<domain_name>.com:8086 version 1.x.y
-InfluxDB shell version: 1.x.y
->
-```
-
-That's it! You've successfully set up HTTPS with InfluxDB Enterprise.
+    That's it! You've successfully set up HTTPS with InfluxDB Enterprise.
 
 ## Connect Telegraf to a secured InfluxDB Enterprise instance
 

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -105,12 +105,8 @@ that combine the private key file and the signed certificate file into a single 
 
       # Use a separate private key location.
       https-private-key = "influxdb.key"
-    ```
 
-    If using a self-signed certificate, also set:
-
-    ```
-      # For self-signed key
+      # If using a self-signed certificate:
       https-insecure-tls = true
     ```
 
@@ -119,10 +115,6 @@ that combine the private key file and the signed certificate file into a single 
     Make the following sets of changes in the configuration file at `/etc/influxdb/influxdb.conf` on each Data Node:
 
     1. Enable HTTPS for each Data Node within the `[http]` section of the configuration file by setting:
-
-      * `https-enabled` to `true`
-      * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-      * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
 
       ```toml
       [http]
@@ -135,18 +127,14 @@ that combine the private key file and the signed certificate file into a single 
         [...]
 
         # The SSL certificate to use when HTTPS is enabled.
-        https-certificate = "<bundled-certificate-file>.pem"
+        https-certificate = "influxdb.crt"
 
         # Use a separate private key location.
-        https-private-key = "<bundled-certificate-file>.pem"
+        https-private-key = "influxdb.key"
       ```
 
    2. Configure the Data Nodes to use HTTPS when communicating with other Data Nodes.
       In the `[cluster]` section of the configuration file, set the following:
-
-      * `https-enabled` to `true`
-      * `http-certificate` to `/etc/ssl/<signed-certificate-file>.crt` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
-      * `http-private-key` to `/etc/ssl/<private-key-file>.key` (or to `/etc/ssl/<bundled-certificate-file>.pem`)
 
       ```toml
       [cluster]
@@ -157,17 +145,14 @@ that combine the private key file and the signed certificate file into a single 
         https-enabled = true
 
         # The SSL certificate to use when HTTPS is enabled.
-        https-certificate = "<bundled-certificate-file>.pem"
+        https-certificate = "influxdb.crt"
 
         # Use a separate private key location.
-        https-private-key = "<bundled-certificate-file>.pem"
+        https-private-key = "influxdb.key"
       ```
 
    3. Configure the Data Nodes to use HTTPS when communicating with the Meta Nodes.
       In the `[meta]` section of the configuration file, set the following:
-
-      * `meta-tls-enabled` to `true`
-      * `meta-insecure-tls` to `true` (if using a self-signed key)
 
       ```toml
       [meta]
@@ -175,13 +160,13 @@ that combine the private key file and the signed certificate file into a single 
         [...]
           meta-tls-enabled = true
 
-          #for self-signed key
+          # If using a self-signed certificate:
           meta-insecure-tls = true
       ```
 
 6. **Restart InfluxDB Enterprise**
 
-    Restart the InfluxDB Enterprise Meta Node processes for the configuration changes to take effect:
+    Restart the InfluxDB Enterprise processes for the configuration changes to take effect:
 
     ```sh
     sudo systemctl start influxdb-meta
@@ -201,7 +186,7 @@ that combine the private key file and the signed certificate file into a single 
     influxd-ctl -bind-tls show
     ```
 
-    If using a self-signed certificate, use
+    If using a self-signed certificate, use:
 
     ```sh
     influxd-ctl -bind-tls -k show

--- a/content/enterprise_influxdb/v1.7/guides/https_setup.md
+++ b/content/enterprise_influxdb/v1.7/guides/https_setup.md
@@ -15,10 +15,8 @@ When configured with a signed certificate, HTTPS can also verify the authenticit
 InfluxData **strongly recommends** enabling HTTPS, especially if you plan on sending requests to InfluxDB Enterprise over a network.
 </dt>
 
-The following two sections outline how to set up HTTPS with InfluxDB Enterprise:
-
-- [using a CA-signed certificate](#setup-https-with-a-ca-signed-certificate)
-- [using a self-signed certificate](#setup-https-with-a-self-signed-certificate)
+The following two sections outline how to set up HTTPS with InfluxDB Enterprise
+using either a CA-signed or self-signed certificate.
 
 {{% note %}}
 These steps have been tested on Debian-based Linux distributions.
@@ -57,29 +55,33 @@ that combine the private key file and the signed certificate file into a single 
 
 1. **Generate a self-signed certificate** (optional)
 
+    If using a self-signed certificate, use the `openssl` utility (preinstalled on many OSes) to create a certificate.
     The following command generates a private key file (`.key`) and a self-signed
     certificate file (`.crt`) which remain valid for the specified `NUMBER_OF_DAYS`.
-    It outputs those files to InfluxDB Enterprise's default certificate file paths and gives them
-    the required permissions.
+    It outputs those files to `/etc/ssl/` and gives them the required permissions.
+    (Other paths will also work.)
 
-    ```sh
-    sudo openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/ssl/influxdb-selfsigned.key -out /etc/ssl/influxdb-selfsigned.crt -days <NUMBER_OF_DAYS>
+    ```
+    sudo openssl req -x509 -nodes -newkey rsa:2048 \
+      -keyout /etc/ssl/influxdb-selfsigned.key \
+      -out /etc/ssl/influxdb-selfsigned.crt \
+      -days <NUMBER_OF_DAYS>
     ```
 
     When you execute the command, it will prompt you for more information.
-    You can choose to fill out that information or leave it blank;
-    both actions generate valid certificate files.
+    You can choose to fill out that information or leave it blank; both actions generate valid certificate files.
 
-2. **Install the SSL/TLS certificate in each Data Node**
+    In subsequent steps, you will need to copy the certificate to each node in the cluster.
+
+2. **Install the SSL/TLS certificate in each Meta Node**
 
     Place the private key file (`.key`) and the signed certificate file (`.crt`)
-    or the single bundled file (`.pem`) in the `/etc/ssl` directory of each Data Node.
+    or the single bundled file (`.pem`) in the `/etc/ssl` directory of each Meta Node and Data Node.
 
-3. **Ensure file permissions for each Data Node**
+3. **Ensure file permissions for each Node**
    
     Certificate files require read and write access by the `root` user.
-    Ensure that you have the correct file permissions in each Data Node by running the following
-    commands:
+    Ensure that you have the correct file permissions in each Meta Node and Data Node by running the following commands:
 
     ```
     sudo chown root:root /etc/ssl/<CA-certificate-file>


### PR DESCRIPTION
Revisions throughout. Reduced this to one set of instructions instead of two.

## For reviewers

Probably easier to pull down these changes and review locally with `hugo server`.

- [x] Builds succeeds locally