### PR TITLE
Added docs for pending discord alert handler

### DIFF
--- a/content/kapacitor/v1.5/administration/configuration.md
+++ b/content/kapacitor/v1.5/administration/configuration.md
@@ -548,6 +548,7 @@ document.
 The following handlers are currently supported:
 
 * [Alerta](/kapacitor/v1.5/event_handlers/alerta/): Sending alerts to Alerta.
+* [Discord](/kapacitor/v1.5/event_handlers/discord/): Sending alerts to Discord.
 * [Email](/kapacitor/v1.5/event_handlers/email/): To send alerts by email.
 * [HipChat](/kapacitor/v1.5/event_handlers/hipchat/): Sending alerts to the HipChat service.
 * [Kafka](/kapacitor/v1.5/event_handlers/kafka/): Sending alerts to an Apache Kafka cluster.

--- a/content/kapacitor/v1.5/event_handlers/_index.md
+++ b/content/kapacitor/v1.5/event_handlers/_index.md
@@ -21,6 +21,7 @@ syntax for officially supported Kapacitor event handlers.
 
 [Aggregate](/kapacitor/v1.5/event_handlers/aggregate/)  
 [Alerta](/kapacitor/v1.5/event_handlers/alerta/)  
+[Discord](/kapacitor/v1.5/event_handlers/discord/)  
 [Email](/kapacitor/v1.5/event_handlers/email/)  
 [Exec](/kapacitor/v1.5/event_handlers/exec/)  
 [Hipchat](/kapacitor/v1.5/event_handlers/hipchat/)  

--- a/content/kapacitor/v1.5/event_handlers/discord.md
+++ b/content/kapacitor/v1.5/event_handlers/discord.md
@@ -1,0 +1,314 @@
+---
+title: Discord event handler
+description: The Discord event handler allows you to send Kapacitor alerts to Discord. This page includes configuration options and usage examples.
+menu:
+  kapacitor_1_5:
+    name: Discord
+    weight: 250
+    parent: event-handlers
+---
+
+[Discord](https://discordapp.com) is a popular chat service targeted primarily at gamers but is used by some teams.
+Kapacitor can be configured to send alert messages to Discord.
+
+## Configuration
+Configuration as well as default [option](#options) values for the Discord event
+handler are set in your `kapacitor.conf`.
+Below is an example configuration:
+
+```toml
+[[discord]]
+  enabled = false
+  default = true
+  url = "https://discordapp.com/api/webhooks/xxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  workspace = "guild-channel"
+  timestamp = true
+  username = "Kapacitor"
+  avatar-url = "https://influxdata.github.io/branding/img/downloads/influxdata-logo--symbol--pool-alpha.png"
+  embed-title = "Kapacitor Alert"
+  global = false
+  state-changes-only = false
+  ssl-ca = "/path/to/ca.crt"
+  ssl-cert = "/path/to/cert.crt"
+  ssl-key = "/path/to/private-key.key"
+  insecure-skip-verify = false
+```
+
+> Multiple Discord clients may be configured by repeating `[[discord]]` sections.
+The `workspace` acts as a unique identifier for each configured Discord client.
+
+#### `enabled`
+Set to `true` to enable the Discord event handler.
+
+#### `default`
+Identify one of the Discord configurations as the default if there are multiple
+Discord configurations.
+
+#### `workspace`
+The Discord workspace ID.
+This can be any string that identifies this particular Discord configuration.
+A logical choice is the name of the Discord channel and the guild it's a part 
+of, e.g. `<guild>-<channel>`.
+
+#### `timestamp`
+Boolean signifying whether the timestamp should be shown in the embed.
+
+#### `url`
+The Discord webhook URL. This can be obtained by adding an Incoming Webhook integration.
+Follow [this guide](https://support.discordapp.com/hc/en-us/articles/228383668) and add a webhook for Kapacitor.
+Discord will provide you with the webhook URL.
+
+#### `username`
+The username of the Discord bot. If set, this will override the username 
+set when generating the webhook.
+
+#### `avatar-url`
+A URL pointing to the desired avatar of the bot. If set, this will
+override the avatar set when generating the webhook.
+
+#### `embed-title`
+The title displayed in the alert embed. If left blank, no title will
+be set
+
+#### `global`
+If true all the alerts will be sent to Discord without explicitly specifying Discord
+in the TICKscript.
+
+#### `state-changes-only`
+Sets all alerts in state-changes-only mode, meaning alerts will only be sent if
+the alert state changes.
+_Only applies if `global` is `true`._
+
+#### `ssl-ca`
+Path to certificate authority file.
+
+#### `ssl-cert`
+Path to host certificate file.
+
+#### `ssl-key`
+Path to certificate private key file.
+
+#### `insecure-skip-verify`
+Use SSL but skip chain and host verification.
+_This is necessary if using a self-signed certificate._
+
+## Options
+The following Discord event handler options can be set in a
+[handler file](/kapacitor/v1.5/event_handlers/#handler-file) or when using
+`.discord()` in a TICKscript.
+
+| Name        | Type   | Description                                                                                                                    |
+| ----        | ----   | -----------                                                                                                                    |
+| workspace   | string | Specifies which Discord configuration to use when there are multiple.                                                          |
+| timestamp   | bool   | Specifies whether to show the timestamp in the embed footer. If blank uses the choice from the configuration.                  |
+| username    | string | Username of the Discord bot. If empty uses the username from the configuration.                                                |
+| avatar-url  | string | URL of image to use as the webhook's avatar. If empty uses the url from the configuration.                                     |
+| embed-title | string | Title of alert embed posted to the webhook. If empty uses the title set in the configuration.                                  |
+
+### Example: handler file
+```yaml
+id: handler-id
+topic: topic-name
+kind: discord
+options:
+  workspace: 'guild-channel'
+  username: 'Kapacitor'
+  avatar-url: 'https://influxdata.github.io/branding/img/downloads/influxdata-logo--symbol--pool-alpha.png'
+  timestamp: true
+  embed-title: 'Kapacitor Alert'
+```
+
+### Example: TICKscript
+```js
+|alert()
+  // ...
+  .discord()
+    .workspace('guild-channel')
+    .username('Kapacitor')
+    .avatarUrl('https://influxdata.github.io/branding/img/downloads/influxdata-logo--symbol--pool-alpha.png')
+    .timestamp(true)
+    .embedTitle('Kapacitor Alert')
+```
+
+## Guild Setup
+To allow Kapacitor to send alerts to Discord, follow [this guide](https://support.discordapp.com/hc/en-us/articles/228383668)
+to generate a webhook for Kapacitor. Add the generated webhook 
+URL as the `url` in the `[[discord]]` configuration section of
+your `kapacitor.conf`.
+
+## Using the Discord event handler
+With one or more Discord event handlers enabled and configured in your
+`kapacitor.conf`, use the `.discord()` attribute in your TICKscripts to send
+alerts to Discord or define a Discord handler that subscribes to a topic and sends
+published alerts to Discord.
+
+> To avoid posting a message every alert interval, use
+> [AlertNode.StateChangesOnly](/kapacitor/v1.5/nodes/alert_node/#statechangesonly)
+> so only events where the alert changed state are sent to Discord.
+
+The examples below use the following Discord configurations defined in the `kapacitor.conf`:
+
+_**Discord settings in kapacitor.conf**_
+```toml
+[[discord]]
+  enabled = true
+  default = true
+  url = "https://discordapp.com/api/webhooks/xxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  workspace = "guild-alerts"
+  timestamp = true
+  username = "AlertBot"
+  avatar-url = "https://influxdata.github.io/branding/img/downloads/influxdata-logo--symbol--pool-alpha.png"
+  embed-title = "Alert"
+  global = false
+  state-changes-only = false
+
+[[discord]]
+  enabled = true
+  default = false
+  url = "https://discordapp.com/api/webhooks/xxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  workspace = "guild-errors"
+  timestamp = true
+  username = "StatsBot"
+  avatar-url = "https://influxdata.github.io/branding/img/downloads/influxdata-logo--symbol--pool-alpha.png"
+  embed-title = "Errors"
+  global = false
+  state-changes-only = false
+```
+
+### Send alerts to Discord from a TICKscript
+The following TICKscript uses the `.discord()` event handler to send the message,
+"Hey, check your CPU", to the Discord webhook channel whenever idle CPU usage
+drops below 20%.
+
+_**discord-cpu-alert.tick**_  
+```js
+stream
+  |from()
+    .measurement('cpu')
+  |alert()
+    .warn(lambda: "usage_idle" < 20)
+    .stateChangesOnly()
+    .message('Hey, check your CPU')
+    .discord()   
+      .embedTitle('Uh Oh!')  
+```
+
+### Send alerts to Discord from a defined handler
+
+The following setup sends an alert to the `cpu` topic with the message,
+"Hey, check your CPU".
+A Discord handler is added that subscribes to the `cpu` topic and publishes all
+alert messages to Discord.
+
+Create a TICKscript that publishes alert messages to a topic.
+The TICKscript below sends an critical alert message to the `cpu` topic any time
+idle CPU usage drops below 5%.
+
+_**cpu\_alert.tick**_
+```js
+stream
+  |from()
+    .measurement('cpu')
+  |alert()
+    .crit(lambda: "usage_idle" < 5)
+    .stateChangesOnly()
+    .message('Hey, check your CPU')
+    .topic('cpu')
+```
+
+Add and enable the TICKscript:
+
+```bash
+kapacitor define cpu_alert -tick cpu_alert.tick
+kapacitor enable cpu_alert
+```
+
+Create a handler file that subscribes to the `cpu` topic and uses the Discord
+event handler to send alerts to Discord. This handler is using the non-default Discord
+handler, "critical-alerts", which sends messages to the #critical-alerts channel
+in Discord.
+
+_**discord\_cpu\_handler.yaml**_
+```yaml
+id: discord-cpu-alert
+topic: cpu
+kind: discord
+options:
+  workspace: 'guild-alerts'
+  embed-title: 'Hey, Listen!'
+```
+
+Add the handler:
+
+```bash
+kapacitor define-topic-handler discord_cpu_handler.yaml
+```
+
+### Using multiple Discord configurations
+Kapacitor can use multiple Discord integrations, each identified by the value of
+the [`workspace`](#workspace) config. The TICKscript below illustrates how
+multiple Discord integrations can be used.
+
+In the `kapacitor.conf` [above](#using-the-discord-event-handler), there are two
+Discord configurations; one for alerts and the other for daily stats. The
+`workspace` configuration for each Discord configuration act as a unique identifiers.
+
+The following TICKscript sends alerts to the `alerts` Discord workspace.
+
+_**discord-cpu-alert.tick**_  
+```js
+stream
+  |from()
+    .measurement('cpu')
+  |alert()
+    .crit(lambda: "usage_idle" < 5)
+    .stateChangesOnly()
+    .message('Hey, I think the machine is on fire.')
+    .discord()
+      .workspace('alerts')
+      .embedTitle('AAAAAAAAAAAAAAAAAAAAAA')
+```
+
+Error rates are also being stored in the same InfluxDB instance and we want to
+send daily reports of `500` errors to the `error-reports` Discord workspace.
+The following TICKscript collects `500` error occurances and publishes them to
+the `500-errors` topic.
+
+_**500_errors.tick**_
+```js
+stream
+  |from()
+    .measurement('errors')
+    .groupBy('500')
+  |alert()
+    .info(lamda: 'count' > 0)
+    .noRecoveries()
+    .topic('500-errors')  
+```
+
+Below is an [aggregate](/kapacitor/v1.5/event_handlers/aggregate/) handler that
+subscribes to the `500-errors` topic, aggregates the number of 500 errors over a
+24 hour period, then publishes an aggregate message to the `500-errors-24h` topic.
+
+_**500\_errors\_24h.yaml**_
+```yaml
+id: 500-errors-24h
+topic: 500-errors
+kind: aggregate
+options:
+  interval: 24h
+  topic: 500-errors-24h
+  message: '{{ .Count }} 500 errors last 24 hours.'
+```
+
+Last, but not least, a Discord handler that subscribes to the `500-errors-24h`
+topic and publishes aggregated count messages to the `error-reports` Discord workspace:
+
+_**discord\_500\_errors\_daily.yaml**_
+```yaml
+id: discord-500-errors-daily
+topic: 500-errors-24h
+kind: discord
+options:
+  workspace: guild-errors
+```

--- a/content/kapacitor/v1.5/event_handlers/discord.md
+++ b/content/kapacitor/v1.5/event_handlers/discord.md
@@ -1,6 +1,6 @@
 ---
 title: Discord event handler
-description: The Discord event handler allows you to send Kapacitor alerts to Discord. This page includes configuration options and usage examples.
+description: The Discord event handler lets you send Kapacitor alerts to Discord. This page includes configuration options and usage examples.
 menu:
   kapacitor_1_5:
     name: Discord
@@ -8,8 +8,8 @@ menu:
     parent: event-handlers
 ---
 
-[Discord](https://discordapp.com) is a popular chat service targeted primarily at gamers but is used by some teams.
-Kapacitor can be configured to send alert messages to Discord.
+[Discord](https://discordapp.com) is a popular chat service targeted primarily at gamers and by teams outside of gaming looking for a free solution.
+To configure Kapacitor to send alert messages to Discord, set the applicable configuration options.
 
 ## Configuration
 Configuration as well as default [option](#options) values for the Discord event
@@ -41,38 +41,32 @@ The `workspace` acts as a unique identifier for each configured Discord client.
 Set to `true` to enable the Discord event handler.
 
 #### `default`
-Identify one of the Discord configurations as the default if there are multiple
-Discord configurations.
+If multiple Discord client configurations are specified, identify one configuration as the default.
 
 #### `workspace`
 The Discord workspace ID.
-This can be any string that identifies this particular Discord configuration.
-A logical choice is the name of the Discord channel and the guild it's a part 
-of, e.g. `<guild>-<channel>`.
+Set this string to identify this particular Discord configuration.
+For example, the name of the Discord channel and the guild it's a part 
+of, such as `<guild>-<channel>`.
 
 #### `timestamp`
 Boolean signifying whether the timestamp should be shown in the embed.
 
 #### `url`
-The Discord webhook URL. This can be obtained by adding an Incoming Webhook integration.
-Follow [this guide](https://support.discordapp.com/hc/en-us/articles/228383668) and add a webhook for Kapacitor.
+The Discord webhook URL. This can be obtained by adding a webhook in the channel settings - see [Intro to Webhooks](https://support.discordapp.com/hc/en-us/articles/228383668) for a full guide.
 Discord will provide you with the webhook URL.
 
 #### `username`
-The username of the Discord bot. If set, this will override the username 
-set when generating the webhook.
+Set the Discord bot username to override the username set when generating the webhook.
 
 #### `avatar-url`
-A URL pointing to the desired avatar of the bot. If set, this will
-override the avatar set when generating the webhook.
+Set a URL to a specified avatar to override the avatar set when generating the webhook.
 
 #### `embed-title`
-The title displayed in the alert embed. If left blank, no title will
-be set
+Set the title to display in the alert embed. If blank, no title will is set.
 
 #### `global`
-If true all the alerts will be sent to Discord without explicitly specifying Discord
-in the TICKscript.
+Set to `true` to send all alerts to Discord without explicitly specifying Discord in the TICKscript.
 
 #### `state-changes-only`
 Sets all alerts in state-changes-only mode, meaning alerts will only be sent if
@@ -80,20 +74,20 @@ the alert state changes.
 _Only applies if `global` is `true`._
 
 #### `ssl-ca`
-Path to certificate authority file.
+Set path to certificate authority file.
 
 #### `ssl-cert`
-Path to host certificate file.
+Set path to host certificate file.
 
 #### `ssl-key`
-Path to certificate private key file.
+Set path to certificate private key file.
 
 #### `insecure-skip-verify`
-Use SSL but skip chain and host verification.
+Set to `true` to use SSL but skip chain and host verification.
 _This is necessary if using a self-signed certificate._
 
 ## Options
-The following Discord event handler options can be set in a
+Set the following Discord event handler options in a
 [handler file](/kapacitor/v1.5/event_handlers/#handler-file) or when using
 `.discord()` in a TICKscript.
 
@@ -130,10 +124,9 @@ options:
     .embedTitle('Kapacitor Alert')
 ```
 
-## Guild Setup
-To allow Kapacitor to send alerts to Discord, follow [this guide](https://support.discordapp.com/hc/en-us/articles/228383668)
-to generate a webhook for Kapacitor. Add the generated webhook 
-URL as the `url` in the `[[discord]]` configuration section of
+## Set up Guild
+To allow Kapacitor to send alerts to Discord, obtain a webhook url from Discord - see [Intro to Webhooks](https://support.discordapp.com/hc/en-us/articles/228383668)
+Then, add the generated webhook URL as the `url` in the `[[discord]]` configuration section of
 your `kapacitor.conf`.
 
 ## Using the Discord event handler
@@ -146,7 +139,7 @@ published alerts to Discord.
 > [AlertNode.StateChangesOnly](/kapacitor/v1.5/nodes/alert_node/#statechangesonly)
 > so only events where the alert changed state are sent to Discord.
 
-The examples below use the following Discord configurations defined in the `kapacitor.conf`:
+See examples below for sample Discord configurations defined the `kapacitor.conf`:
 
 _**Discord settings in kapacitor.conf**_
 ```toml
@@ -176,8 +169,9 @@ _**Discord settings in kapacitor.conf**_
 ```
 
 ### Send alerts to Discord from a TICKscript
-The following TICKscript uses the `.discord()` event handler to send the message,
-"Hey, check your CPU", to the Discord webhook channel whenever idle CPU usage
+Use the `.discord()` event handler in your TICKscript to send an alert.
+For example, this configuration will send an alert with the message
+"Hey, check your CPU", to the Discord channel whenever idle CPU usage
 drops below 20%.
 
 _**discord-cpu-alert.tick**_  
@@ -195,8 +189,8 @@ stream
 
 ### Send alerts to Discord from a defined handler
 
-The following setup sends an alert to the `cpu` topic with the message,
-"Hey, check your CPU".
+Add a Discord handler that subscribes to the `cpu` by creating a TICKscript that publishes alert messages to a topic.
+For example, this configuration will send an alert with the message "Hey, check your CPU".
 A Discord handler is added that subscribes to the `cpu` topic and publishes all
 alert messages to Discord.
 
@@ -269,7 +263,7 @@ stream
       .embedTitle('AAAAAAAAAAAAAAAAAAAAAA')
 ```
 
-Error rates are also being stored in the same InfluxDB instance and we want to
+Error rates are also stored in the same InfluxDB instance and we want to
 send daily reports of `500` errors to the `error-reports` Discord workspace.
 The following TICKscript collects `500` error occurances and publishes them to
 the `500-errors` topic.

--- a/content/kapacitor/v1.5/nodes/alert_node.md
+++ b/content/kapacitor/v1.5/nodes/alert_node.md
@@ -34,6 +34,7 @@ and [AlertNode.Crit](/kapacitor/v1.5/nodes/alert_node/#crit) below.
 | **[crit](#crit)&nbsp;(&nbsp;`value`&nbsp;`ast.LambdaNode`)** | Filter expression for the CRITICAL alert level. An empty value indicates the level is invalid and is skipped.  |
 | **[critReset](#critreset)&nbsp;(&nbsp;`value`&nbsp;`ast.LambdaNode`)** | Filter expression for resetting the CRITICAL alert level to lower level.  |
 | **[details](#details)&nbsp;(&nbsp;`value`&nbsp;`string`)** | Template for constructing a detailed HTML message for the alert. The same template data is available as the AlertNode.Message property, in addition to a Message field that contains the rendered Message value.  |
+| **[discord](#discord)&nbsp;(&nbsp;)** | Send the alert to Discord. |
 | **[durationField](#durationfield)&nbsp;(&nbsp;`value`&nbsp;`string`)** | Optional field key to add the alert duration to the data. The duration is always in units of nanoseconds.  |
 | **[email](#email)&nbsp;(&nbsp;`to`&nbsp;`...string`)** | Email the alert data.  |
 | **[exec](#exec)&nbsp;(&nbsp;`executable`&nbsp;`string`,&nbsp;`args`&nbsp;`...string`)** | Execute a command whenever an alert is triggered and pass the alert data over STDIN in JSON format.  |
@@ -138,6 +139,7 @@ option, `global`, that indicates that all alerts implicitly use the handler.
 | Handler                       | Description                                                                           |
 | -------                       | -----------                                                                           |
 | [Alerta](#alerta)             | Post alert message to Alerta.                                                         |
+| [Discord](#discord)           | Post alert message to Discord channel.                                                |
 | [email](#email)               | Send and email with alert data.                                                       |
 | [exec](#exec)                 | Execute a command passing alert data over STDIN.                                      |
 | [HipChat](#hipchat)           | Post alert message to HipChat room.                                                   |
@@ -364,6 +366,29 @@ Value: {{ index .Fields "value" }}
 
 ```js
 alert.details(value string)
+```
+
+<a class="top" href="javascript:document.getElementsByClassName('article-heading')[0].scrollIntoView();" title="top"><span class="icon arrow-up"></span></a>
+
+### Discord
+
+Send the alert to Discord.
+Detailed configuration options and setup instructions are provided in the
+[Discord Event Handler](/kapacitor/v1.5/event_handlers/discord/) article.
+
+_**Example kapacitor.conf**_
+```toml
+[discord]
+  enabled = true
+  url = "https://discordapp.com/api/webhooks/xxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+_**Example TICKscript**_
+```js
+stream
+  |alert()
+    .discord()
+      .embedTitle('Alert!')
 ```
 
 <a class="top" href="javascript:document.getElementsByClassName('article-heading')[0].scrollIntoView();" title="top"><span class="icon arrow-up"></span></a>


### PR DESCRIPTION
Documentation for https://github.com/influxdata/kapacitor/pull/2287/. Mostly copied and corrected from the Slack config as I used it for the base of the kapacitor implementation. 