### PR TITLE
Updated instructions to LDAP docs

### DIFF
--- a/content/enterprise_influxdb/v1.7/administration/ldap.md
+++ b/content/enterprise_influxdb/v1.7/administration/ldap.md
@@ -25,6 +25,7 @@ To use LDAP with an InfluxDB Enterprise cluster, do the following:
 1. [Configure data nodes](#configure-data-nodes)
 2. [Configure meta nodes](#configure-meta-nodes)
 3. [Create, verify, and upload the LDAP configuration file](#create-verify-and-upload-the-ldap-configuration-file)
+4. [Restart meta and data nodes](#restart-meta-and-data-nodes)
 
 ### Configure data nodes
 
@@ -86,6 +87,49 @@ For more detail on authentication, see [Authentication and authorization in Infl
     ```bash
     influxd-ctl ldap set-config /path/to/ldap.toml
     ```
+
+###  Restart meta and data nodes
+
+Restart all meta and data nodes in your InfluxDB Enterprise cluster to load your
+updated configuration.
+
+On each **meta** node:
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[sysvinit](#)
+[systemd](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+```sh
+service influxdb-meta restart
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```sh
+sudo systemctl restart influxdb-meta
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
+
+On each **data** node:
+
+{{< code-tabs-wrapper >}}
+{{% code-tabs %}}
+[sysvinit](#)
+[systemd](#)
+{{% /code-tabs %}}
+{{% code-tab-content %}}
+```sh
+service influxdb restart
+```
+{{% /code-tab-content %}}
+{{% code-tab-content %}}
+```sh
+sudo systemctl restart influxdb
+```
+{{% /code-tab-content %}}
+{{< /code-tabs-wrapper >}}
 
 ## Sample LDAP configuration
 

--- a/content/enterprise_influxdb/v1.7/administration/ldap.md
+++ b/content/enterprise_influxdb/v1.7/administration/ldap.md
@@ -93,7 +93,7 @@ For more detail on authentication, see [Authentication and authorization in Infl
 Restart all meta and data nodes in your InfluxDB Enterprise cluster to load your
 updated configuration.
 
-On each **meta** node:
+On each **meta** node, run:
 
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}
@@ -112,7 +112,7 @@ sudo systemctl restart influxdb-meta
 {{% /code-tab-content %}}
 {{< /code-tabs-wrapper >}}
 
-On each **data** node:
+On each **data** node, run:
 
 {{< code-tabs-wrapper >}}
 {{% code-tabs %}}


### PR DESCRIPTION
Added information about restarting meta and data nodes after updating the InfluxDB and LDAP configurations.

**Note:** Once approved, this change needs to be ported to the `influxdb-enterprise-1.8` branch in the `enteprise_influxdb/v1.8` directory.