### PR TITLE
Note configuration guidelines were tested against TSI

### DIFF
--- a/content/influxdb/v1.7/administration/upgrading.md
+++ b/content/influxdb/v1.7/administration/upgrading.md
@@ -37,7 +37,7 @@ We recommend enabling Time Series Index (TSI) (step 3 of Upgrade to InfluxDB 1.7
 
 ## Switch between `tsi1` and `inmem`
 
-After enabling TSI (`tsi1`), switch between using TSI (`tsi1`) and in-memory index (`inmem`) as needed by completing step 3 and 4 above in [Upgrade to InfluxDB 1.7.x](#upgrade-to-influxdb-1-7-x), altering `inmem` and `tsi` as applicable.
+After enabling TSI (`tsi1`), switch between using TSI (`tsi1`) and in-memory index (`inmem`) as needed by completing steps 3 and 4 above in [Upgrade to InfluxDB 1.7.x](#upgrade-to-influxdb-1-7-x), altering `inmem` and `tsi` as applicable.
 
 ## Downgrade InfluxDB
 

--- a/content/influxdb/v1.7/administration/upgrading.md
+++ b/content/influxdb/v1.7/administration/upgrading.md
@@ -8,17 +8,16 @@ menu:
         parent: Administration
 ---
 
-
-We recommend enabling Time Series Index (TSI) (step 3 of Upgrade to InfluxDB 1.7.x). [Switch between TSM and TSI](#switch-between-tsm-and-tsi-indexes) as needed. To learn more about TSI, see:
+We recommend enabling Time Series Index (TSI) (step 3 of Upgrade to InfluxDB 1.7.x). To learn more about TSI, see:
 
 - [Time Series Index (TSI) overview](/influxdb/v1.7/concepts/time-series-index/)
 - [Time Series Index (TSI) details](/influxdb/v1.7/concepts/tsi-details/)
 
-> **_Note:_** The default configuration continues to use TSM-based shards with in-memory indexes (as in earlier versions).
+> **_Note:_** The default InfluxDB configuration continues to use TSM-based shards with in-memory indexes (`inmem`) (as in earlier versions).
 
 ## Upgrade to InfluxDB 1.7.x
 
-1. [Download](https://portal.influxdata.com/downloads) InfluxDB version 1.7.x and [install the upgrade](/influxdb/v1.7/introduction/installation).
+1. [Download](https://portal.influxdata.com/downloads) InfluxDB 1.7.x and [install the upgrade](/influxdb/v1.7/introduction/installation).
 
 2. Migrate configuration file customizations from your existing configuration file to the InfluxDB 1.7.x [configuration file](/influxdb/v1.7/administration/config/). Add or modify your environment variables as needed.
 
@@ -30,25 +29,15 @@ We recommend enabling Time Series Index (TSI) (step 3 of Upgrade to InfluxDB 1.7
 
     c. Delete shard `index` directories (by default, located at `/<shard_ID>/index`).
 
-    d. Convert TSM-based shards to TSI-based shards by running the [influx_inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi) command.
+    d. Build TSI by running the [influx_inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi) command.
 
     > **Note** Run the buildtsi command using the user account that you are going to run the database as, or ensure that the permissions match afterward.
 
 4. Restart the `influxdb` service.
 
-## Switch between TSM and TSI indexes
+## Switch between `tsi1` and `inmem`
 
-After upgrading to InfluxDB 1.7.x, switch between using the TSM index and the TSI index as needed.
-
-### To switch from TSM to TSI
-
-Complete step 3 and 4 in [Upgrade to InfluxDB 1.7.x](#upgrade-to-influxdb-1-7-x).
-
-### To switch from TSI to TSM
-
-1. In the InfluxDB configuration file, set `index-version = "inmem"`.
-2. Delete all shard `index` directories (by default, located at `/<shard_ID>/index`).
-3. Restart the `influxdb` service.
+After enabling TSI (`tsi1`), switch between using TSI (`tsi1`) and in-memory index (`inmem`) as needed by completing step 3 and 4 above in [Upgrade to InfluxDB 1.7.x](#upgrade-to-influxdb-1-7-x), altering `inmem` and `tsi` as applicable.
 
 ## Downgrade InfluxDB
 

--- a/content/influxdb/v1.7/administration/upgrading.md
+++ b/content/influxdb/v1.7/administration/upgrading.md
@@ -13,7 +13,7 @@ We recommend enabling Time Series Index (TSI) (step 3 of Upgrade to InfluxDB 1.7
 - [Time Series Index (TSI) overview](/influxdb/v1.7/concepts/time-series-index/)
 - [Time Series Index (TSI) details](/influxdb/v1.7/concepts/tsi-details/)
 
-> **_Note:_** The default InfluxDB configuration continues to use TSM-based shards with in-memory indexes (`inmem`) (as in earlier versions).
+> **_Note:_** The default InfluxDB configuration continues to use in-memory indexes (`inmem`) (as in earlier versions).
 
 ## Upgrade to InfluxDB 1.7.x
 
@@ -35,9 +35,12 @@ We recommend enabling Time Series Index (TSI) (step 3 of Upgrade to InfluxDB 1.7
 
 4. Restart the `influxdb` service.
 
-## Switch between `tsi1` and `inmem`
+## Switch index types
 
-After enabling TSI (`tsi1`), switch between using TSI (`tsi1`) and in-memory index (`inmem`) as needed by completing steps 3 and 4 above in [Upgrade to InfluxDB 1.7.x](#upgrade-to-influxdb-1-7-x), altering `inmem` and `tsi` as applicable.
+Switch index types at any time by doing one of the following:
+
+- To switch from to `inmem` to `tsi1`, complete steps 3 and 4 above in [Upgrade to InfluxDB 1.7.x](#upgrade-to-influxdb-1-7-x).
+- To switch from to `tsi1` to `inmem`, change `tsi1` to `inmem` by completing steps 3a-3c and 4 above in [Upgrade to InfluxDB 1.7.x](#upgrade-to-influxdb-1-7-x).
 
 ## Downgrade InfluxDB
 

--- a/content/influxdb/v1.7/concepts/tsi-details.md
+++ b/content/influxdb/v1.7/concepts/tsi-details.md
@@ -8,16 +8,18 @@ menu:
     parent: Concepts
 ---
 
-InfluxDB stores measurement and tag information in an index so data can be queried quickly. In earlier versions, the index was stored in-memory, requiring a lot of RAM and restricting the number of series that a machine could hold (typically, 1-4 million series, depending on machine).
+InfluxDB stores measurement and tag information in an index so that data can be queried quickly. 
+
+In earlier versions, the index was stored in-memory, requiring a lot of RAM and restricting the number of series that a machine could hold (typically, 1-4 million series, depending on machine).
 
 Time Series Index (TSI) stores index data on disk, removing RAM restrictions. This lets you store more series.
 TSI uses the operating system's page cache to pull hot data into memory, leaving cold data on disk.
 
 ## Enable TSI
 
-For **InfluxDB OSS**, complete step 3 and 4 of [Upgrading to InfluxDB 1.7.x](https://docs.influxdata.com/influxdb/v1.7/administration/upgrading/#upgrade-to-influxdb-1-7-x).
+- For **InfluxDB OSS**, complete step 3 and 4 of [Upgrading to InfluxDB 1.7.x](https://docs.influxdata.com/influxdb/v1.7/administration/upgrading/#upgrade-to-influxdb-1-7-x).
 
-For **InfluxDB Enterprise**, on each data node in your cluster, complete step 2 and steps 4-7 of [Upgrade data nodes](/enterprise_influxdb/v1.7/administration/upgrading/#upgrade-data-nodes).
+- For **InfluxDB Enterprise**, on each data node in your cluster, complete step 2 and steps 4-7 of [Upgrade data nodes](/enterprise_influxdb/v1.7/administration/upgrading/#upgrade-data-nodes).
 
 ## Tooling
 

--- a/content/influxdb/v1.7/concepts/tsi-details.md
+++ b/content/influxdb/v1.7/concepts/tsi-details.md
@@ -10,9 +10,9 @@ menu:
 
 InfluxDB stores measurement and tag information in an index so that data can be queried quickly. 
 
-In earlier versions, the index was stored in-memory, requiring a lot of RAM and restricting the number of series that a machine could hold (typically, 1-4 million series, depending on machine).
+In earlier versions, the index was stored in-memory, requiring a lot of RAM and restricting the number of series that a machine could hold (typically, 1-4 million series, depending on the machine).
 
-Time Series Index (TSI) stores index data on disk, removing RAM restrictions. This lets you store more series.
+Time Series Index (TSI) stores index data on disk, removing RAM restrictions. This lets you store more series on a machine.
 TSI uses the operating system's page cache to pull hot data into memory, leaving cold data on disk.
 
 ## Enable TSI

--- a/content/influxdb/v1.7/concepts/tsi-details.md
+++ b/content/influxdb/v1.7/concepts/tsi-details.md
@@ -8,53 +8,34 @@ menu:
     parent: Concepts
 ---
 
-When InfluxDB ingests data, we store not only the value but we also index the measurement and tag information so that it can be queried quickly.
-In earlier versions, index data could only be stored in-memory, however, that requires a lot of RAM and places an upper bound on the number of series a machine can hold.
-This upper bound is usually somewhere between 1 - 4 million series depending on the machine used.
+InfluxDB stores measurement and tag information in an index so data can be queried quickly. In earlier versions, the index was stored in-memory, requiring a lot of RAM and restricting the number of series that a machine could hold (typically, 1-4 million series, depending on machine).
 
-The Time Series Index (TSI) was developed to allow us to go past that upper bound.
-TSI stores index data on disk so that we are no longer restricted by RAM.
-TSI uses the operating system's page cache to pull hot data into memory and let cold data rest on disk.
+Time Series Index (TSI) stores index data on disk, removing RAM restrictions. This lets you store more series.
+TSI uses the operating system's page cache to pull hot data into memory, leaving cold data on disk.
 
 ## Enable TSI
 
-To enable TSI, set the following line in the InfluxDB configuration file (`influxdb.conf`):
+For **InfluxDB OSS**, complete step 3 and 4 of [Upgrading to InfluxDB 1.7.x](https://docs.influxdata.com/influxdb/v1.7/administration/upgrading/#upgrade-to-influxdb-1-7-x).
 
-```
-index-version = "tsi1"
-```
-
-(Be sure to include the double quotes.)
-
-### InfluxDB Enterprise
-
-- To convert your data nodes to support TSI, see [Upgrade InfluxDB Enterprise clusters](https://docs.influxdata.com/enterprise_influxdb/v1.7/administration/upgrading/).
-
-- For detail on configuration, see [Configure InfluxDB Enterprise clusters](https://docs.influxdata.com/enterprise_influxdb/v1.7/administration/configuration/#sidebar).
-
-### InfluxDB OSS
-
-- For detail on configuration, see [Configuring InfluxDB OSS](https://docs.influxdata.com/influxdb/v1.7/administration/config/#sidebar).
+For **InfluxDB Enterprise**, on each data node in your cluster, complete step 2 and steps 4-7 of [Upgrade data nodes](/enterprise_influxdb/v1.7/administration/upgrading/#upgrade-data-nodes).
 
 ## Tooling
 
 ### `influx_inspect dumptsi`
 
-If you are troubleshooting an issue with an index, you can use the `influx_inspect dumptsi` command.
-This command allows you to print summary statistics on an index, file, or a set of files.
-This command only works on one index at a time.
+Use the `influx_inspect dumptsi` command to troubleshoot an issue with an index: print summary statistics on an index, file, or a set of files.
 
-For details on this command, see [influx_inspect dumptsi](/influxdb/v1.7/tools/influx_inspect/#dumptsi).
+> **Note:** This command only works on one index at a time.
+
+For more details, see [influx_inspect dumptsi](/influxdb/v1.7/tools/influx_inspect/#dumptsi).
 
 ### `influx_inspect buildtsi`
 
-If you want to convert an existing shard from an in-memory index to a TSI index, or if you have an existing TSI index which has become corrupt, you can use the `buildtsi` command to create the index from the underlying TSM data.
-If you have an existing TSI index that you want to rebuild, first delete the `index` directory within your shard.
+If you have a corrupted TSI, delete the `index` directory within your shard, and then use the `buildtsi` command to rebuild TSI.
 
 This command works at the server-level but you can optionally add database, retention policy and shard filters to only apply to a subset of shards.
 
 For details on this command, see [influx inspect buildtsi](/influxdb/v1.7/tools/influx_inspect/#buildtsi).
-
 
 ## Understanding TSI
 

--- a/content/influxdb/v1.7/concepts/tsi-details.md
+++ b/content/influxdb/v1.7/concepts/tsi-details.md
@@ -8,11 +8,11 @@ menu:
     parent: Concepts
 ---
 
-InfluxDB stores measurement and tag information in an index so that data can be queried quickly. 
+InfluxDB stores measurement and tag information in an index so data can be queried quickly.
 
 In earlier versions, the index was stored in-memory, requiring a lot of RAM and restricting the number of series that a machine could hold (typically, 1-4 million series, depending on the machine).
 
-Time Series Index (TSI) stores index data on disk, removing RAM restrictions. This lets you store more series on a machine.
+Time Series Index (TSI) stores index data both in memory and on disk, removing RAM restrictions. This lets you store more series on a machine.
 TSI uses the operating system's page cache to pull hot data into memory, leaving cold data on disk.
 
 ## Enable TSI

--- a/content/influxdb/v1.7/guides/hardware_sizing.md
+++ b/content/influxdb/v1.7/guides/hardware_sizing.md
@@ -138,7 +138,7 @@ Cluster configurations guidelines are organized by:
 - Number of data nodes
 - Number of server cores
 
-> Recommended configuration guidelines were tested against Time Series Index (TSI) (`tsi1`). To prevent multiple indexes types from being used simultaneously (`tsi1` and the earlier `inmem`), TSI isn't enabled by default. We recommend enabling TSI; for more information, see [TSI details](/influxdb/v1.7/concepts/tsi-details/). For `inmem`, use the guidelines below as a benchmark and adjust as needed.
+> Recommended configuration guidelines were tested against Time Series Index (TSI) (`tsi1`). To prevent multiple index types from being used simultaneously (`tsi1` and the earlier `inmem`), TSI isn't enabled by default. We recommend enabling TSI; for more information, see [TSI details](/influxdb/v1.7/concepts/tsi-details/). For `inmem`, use the guidelines below as a benchmark and adjust as needed.
 
 For each cluster configuration, you'll find guidelines for the following:
 

--- a/content/influxdb/v1.7/guides/hardware_sizing.md
+++ b/content/influxdb/v1.7/guides/hardware_sizing.md
@@ -128,7 +128,7 @@ InfluxDB Enterprise guidelines vary by writes and queries per second, series car
 - R4.4xlarge (16 cores); 122 GB RAM
 - R4.8xlarge (32 cores); 244 GB RAM
 
-> Guidelines stem from a DevOps monitoring use case: maintaining a group of computers and monitoring server metrics (such as CPU, kernel, memory, disk space, disk I/O, network, and so on).
+> Guidelines stem from a DevOps monitoring use case: maintaining a group of computers and monitoring server metrics (such as CPU, kernel, memory, disk space, disk I/O, network, and so on). 
 
 ### Recommended cluster configurations
 
@@ -137,6 +137,8 @@ Cluster configurations guidelines are organized by:
 - Series cardinality in your data set: 10,000, 100,000, 1,000,000, or 10,000,000
 - Number of data nodes
 - Number of server cores
+
+> Recommended configuration guidelines were tested against Time Series Index (TSI) (`tsi1`). To prevent multiple indexes types from being used simultaneously (`tsi1` and the earlier `inmem`), TSI isn't enabled by default. We recommend enabling TSI; for more information, see [TSI details](/influxdb/v1.7/concepts/tsi-details/). For `inmem`, use the guidelines below as a benchmark and adjust as needed.
 
 For each cluster configuration, you'll find guidelines for the following:
 


### PR DESCRIPTION
- Note configuration guidelines were tested against TSI (`tsi1`) 
- Recommend enabling `tsi1` and include link for how to enable TSI
- Explain how to use guidelines for `inmem`