### PR TITLE
Add new ways to backup and restore

### DIFF
--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -435,37 +435,26 @@ For an example of using the exporting and importing data approach for disaster r
 
 ## Take AWS snapshot with EBS volumes
 
-Set up at least two EBS volumes, one for your OS root directory and one for your InfluxDB data.
+Set up at least two EBS volumes, one for your OS root directory and one for your InfluxDB Enterprise cluster data.
 
-1. Copy all Enterprise cluster data to a separate EBS volume for backup, including the following directories:
+1. Identify InfluxDB Enterprise directories to place on your secondary storage device for backup, including the following directories:
   
   - For meta nodes: `/meta`
   - For data nodes: `/data`, `/hh`, `/wal`, and `/meta`
 
 2. Create a virtual machine (VM) with your operating system (OS).
 3. Create a secondary storage device (EBS) and associate it with your VM.
-4. Create filesystem on secondary device using `fdisk` and `mkfs`.
-5. Create directory structure for InfluxDB on secondary device (`/influxdb`).
-6. Set VM to mount secondary device as `/influxdb` by changing the path to `/etc/fstab`.
+4. Create filesystem on the secondary storage device using `fdisk` and `mkfs`.
+5. Create directory structure for InfluxDB on the secondary storage device (`/influxdb`).
+6. In `/etc/fstab`, mount the VM to the secondary storage device. For example, on Linux, set the mount point for `/dev/sdb` to `/influxdb`.
 7. Download and install InfluxDB, and then stop `influxdb` service if it starts.
-8. Change storage location for InfluxDB files in InfluxDB configuration files from:
-
-    ```
-    "/var/lib/influxdb/"
-    ```
-
-    to
-
-    ```
-    /influxdb
-    ```
-
-8. Copy files from /var/lib/influxdb to /influxdb (meta, wal, data, and others.)
-9. Restart the `influxdb` service, monitor logs.
-10. Make backup copy of conf files to `/influxdb/conf`
+8. In InfluxDB configuration files, find the default storage location on the root volume (`/var/lib/influxdb/`) and update this location to point to the secondary storage device (`/influxdb`).
+9. Copy files from /var/lib/influxdb to /influxdb (meta, wal, data, and others.)
+10. Restart the `influxdb` service, monitor logs to ensure that the service starts successfully.
+11. Make backup copy of conf files to `/influxdb/conf`
     Data should be on the secondary drive, so you can take snapshots of that drive only to save snapshot space. For detail about AWS snapshots, see how to [automate the Amazon EBS Snapshot Lifestyle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).
 
-11. To take a snapshot, complete the following tasks as needed:
+12. Complete the following tasks to take a snapshot of the secondary storage device:
   
     a. Create an EBS snapshot.
     b. Recover data from a snapshot by detaching your existing EBS volume and attaching the snapshot.

--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -269,16 +269,6 @@ for a complete list of the global `influxd-ctl` options.
 - `-rp <string>`: the name of the single retention policy to restore
 - `-shard <unit>`: the shard ID to restore
 
-##### Restore options
-
-- `-db <string>`: the name of the single database to restore
-- `-list`: shows the contents of the backup
-- `-newdb <string>`: the name of the new database to restore to (must specify with `-db`)
-- `-newrf <int>`: the new replication factor to restore to (this is capped to the number of data nodes in the cluster)
-- `-newrp <string>`: the name of the new retention policy to restore to (must specify with `-rp`)
-- `-rp <string>`: the name of the single retention policy to restore
-- `-shard <unit>`: the shard ID to restore
-
 #### Examples
 
 {{%expand "> Restore from an incremental backup" %}}

--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -44,9 +44,12 @@ Use the `backup` and `restore` utilities to back up and restore between `influxd
 
 ### Backup utility
 
-A backup creates a copy of the [metastore](/influxdb/v1.7/concepts/glossary/#metastore) and [shard](/influxdb/v1.7/concepts/glossary/#shard) data at that point in time and stores the copy in the specified directory.
+A backup creates a copy of the [metastore](/influxdb/v1.7/concepts/glossary/#metastore) and [shard](/influxdb/v1.7/concepts/glossary/#shard) data **on disk** at that point in time and stores the copy in the specified directory.
+
+>**Note:** `backup` ignores WAL files and in-memory cache data.
+
 All backups also include a manifest, a JSON file describing what was collected during the backup.
-The filenames reflect the UTC timestamp of when the backup was created, for example:
+The filenames reflect the UTC timestamp of when the backup **from disk** was created, for example:
 
 - Metastore backup: `20060102T150405Z.meta` (includes usernames and passwords)
 - Shard data backup: `20060102T150405Z.<shard_id>.tar.gz`

--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -23,7 +23,7 @@ For each of the following scenarios, plan a back up and restore strategy that su
 To choose a strategy that best suits your use case, we recommend considering your volume of data, application requirements, acceptable recovery time, and budget. We offer the following methods for backup and restore:
 
 - [Backup and restore utilities](#backup-and-restore-utilities) (suits **most InfluxDB Enterprise applications**)
-- [Export and import commands](#export-and-import-commands) (best for **100s of gigabytes of data or more**)
+- [Export and import commands](#export-and-import-commands) (best for **backfill or recover shards as files**)
 - [Take AWS snapshot with EBS volumes](#take-aws-snapshots-with-ebs-volumes) (optimal **convenience if budget permits**)
 - [Run two clusters in separate AWS regions](#run-two-clusters-in-separate-aws-regions) (also optimal **convenience if budget permits**, more custom work upfront)
 
@@ -430,7 +430,7 @@ Set up at least two EBS volumes, one for your OS root directory and one for your
 6. In `/etc/fstab`, mount the VM to the secondary storage device. For example, on Linux, set the mount point for `/dev/sdb` to `/influxdb`.
 7. Download and install InfluxDB, and then stop `influxdb` service if it starts.
 8. In InfluxDB configuration files, find the default storage location on the root volume (`/var/lib/influxdb/`) and update this location to point to the secondary storage device (`/influxdb`).
-9. Copy files from `/var/lib/influxdb` to `/influxdb` (`meta`, `wal`, `data`, and others youi identified in step 1.)
+9. Copy files from `/var/lib/influxdb` to `/influxdb` (`meta`, `wal`, `data`, and others you identified in step 1.)
 10. Restart the `influxdb` service, monitor logs to ensure that the service starts successfully.
 11. Make backup copy of configuration files to `/influxdb/conf`.
     Data should be on the secondary storage device, so you can take snapshots of that drive only to save snapshot space.
@@ -439,7 +439,7 @@ Set up at least two EBS volumes, one for your OS root directory and one for your
   
     a. Create an EBS snapshot.
     b. Recover data from a snapshot by detaching your existing EBS volume and attaching the snapshot.
-    c. Re-sync a recovered single node.
+    c. Use the [`influx_inspect export` command](/influxdb/latest/tools/influx_inspect#export) to filter data by timestamps, and then export data for the specified timeframe in line protocol format. On your new cluster, use `influx -import` to import the line protocol.
   
     For detail about AWS snapshots, see how to [automate the Amazon EBS Snapshot Lifestyle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).
 

--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -23,7 +23,7 @@ For each of the following scenarios, plan a back up and restore strategy that su
 To choose a strategy that best suits your use case, we recommend considering your volume of data, application requirements, acceptable recovery time, and budget. We offer the following methods for backup and restore:
 
 - [Backup and restore utilities](#backup-and-restore-utilities) (suits **most InfluxDB Enterprise applications**)
-- [Export and import commands](#export-and-import-commands) (best for **backfill or recover shards as files**)
+- [Export and import commands](#export-and-import-commands) (best for **backfill or recovering shards as files**)
 - [Take AWS snapshot with EBS volumes](#take-aws-snapshots-with-ebs-volumes) (optimal **convenience if budget permits**)
 - [Run two clusters in separate AWS regions](#run-two-clusters-in-separate-aws-regions) (also optimal **convenience if budget permits**, more custom work upfront)
 

--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -22,12 +22,14 @@ Plan a back up and restore strategy for the following scenarios:
 
 ### Choose a strategy that fits your needs
 
-Consider your use cases, volume of data, and application requirements, and then plan a backup and restore strategy that suits your needs. Use one or more of the following methods as part of your strategy:
+We offer the following methods for backup and restore:
 
 - [Backup and restore utilities](#backup-and-restore-utilities)
 - [Export and import commands](#export-and-import-commands) (preferred for large datasets)
 - [Take AWS snapshot with EBS volumes](#take-aws-snapshot-with-ebs-volumes)
 - [Run two clusters in separate AWS regions](#run-two-clusters-in-separate-aws-regions)
+
+To pick a strategy that best suits your use case, we recommend considering your volume of data, application requirements, acceptable recovery time, and budget. For example, if you're short on recovery time, our `backup` and `restore` utilities may be your best bet. If you're looking for convenience and budget permits, taking AWS snapshots may be optimal. Plan (and test) a backup and restore strategy that suits your needs.
 
 > **Note:** Use the [`backup` and `restore` utilities (InfluxDB OSS 1.5 and later)](/influxdb/latest/administration/backup_and_restore/) to:
 >
@@ -438,14 +440,19 @@ For an example of using the exporting and importing data approach for disaster r
 
 ## Take AWS snapshot with EBS volumes
 
-Set up at least two EBS volumes, one for your OS root directory and one for your InfluxDB Enterprise cluster. Then, restore your backup to the empty EBS volume created for your InfluxDB Enterprise cluster.
+Set up at least two EBS volumes, one for your OS root directory and one for your InfluxDB Enterprise cluster.
 
-> **Important:** Backups must be restored to an empty EBS volume.
-
-1. Identify InfluxDB Enterprise directories to place on your secondary storage device for backup, including the following directories:
+1. Identify InfluxDB Enterprise directories to place on your secondary storage device for backup, including the following directories (and others you'd like to back up):
   
-  - For meta nodes: `/meta`
-  - For data nodes: `/data`, `/hh`, `/wal`, and `/meta`
+  - For meta nodes:
+    - `/meta`
+    - (optional) `/conf`
+  - For data nodes:
+    - `/data`
+    - `/hh`
+    - `/wal`
+    - `/meta`
+    -  (optional) `/conf`
 
 2. Create a virtual machine (VM) with your operating system (OS).
 3. Create a secondary storage device (EBS) and associate it with your VM.
@@ -454,16 +461,18 @@ Set up at least two EBS volumes, one for your OS root directory and one for your
 6. In `/etc/fstab`, mount the VM to the secondary storage device. For example, on Linux, set the mount point for `/dev/sdb` to `/influxdb`.
 7. Download and install InfluxDB, and then stop `influxdb` service if it starts.
 8. In InfluxDB configuration files, find the default storage location on the root volume (`/var/lib/influxdb/`) and update this location to point to the secondary storage device (`/influxdb`).
-9. Copy files from `/var/lib/influxdb` to `/influxdb` (`meta`, `wal`, `data`, and others.)
+9. Copy files from `/var/lib/influxdb` to `/influxdb` (`meta`, `wal`, `data`, and others youi identified in step 1.)
 10. Restart the `influxdb` service, monitor logs to ensure that the service starts successfully.
-11. Make backup copy of conf files to `/influxdb/conf`
-    Data should be on the secondary drive, so you can take snapshots of that drive only to save snapshot space. For detail about AWS snapshots, see how to [automate the Amazon EBS Snapshot Lifestyle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).
+11. Make backup copy of configuration files to `/influxdb/conf`.
+    Data should be on the secondary storage device, so you can take snapshots of that drive only to save snapshot space.
 
 12. Take a snapshot of the secondary storage device:
   
     a. Create an EBS snapshot.
     b. Recover data from a snapshot by detaching your existing EBS volume and attaching the snapshot.
     c. Re-sync a recovered single node.
+  
+    For detail about AWS snapshots, see how to [automate the Amazon EBS Snapshot Lifestyle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).
 
 ## Run two clusters in separate AWS regions
 

--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -435,7 +435,9 @@ For an example of using the exporting and importing data approach for disaster r
 
 ## Take AWS snapshot with EBS volumes
 
-Set up at least two EBS volumes, one for your OS root directory and one for your InfluxDB Enterprise cluster data.
+Set up at least two EBS volumes, one for your OS root directory and one for your InfluxDB Enterprise cluster. Then, restore your backup to the empty EBS volume created for your InfluxDB Enterprise cluster.
+
+> **Important:** Backups must be restored to an empty EBS volume.
 
 1. Identify InfluxDB Enterprise directories to place on your secondary storage device for backup, including the following directories:
   

--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -435,15 +435,20 @@ For an example of using the exporting and importing data approach for disaster r
 
 ## Take AWS snapshot with EBS volumes
 
-1. Set up at least two EBS volumes: one for your OS root directory and one for your InfluxDB data:
+Set up at least two EBS volumes, one for your OS root directory and one for your InfluxDB data.
+
+1. Copy all Enterprise cluster data to a separate EBS volume for backup, including the following directories:
   
-  a. Create a VM with OS of choice.
-  b. Create a secondary storage device (EBS) that's associated with the VM.
-  c. Create filesystem on secondary device using fdisk and mkfs.
-  d. Create directory structure for influx on secondary device (we use /influxdb).
-  e. Set VM to mount secondary device as '/influxdb' by changing the /etc/fstab.
-  f. Download and install Influx, then stop service if it starts.
-  g. Change storage location for influx files from inside the configuration files.
+  - For meta nodes: `/meta`
+  - For data nodes: `/data`, `/hh`, `/wal`, and `/meta`
+
+2. Create a virtual machine (VM) with your operating system (OS).
+3. Create a secondary storage device (EBS) and associate it with your VM.
+4. Create filesystem on secondary device using `fdisk` and `mkfs`.
+5. Create directory structure for InfluxDB on secondary device (`/influxdb`).
+6. Set VM to mount secondary device as `/influxdb` by changing the path to `/etc/fstab`.
+7. Download and install InfluxDB, and then stop `influxdb` service if it starts.
+8. Change storage location for InfluxDB files in InfluxDB configuration files from:
 
     ```
     "/var/lib/influxdb/"
@@ -455,22 +460,16 @@ For an example of using the exporting and importing data approach for disaster r
     /influxdb
     ```
 
-8) Copy any contents from /var/lib/influxdb to /influxdb (meta, wal, data, et. al.)
-9) Restart influxdb service, monitor logs.
-10) Make backup copy of conf files to /influxdb/conf
+8. Copy files from /var/lib/influxdb to /influxdb (meta, wal, data, and others.)
+9. Restart the `influxdb` service, monitor logs.
+10. Make backup copy of conf files to `/influxdb/conf`
+    Data should be on the secondary drive, so you can take snapshots of that drive only to save snapshot space. For detail about AWS snapshots, see how to [automate the Amazon EBS Snapshot Lifestyle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).
 
-Once steps 1-10 are completed, the data should be homed on the 'secondary' drive, which means that snapshots are only necessary for that drive, saving snapshot space.
-
-1. Copy all Enterprise cluster data to a separate EBS volume for backup, including the following directories:
+11. To take a snapshot, complete the following tasks as needed:
   
-  - For meta nodes: `/meta`
-  - For data nodes: `/data`, `/hh`, `/wal`, and `/meta`
-
-2. Review how to [automate the Amazon EBS Snapshot Lifestyle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html) and complete the following tasks as needed:
-  
-  a. Create an EBS snapshot.
-  b. Recover data from a snapshot by detaching your existing EBS volume and attaching the snapshot.
-  c. Re-sync a recovered single node.
+    a. Create an EBS snapshot.
+    b. Recover data from a snapshot by detaching your existing EBS volume and attaching the snapshot.
+    c. Re-sync a recovered single node.
 
 ## Run two clusters in separate AWS regions
 

--- a/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
+++ b/content/enterprise_influxdb/v1.7/administration/backup-and-restore.md
@@ -449,12 +449,12 @@ Set up at least two EBS volumes, one for your OS root directory and one for your
 6. In `/etc/fstab`, mount the VM to the secondary storage device. For example, on Linux, set the mount point for `/dev/sdb` to `/influxdb`.
 7. Download and install InfluxDB, and then stop `influxdb` service if it starts.
 8. In InfluxDB configuration files, find the default storage location on the root volume (`/var/lib/influxdb/`) and update this location to point to the secondary storage device (`/influxdb`).
-9. Copy files from /var/lib/influxdb to /influxdb (meta, wal, data, and others.)
+9. Copy files from `/var/lib/influxdb` to `/influxdb` (`meta`, `wal`, `data`, and others.)
 10. Restart the `influxdb` service, monitor logs to ensure that the service starts successfully.
 11. Make backup copy of conf files to `/influxdb/conf`
     Data should be on the secondary drive, so you can take snapshots of that drive only to save snapshot space. For detail about AWS snapshots, see how to [automate the Amazon EBS Snapshot Lifestyle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).
 
-12. Complete the following tasks to take a snapshot of the secondary storage device:
+12. Take a snapshot of the secondary storage device:
   
     a. Create an EBS snapshot.
     b. Recover data from a snapshot by detaching your existing EBS volume and attaching the snapshot.


### PR DESCRIPTION
- Updates to content per Dan's suggestions
- Rewrote and organized existing content to simplify (16 pp to 7pp)
- Added content for 2 new "backup and restore" methods:
   - how to take AWS snapshots with EBS volumes 
   - how to run two clusters in separate AWS regions