### PR TITLE
Document /api/v2/write API endpoint

### DIFF
--- a/content/influxdb/v1.8/tools/api.md
+++ b/content/influxdb/v1.8/tools/api.md
@@ -26,6 +26,7 @@ Those settings [are configurable](/influxdb/v1.8/administration/config/#http-end
 | [/debug/vars](#debug-vars-http-endpoint)  | Use `/debug/vars` to collect statistics  |
 | [/ping](#ping-http-endpoint) | Use `/ping` to check the status of your InfluxDB instance and your version of InfluxDB. |
 | [/query](#query-http-endpoint) | Use `/query` to query data and manage databases, retention policies, and users. |
+| [/v2/write](#v2-write-http-endpoint) | Use InfluxDB 2.0 client libraries to write to InfluxDB 1.8.0+. |
 | [/write](#write-http-endpoint) | Use `/write` to write data to a pre-existing database. |
 
 ## `/debug/pprof` HTTP endpoint
@@ -591,6 +592,15 @@ Content-Length: 33
 
 {"error":"authorization failed"}
 ```
+
+## `/v2/write/` HTTP endpoint
+
+The `/v2/write` endpoint accepts `POST` HTTP requests.
+Use this endpoint to write to an InfluxDB 1.8.0+ database using InfluxDB 2.0 client libraries.
+This endpoint maps the supplied bucket and organization to a version 1.8 database and retention policy.
+
+For more information, see [InfluxDB 2.0 client libraries](https://v2.docs.influxdata.com/v2.0/reference/api/client-libraries/).
+
 
 ## `/write` HTTP endpoint
 

--- a/content/influxdb/v1.8/tools/api.md
+++ b/content/influxdb/v1.8/tools/api.md
@@ -26,7 +26,7 @@ Those settings [are configurable](/influxdb/v1.8/administration/config/#http-end
 | [/debug/vars](#debug-vars-http-endpoint)  | Use `/debug/vars` to collect statistics  |
 | [/ping](#ping-http-endpoint) | Use `/ping` to check the status of your InfluxDB instance and your version of InfluxDB. |
 | [/query](#query-http-endpoint) | Use `/query` to query data and manage databases, retention policies, and users. |
-| [/v2/write](#v2-write-http-endpoint) | Use InfluxDB 2.0 client libraries to write to InfluxDB 1.8.0+. |
+| [/api/v2/write](#api-v2-write-http-endpoint) | Use InfluxDB 2.0 client libraries to write to InfluxDB 1.8.0+. |
 | [/write](#write-http-endpoint) | Use `/write` to write data to a pre-existing database. |
 
 ## `/debug/pprof` HTTP endpoint
@@ -593,9 +593,9 @@ Content-Length: 33
 {"error":"authorization failed"}
 ```
 
-## `/v2/write/` HTTP endpoint
+## `/api/v2/write/` HTTP endpoint
 
-The `/v2/write` endpoint accepts `POST` HTTP requests.
+The `/api/v2/write` endpoint accepts `POST` HTTP requests.
 Use this endpoint to write to an InfluxDB 1.8.0+ database using InfluxDB 2.0 client libraries.
 This endpoint maps the supplied bucket and organization to a version 1.8 database and retention policy.
 

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -11,9 +11,14 @@ menu:
     parent: Tools
 ---
 
-InfluxDB client libraries are developed by the open source community. These client libraries support the InfluxDB API and should be fully compatible with InfluxDB version 1.5. Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
+InfluxDB client libraries are developed by the open source community and InfluxData.
+These client libraries support the InfluxDB API and should be fully compatible with InfluxDB version 1.5+.
+Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
 
 Thanks to the open source community for your contributions, commitment, and effort!
+
+> [Client libraries](https://v2.docs.influxdata.com/v2.0/reference/api/client-libraries/) are also available for InfluxDB 2.0.
+> These are backwards-compatible with 1.8.0+ using the [`/v2/write` API endpoint](/influxdb/v1.8/tools/api#v2-write-http-endpoint).
 
 ## C++
 * [influxdb-cxx](https://github.com/awegrzyn/influxdb-cxx.git)

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -18,7 +18,7 @@ Functionality will vary as there are no standard features that all libraries mus
 Thanks to the open source community for your contributions, commitment, and effort!
 
 > [Client libraries](https://v2.docs.influxdata.com/v2.0/reference/api/client-libraries/) are also available for InfluxDB 2.0.
-> These are backwards-compatible with 1.8.0+ using the [`/v2/write` API endpoint](/influxdb/v1.8/tools/api#v2-write-http-endpoint).
+> These are backwards-compatible with 1.8.0+ using the [`/api/v2/write` API endpoint](/influxdb/v1.8/tools/api#api-v2-write-http-endpoint).
 
 ## C++
 * [influxdb-cxx](https://github.com/awegrzyn/influxdb-cxx.git)


### PR DESCRIPTION
- Add /v2/write/ HTTP endpoint to API docs
- Mention the new endpoint in client library docs.
- Link to version 2 client libraries.

Local build succeeds.