### PR TITLE
Clarify "InfluxDB query management" page is for InfluxQL only

### DIFF
--- a/content/influxdb/v1.7/troubleshooting/query_management.md
+++ b/content/influxdb/v1.7/troubleshooting/query_management.md
@@ -1,5 +1,5 @@
 ---
-title: InfluxDB query management
+title: InfluxQL query management
 
 menu:
   influxdb_1_7:
@@ -8,18 +8,13 @@ menu:
     parent: Troubleshooting
 ---
 
-With the InfluxDB query management features, users are able to
-identify currently-running queries,
-kill queries that are overloading their system,
-and prevent and halt the execution of inefficient queries with several configuration settings.
+Manage your InfluxQL queries using the following:
 
-<table style="width:100%">
-  <tr>
-    <td><a href="#list-currently-running-queries-with-show-queries">SHOW QUERIES</a></td>
-    <td><a href="#stop-currently-running-queries-with-kill-query">KILL QUERY</a></td>
-    <td><a href="#configuration-settings-for-query-management">Configuration Settings</a></td>
-  </tr>
-</table>
+- [SHOW QUERIES](#list-currently-running-queries-with-show-queries) to identify currently-running queries
+- [KILL QUERIES](#stop-currently-running-queries-with-kill-query) to stop queries overloading your system
+- [Configuration settings](#configuration-settings-for-query-management) to prevent and halt the execution of inefficient queries
+
+> The commands and configurations provided on this page are for **Influx Query Language (InfluxQL) only** -- **no equivalent set of Flux commands and configurations currently exists**. For the most current Flux documentation, see [Get started with Flux](/flux/v0.50/introduction/getting-started/).
 
 ## List currently-running queries with `SHOW QUERIES`
 

--- a/content/influxdb/v1.8/troubleshooting/query_management.md
+++ b/content/influxdb/v1.8/troubleshooting/query_management.md
@@ -1,5 +1,5 @@
 ---
-title: InfluxDB query management
+title: InfluxQL query management
 
 menu:
   influxdb_1_8:
@@ -8,18 +8,13 @@ menu:
     parent: Troubleshooting
 ---
 
-With the InfluxDB query management features, users are able to
-identify currently-running queries,
-kill queries that are overloading their system,
-and prevent and halt the execution of inefficient queries with several configuration settings.
+Manage your InfluxQL queries using the following:
 
-<table style="width:100%">
-  <tr>
-    <td><a href="#list-currently-running-queries-with-show-queries">SHOW QUERIES</a></td>
-    <td><a href="#stop-currently-running-queries-with-kill-query">KILL QUERY</a></td>
-    <td><a href="#configuration-settings-for-query-management">Configuration Settings</a></td>
-  </tr>
-</table>
+- [SHOW QUERIES](#list-currently-running-queries-with-show-queries) to identify currently-running queries
+- [KILL QUERIES](#stop-currently-running-queries-with-kill-query) to stop queries overloading your system
+- [Configuration settings](#configuration-settings-for-query-management) to prevent and halt the execution of inefficient queries
+
+> The commands and configurations provided on this page are for **Influx Query Language (InfluxQL) only** -- **no equivalent set of Flux commands and configurations currently exists**. For the most current Flux documentation, see [Get started with Flux](/flux/v0.50/introduction/getting-started/).
 
 ## List currently-running queries with `SHOW QUERIES`
 


### PR DESCRIPTION
updates in v1.7 and v1.8:

- Change title from _**InfluxDB** Query Management_ to _**InfluxQL** Query Management_
- Update introductory info to:

   - Clarify equivalent Flux configs not available per #[2711](https://github.com/influxdata/docs.influxdata.com/issues/2711) and refer to the latest Flux documentation. Keep info about our future Flux plans/how folks can provide feedback via community in [_InfluxDB 1.8 release notes_](https://github.com/influxdata/docs.influxdata.com/issues/2717).
   - Remove table
   - Simplify text

**Note:** As new development occurs, we'll add new Flux controls on "Flux Query Management" page (ideally, update this title and related procedures to task-based heading); update navigation for example "Managing InfluxDB queries" (w links to both InfluxQL and Flux), etc.
