### PR TITLE
InfluxDB 1.8 release notes

### DIFF
--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -12,7 +12,7 @@ menu:
 ### Features
 
 - Add [`influx inspect verify-tombstone` command](/influxdb/v1.8/tools/influx_inspect/#verify-tombstone)
-- Add offline series compaction to `influx_inspect buildtsi`.
+- Add [offline series compaction to `influx_inspect buildtsi`](/influxdb/v1.8/administration/compact-series-file/).
 - Add support for connecting to a custom HTTP endpoint using `-url-prefix` in [`influx` CLI](/influxdb/v1.8/tools/influx-cli/_index).
 - Update Go version to 1.13.8.
 - Add [InfluxDB 2.0 write API compatibility](/v1.8/tools/api/#api-v2-write-http-endpoint) to use InfluxDB 2.0 client libraries.

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -12,12 +12,12 @@ menu:
 ### Features
 
 - Add [`influx inspect verify-tombstone` command](/influxdb/v1.8/tools/influx_inspect/#verify-tombstone)
-- Add offline series compaction to influx_inspect buildtsi
-- Make influx CLI support custom HTTP endpoint
-- Update Go version to 1.13.8
-- Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries
+- Add offline series compaction to `influx_inspect buildtsi`.
+- Add support for connecting to a custom HTTP endpoint using `-path-prefix` in `influx` CLI.
+- Update Go version to 1.13.8.
+- Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 - Enhance support for bound parameters.
-- Update Flux version to v0.64.0
+- Update Flux version to v0.64.0.
   To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).
 
   > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on [InfluxCommunity](https://community.influxdata.com/), [Slack](https://influxcommunity.slack.com/), or [GitHub](https://github.com/influxdata/flux). InfluxDB Enterprise customers, please contact <support@influxdata.com>.

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -15,7 +15,7 @@ menu:
 - Add offline series compaction to `influx_inspect buildtsi`.
 - Add support for connecting to a custom HTTP endpoint using `-url-prefix` in [`influx` CLI](/influxdb/v1.8/tools/influx-cli/_index).
 - Update Go version to 1.13.8.
-- Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
+- Add [InfluxDB 2.0 write API compatibility](/v1.8/tools/api/#api-v2-write-http-endpoint) to use InfluxDB 2.0 client libraries.
 - Enhance support for bound parameters.
 - Update Flux version to v0.64.0.
   To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -21,6 +21,7 @@ TBD
   To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).
 
   > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on [InfluxCommunity](https://community.influxdata.com/), [Slack](https://influxcommunity.slack.com/), or [GitHub](https://github.com/influxdata/flux). InfluxDB Enterprise customers, please contact <support@influxdata.com>.
+  
 - Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 
 ### Bug fixes

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -17,6 +17,7 @@ menu:
 - Update Go version to 1.13.8.
 - Add [InfluxDB 2.0 API compatibility endpoints](/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints) to use InfluxDB 2.0 client libraries.
 - Enhance support for bound parameters.
+- Add support to enable TLS 1.3 configuration and update current list of [Go ciphers](https://golang.org/pkg/crypto/tls/#pkg-constants).
 - Update Flux version to v0.65.0.
   To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.65/introduction/).
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -9,10 +9,6 @@ menu:
 
 ## v1.8.0 [2020-3-TBD]
 
-### Breaking changes
-
-TBD
-
 ### Features
 
 - Add [`influx inspect verify-tombstone` command](/influxdb/v1.8/tools/influx_inspect/#verify-tombstone)

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -24,18 +24,16 @@ menu:
 
 ### Bug fixes
 
-- Delete rebuilds series index when series to be deleted are only found in cache.
-- Delete rebuilds series index when series to be deleted are outside timerange.
+- Rebuild the series index when data is actually deleted (not when deleted data is only found in cache or outside of time range).
 - Parse Accept header correctly.
-- Upgrade compaction error log from Info to Warn.
-- Remove double increment of meta index.
-- Improve series cardinality limit for inmem index.
+- Upgrade compaction error log from `Info` to `Warn`.
+- Remove double increment of `meta` index.
+- Improve series cardinality limit for `inmem` index.
 - Ensure all block data returned.
-- Skip WriteSnapshot during backup if snapshotter is busy.
-- Reduce influxd and influx startup time if Flux isn't used.
-- Fix bugs in -compact-series-file.
-- Update to Go 1.13.8 and Go modules.
-- Fix a SIGSEGV when accessing tsi active log.
+- Skip `WriteSnapshot` during back up if `snapshotter` is busy.
+- Reduce `influxd` and `influx` startup time if Flux isn't used.
+- Fix bugs in `-compact-series-file` flag.
+- Fix a SIGSEGV when accessing `tsi` active log.
 - Remove unsafe marshalling.
 
 ## v1.7.9 [2019-10-27]

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -7,7 +7,7 @@ menu:
     parent: About the project
 ---
 
-## v1.8.0 [2020-3-TBD]
+## v1.8.0 [2020-4-13]
 
 ### Features
 
@@ -15,10 +15,10 @@ menu:
 - Add [offline series compaction to `influx_inspect buildtsi`](/influxdb/v1.8/administration/compact-series-file/).
 - Add support for connecting to a custom HTTP endpoint using `-url-prefix` in [`influx` CLI](/influxdb/v1.8/tools/influx-cli/_index).
 - Update Go version to 1.13.8.
-- Add [InfluxDB 2.0 write API compatibility](/v1.8/tools/api/#api-v2-write-http-endpoint) to use InfluxDB 2.0 client libraries.
+- Add [InfluxDB 2.0 API compatibility endpoints](/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints) to use InfluxDB 2.0 client libraries.
 - Enhance support for bound parameters.
-- Update Flux version to v0.64.0.
-  To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).
+- Update Flux version to v0.65.0.
+  To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.65/introduction/).
 
   > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on [InfluxCommunity](https://community.influxdata.com/), [Slack](https://influxcommunity.slack.com/), or [GitHub](https://github.com/influxdata/flux). InfluxDB Enterprise customers, please contact <support@influxdata.com>.
 
@@ -34,7 +34,7 @@ menu:
 - Reduce `influxd` and `influx` startup time if Flux isn't used.
 - Fix bugs in `-compact-series-file` flag.
 - Fix a SIGSEGV when accessing `tsi` active log.
-- Remove unsafe marshalling.
+- Verify precision in write requests.
 
 ## v1.7.9 [2019-10-27]
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -16,6 +16,7 @@ TBD
 ### Features
 
 - Add option to back up and restore meta data only.
+- Add [`influx inspect tombstone` command](/influxdb/v1.8/tools/influx_inspect/#verify-tombstone)
 - Update Go version to 1.13.8.
 - Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 - Update Flux version to v0.64.0.

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -15,18 +15,32 @@ TBD
 
 ### Features
 
-- Add option to back up and restore meta data only.
-- Add [`influx inspect tombstone` command](/influxdb/v1.8/tools/influx_inspect/#verify-tombstone)
-- Update Go version to 1.13.8.
-- Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
-- Update Flux version to v0.64.0.
+- Add [`influx inspect verify-tombstone` command](/influxdb/v1.8/tools/influx_inspect/#verify-tombstone)
+- Add offline series compaction to influx_inspect buildtsi
+- Make influx CLI support custom HTTP endpoint
+- Update Go version to 1.13.8
+- Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries
+- Enhance support for bound parameters.
+- Update Flux version to v0.64.0
   To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).
 
   > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on [InfluxCommunity](https://community.influxdata.com/), [Slack](https://influxcommunity.slack.com/), or [GitHub](https://github.com/influxdata/flux). InfluxDB Enterprise customers, please contact <support@influxdata.com>.
 
 ### Bug fixes
 
-- Make anti-entropy ignore expired shards.
+- Delete rebuilds series index when series to be deleted are only found in cache.
+- Delete rebuilds series index when series to be deleted are outside timerange.
+- Parse Accept header correctly.
+- Upgrade compaction error log from Info to Warn.
+- Remove double increment of meta index.
+- Improve series cardinality limit for inmem index.
+- Ensure all block data returned.
+- Skip WriteSnapshot during backup if snapshotter is busy.
+- Reduce influxd and influx startup time if Flux isn't used.
+- Fix bugs in -compact-series-file.
+- Update to Go 1.13.8 and Go modules.
+- Fix a SIGSEGV when accessing tsi active log.
+- Remove unsafe marshalling.
 
 ## v1.7.9 [2019-10-27]
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -15,10 +15,12 @@ TBD
 
 ### Features
 
-- Option to back up and restore meta data only.
+- Add option to back up and restore meta data only.
 - Update Go version to 1.13.8.
 - Update Flux version to v0.64.0.
   To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).
+
+  > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on our community website https://community.influxdata.com/, reach out to us on Slack https://influxcommunity.slack.com/) or GitHub. Enterprise customers, please contact <support@influxdata.com>.
 - Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 
 ### Bug fixes

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -20,7 +20,7 @@ TBD
 - Update Flux version to v0.64.0.
   To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).
 
-  > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on [InfluxCommunity](https://community.influxdata.com/), reach out to us on [Slack](https://influxcommunity.slack.com/) or [GitHub](https://github.com/influxdata/flux). InfluxDB Enterprise customers, please contact <support@influxdata.com>.
+  > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on [InfluxCommunity](https://community.influxdata.com/), [Slack](https://influxcommunity.slack.com/), or [GitHub](https://github.com/influxdata/flux). InfluxDB Enterprise customers, please contact <support@influxdata.com>.
 - Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 
 ### Bug fixes

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -20,7 +20,7 @@ TBD
 - Update Flux version to v0.64.0.
   To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).
 
-  > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on our community website https://community.influxdata.com/, reach out to us on Slack https://influxcommunity.slack.com/) or GitHub. Enterprise customers, please contact <support@influxdata.com>.
+  > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on [InfluxCommunity](https://community.influxdata.com/), reach out to us on [Slack](https://influxcommunity.slack.com/) or [GitHub](https://github.com/influxdata/flux). InfluxDB Enterprise customers, please contact <support@influxdata.com>.
 - Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 
 ### Bug fixes

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -13,7 +13,7 @@ menu:
 
 - Add [`influx inspect verify-tombstone` command](/influxdb/v1.8/tools/influx_inspect/#verify-tombstone)
 - Add offline series compaction to `influx_inspect buildtsi`.
-- Add support for connecting to a custom HTTP endpoint using `-path-prefix` in `influx` CLI.
+- Add support for connecting to a custom HTTP endpoint using `-url-prefix` in `influx` CLI.
 - Update Go version to 1.13.8.
 - Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 - Enhance support for bound parameters.

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -15,22 +15,15 @@ TBD
 
 ### Features
 
-#### Flux v0.64.0 technical preview
-
-* Update Flux version to v0.64.0
-
-* Enable Flux using the configuration setting [`[http] flux-enabled = true`](/influxdb/v1.8/administration/config/#flux-enabled-false).
-* Use the new [`influx -type=flux`](/influxdb/v1.8/tools/shell/#type) option to enable the Flux REPL shell for creating Flux queries.
-* Read about Flux and the Flux language, enabling Flux, or jump into the getting started and other guides in the [Flux v0.7 (technical preview) documentation](/flux/v0.7/).
-
-#### Other features
-
-* Option to back up and restore meta data only.
-* Update Go version to 1.13.8.
+- Option to back up and restore meta data only.
+- Update Go version to 1.13.8.
+- Update Flux version to v0.64.0.
+  To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).
+- Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 
 ### Bug fixes
 
-* Make anti-entropy ignore expired shards.
+- Make anti-entropy ignore expired shards.
 
 ## v1.7.9 [2019-10-27]
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -17,12 +17,11 @@ TBD
 
 - Add option to back up and restore meta data only.
 - Update Go version to 1.13.8.
+- Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 - Update Flux version to v0.64.0.
   To learn about Flux design principles and see how to enable and get started with Flux, see [Introduction to Flux](/flux/v0.64/introduction/).
 
   > We're evaluating the need for Flux controls equivalent to existing InfluxQL controls based on your feedback. Please join the discussion on [InfluxCommunity](https://community.influxdata.com/), [Slack](https://influxcommunity.slack.com/), or [GitHub](https://github.com/influxdata/flux). InfluxDB Enterprise customers, please contact <support@influxdata.com>.
-  
-- Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 
 ### Bug fixes
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -1,5 +1,5 @@
 ---
-title: InfluxDB 1.7 release notes
+title: InfluxDB 1.8 release notes
 menu:
   influxdb_1_8:
     name: Release notes
@@ -7,9 +7,33 @@ menu:
     parent: About the project
 ---
 
+## v1.8.0 [2020-3-TBD]
+
+### Breaking changes
+
+TBD
+
+### Features
+
+#### Flux v0.64.0 technical preview
+
+* Update Flux version to v0.64.0
+
+* Enable Flux using the configuration setting [`[http] flux-enabled = true`](/influxdb/v1.8/administration/config/#flux-enabled-false).
+* Use the new [`influx -type=flux`](/influxdb/v1.8/tools/shell/#type) option to enable the Flux REPL shell for creating Flux queries.
+* Read about Flux and the Flux language, enabling Flux, or jump into the getting started and other guides in the [Flux v0.7 (technical preview) documentation](/flux/v0.7/).
+
+#### Other features
+
+* Option to back up and restore meta data only.
+* Update Go version to 1.13.8.
+
+### Bug fixes
+
+* Make anti-entropy ignore expired shards.
+
 ## v1.7.9 [2019-10-27]
 
-### Release notes
 - This release is built using Go 1.12.10 which eliminates the
   [HTTP desync vulnerability](https://portswigger.net/research/http-desync-attacks-request-smuggling-reborn).
 

--- a/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
+++ b/content/influxdb/v1.8/about_the_project/releasenotes-changelog.md
@@ -13,7 +13,7 @@ menu:
 
 - Add [`influx inspect verify-tombstone` command](/influxdb/v1.8/tools/influx_inspect/#verify-tombstone)
 - Add offline series compaction to `influx_inspect buildtsi`.
-- Add support for connecting to a custom HTTP endpoint using `-url-prefix` in `influx` CLI.
+- Add support for connecting to a custom HTTP endpoint using `-url-prefix` in [`influx` CLI](/influxdb/v1.8/tools/influx-cli/_index).
 - Update Go version to 1.13.8.
 - Add InfluxDB 2.0 write API compatibility to use InfluxDB 2.0 client libraries.
 - Enhance support for bound parameters.


### PR DESCRIPTION
**To do:**
- update release date
- link to offline series compaction to `influx_inspect buildtsi` doc
- link to InfluxDB 2.0 write API when @pierwill  is ready.
- link to `-path-prefix` in `influx` CLI.
