### PR TITLE
update per #2709

### DIFF
--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -890,7 +890,7 @@ input:
   - name: MySQL
     id: mysql
     description: |
-      The MySQL input plugin gathers the statistics data from MySQL servers.
+      The MySQL input plugin gathers the statistics data from MySQL servers. Input plugin supports MariaDB and Percona.
     introduced: 0.1.1
     tags: [linux, macos, windows, data-stores]
 

--- a/data/telegraf_plugins.yml
+++ b/data/telegraf_plugins.yml
@@ -890,7 +890,7 @@ input:
   - name: MySQL
     id: mysql
     description: |
-      The MySQL input plugin gathers the statistics data from MySQL servers. Input plugin supports MariaDB and Percona.
+      The MySQL input plugin gathers the statistics data from MySQL, MariaDB, and Percona servers.
     introduced: 0.1.1
     tags: [linux, macos, windows, data-stores]
 


### PR DESCRIPTION
- Note that MySQL input plugin supports MariaDB and Percona.
- Add note to Telegraf 1.13 and Telegraf 1.14.
