### PR TITLE
Clarify InfluxQL sort order for series

### DIFF
--- a/content/influxdb/v1.7/query_language/data_exploration.md
+++ b/content/influxdb/v1.7/query_language/data_exploration.md
@@ -1959,6 +1959,13 @@ the last point returned has the most recent timestamp.
 `ORDER BY time DESC` reverses that order such that InfluxDB returns the points
 with the most recent timestamps first.
 
+InfluxQL returns series in sorted order,
+which lets you limit or offset query results by series (rather than by row) using
+[slimit](/influxdb/v1.7/query_language/data_exploration/#the-slimit-clause) and
+[soffset](https://docs.influxdata.com/influxdb/v1.7/query_language/data_exploration/#the-soffset-clause).
+This is useful for paging through results by time.
+
+
 ### Syntax
 
 ```sql


### PR DESCRIPTION
This PR aims to address https://github.com/influxdata/DAR/issues/86.

@abalone23 / @jsternberg : can you confirm the accuracy of this addition? Is there a better place for this information than [here](https://docs.influxdata.com/influxdb/v1.7/query_language/data_exploration/#order-by-time-desc)?