### PR TITLE
1.8 client libraries

### DIFF
--- a/content/influxdb/v1.7/tools/api_client_libraries.md
+++ b/content/influxdb/v1.7/tools/api_client_libraries.md
@@ -11,7 +11,7 @@ menu:
     parent: Tools
 ---
 
-InfluxDB client libraries are developed by the open source community. These client libraries support the InfluxDB API and should be fully compatible with InfluxDB 1.5+. Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
+InfluxDB client libraries are developed by the open source community. These client libraries support the InfluxDB 1.7 API and should be fully compatible with InfluxDB 1.5+. Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
 
 >**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB client libraries](/influxdb/v1.8/tools/api-client-libraries).
 

--- a/content/influxdb/v1.7/tools/api_client_libraries.md
+++ b/content/influxdb/v1.7/tools/api_client_libraries.md
@@ -13,7 +13,7 @@ menu:
 
 InfluxDB client libraries are developed by the open source community. These client libraries support the InfluxDB 1.7 API and should be fully compatible with InfluxDB 1.5+. Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
 
->**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB client libraries](/influxdb/v1.8/tools/api-client-libraries).
+>**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB client libraries](/influxdb/v1.8/tools/api-client-libraries/).
 
 Thanks to the open source community for your contributions, commitment, and effort!
 

--- a/content/influxdb/v1.7/tools/api_client_libraries.md
+++ b/content/influxdb/v1.7/tools/api_client_libraries.md
@@ -1,5 +1,5 @@
 ---
-title: InfluxDB API client libraries
+title: InfluxDB client libraries
 description: InfluxDB API client libraries includes support for Elixir, Go, Haskell, Java, JavaScript/Node.js, Lisp, MATLAB, .Net, Perl, PHP, Python, R, Ruby, Rust, Scala, Sensu, and the SNMP agent.
 aliases:
     - /influxdb/v1.7/clients/api_client_libraries/
@@ -13,7 +13,7 @@ menu:
 
 InfluxDB client libraries are developed by the open source community. These client libraries support the InfluxDB API and should be fully compatible with InfluxDB 1.5+. Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
 
->**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB 1.8 API client libraries](/influxdb/v1.8/tools/api-client-libraries).
+>**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB API client libraries](/influxdb/v1.8/tools/api-client-libraries).
 
 Thanks to the open source community for your contributions, commitment, and effort!
 

--- a/content/influxdb/v1.7/tools/api_client_libraries.md
+++ b/content/influxdb/v1.7/tools/api_client_libraries.md
@@ -1,6 +1,6 @@
 ---
 title: InfluxDB client libraries
-description: InfluxDB API client libraries includes support for Elixir, Go, Haskell, Java, JavaScript/Node.js, Lisp, MATLAB, .Net, Perl, PHP, Python, R, Ruby, Rust, Scala, Sensu, and the SNMP agent.
+description: InfluxDB client libraries include support for Elixir, Go, Haskell, Java, JavaScript/Node.js, Lisp, MATLAB, .Net, Perl, PHP, Python, R, Ruby, Rust, Scala, Sensu, and the SNMP agent.
 aliases:
     - /influxdb/v1.7/clients/api_client_libraries/
     - /influxdb/v1.7/clients/
@@ -13,7 +13,7 @@ menu:
 
 InfluxDB client libraries are developed by the open source community. These client libraries support the InfluxDB API and should be fully compatible with InfluxDB 1.5+. Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
 
->**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB API client libraries](/influxdb/v1.8/tools/api-client-libraries).
+>**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB client libraries](/influxdb/v1.8/tools/api-client-libraries).
 
 Thanks to the open source community for your contributions, commitment, and effort!
 

--- a/content/influxdb/v1.7/tools/api_client_libraries.md
+++ b/content/influxdb/v1.7/tools/api_client_libraries.md
@@ -13,7 +13,7 @@ menu:
 
 InfluxDB client libraries are developed by the open source community. These client libraries support the InfluxDB 1.7 API and should be fully compatible with InfluxDB 1.5+. Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
 
->**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB client libraries](/influxdb/v1.8/tools/api-client-libraries/).
+>**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB client libraries](/influxdb/v1.8/tools/api_client_libraries/).
 
 Thanks to the open source community for your contributions, commitment, and effort!
 

--- a/content/influxdb/v1.7/tools/api_client_libraries.md
+++ b/content/influxdb/v1.7/tools/api_client_libraries.md
@@ -11,7 +11,9 @@ menu:
     parent: Tools
 ---
 
-InfluxDB client libraries are developed by the open source community. These client libraries support the InfluxDB API and should be fully compatible with InfluxDB version 1.5. Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
+InfluxDB client libraries are developed by the open source community. These client libraries support the InfluxDB API and should be fully compatible with InfluxDB 1.5+. Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
+
+>**Note:** We highly recommend upgrading to InfluxDB 1.8 to use new client libraries compatible with both InfluxDB 1.8 and InfluxDB 2.0. For more information, see [InfluxDB 1.8 API client libraries](/influxdb/v1.8/tools/api-client-libraries).
 
 Thanks to the open source community for your contributions, commitment, and effort!
 

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -26,7 +26,7 @@ curl -i -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE m
 
 The InfluxDB API is the primary means of writing data into InfluxDB.
 
-- To write to a database created in 1.7 or earlier, send `POST` requests to the `/write` endpoint.
+- To write to an existing database, send `POST` requests to the `/write` endpoint.
 - To write to a database created in 1.8 or later using InfluxDB client libraries (with InfluxDB 2.0 compatibility), send `POST` requests to the `/api/v2/write` endpoint.
 
 For example, to write a single point to the `mydb` database.

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -26,7 +26,7 @@ curl -i -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE m
 
 The InfluxDB API is the primary means of writing data into InfluxDB.
 
-- To **write to a database created in 1.7 or earlier**, send `POST` requests to the `/write` endpoint. For example, to write a single point to the `mydb` database.
+- To **write to a database using the InfluxDB 1.8 API**, send `POST` requests to the `/write` endpoint. For example, to write a single point to the `mydb` database.
 The data consists of the [measurement](/influxdb/v1.8/concepts/glossary/#measurement) `cpu_load_short`, the [tag keys](/influxdb/v1.8/concepts/glossary/#tag-key) `host` and `region` with the [tag values](/influxdb/v1.8/concepts/glossary/#tag-value) `server01` and `us-west`, the [field key](/influxdb/v1.8/concepts/glossary/#field-key) `value` with a [field value](/influxdb/v1.8/concepts/glossary/#field-value) of `0.64`, and the [timestamp](/influxdb/v1.8/concepts/glossary/#timestamp) `1434055562000000000`.
 
 ```bash
@@ -34,7 +34,7 @@ curl -i -XPOST 'http://localhost:8086/write?db=mydb'
 --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
 
-- To **write to a database created in 1.8 or later** using [InfluxDB client libraries (with InfluxDB 2.0 compatibility)](/influxdb/v1.8/tools/api_client_libraries/#client-libraries), send `POST` requests to the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#client-libraries):
+- To **write to a database using the InfluxDB 2.0 API (compatible with InfluxDB 1.8+)**, send `POST` requests to the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#client-libraries):
 
 ```bash
 curl -i -XPOST 'http://localhost:8086/api/v2/write?bucket=db/rp&precision=ns' \

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -26,10 +26,7 @@ curl -i -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE m
 
 The InfluxDB API is the primary means of writing data into InfluxDB.
 
-- To write to an existing database, send `POST` requests to the `/write` endpoint.
-- To write to a database created in 1.8 or later using [InfluxDB client libraries (with InfluxDB 2.0 compatibility)](/influxdb/v1.8/tools/api_client_libraries/#client-libraries), send `POST` requests to the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#client-libraries).
-
-For example, to write a single point to the `mydb` database.
+- To **write to a database created in 1.7 or earlier**, send `POST` requests to the `/write` endpoint. For example, to write a single point to the `mydb` database.
 The data consists of the [measurement](/influxdb/v1.8/concepts/glossary/#measurement) `cpu_load_short`, the [tag keys](/influxdb/v1.8/concepts/glossary/#tag-key) `host` and `region` with the [tag values](/influxdb/v1.8/concepts/glossary/#tag-value) `server01` and `us-west`, the [field key](/influxdb/v1.8/concepts/glossary/#field-key) `value` with a [field value](/influxdb/v1.8/concepts/glossary/#field-value) of `0.64`, and the [timestamp](/influxdb/v1.8/concepts/glossary/#timestamp) `1434055562000000000`.
 
 ```bash
@@ -37,7 +34,7 @@ curl -i -XPOST 'http://localhost:8086/write?db=mydb'
 --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
 
-Alternatively, to write data to InfluxDB 1.8+ using the InfluxDB 2.0 API, include the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#-client-libraries/#client-libraries) in your curl request:
+- To **write to a database created in 1.8 or later** using [InfluxDB client libraries (with InfluxDB 2.0 compatibility)](/influxdb/v1.8/tools/api_client_libraries/#client-libraries), send `POST` requests to the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#client-libraries):
 
 ```bash
 curl -i -XPOST 'http://localhost:8086/api/v2/write?bucket=db/rp&precision=ns' \

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -27,17 +27,22 @@ curl -i -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE m
 The InfluxDB API is the primary means of writing data into InfluxDB.
 
 - To write to an existing database, send `POST` requests to the `/write` endpoint.
-- To write to a database created in 1.8 or later using InfluxDB client libraries (with InfluxDB 2.0 compatibility), send `POST` requests to the `/api/v2/write` endpoint.
+- To write to a database created in 1.8 or later using [InfluxDB client libraries (with InfluxDB 2.0 compatibility)](/influxdb/v1.8/tools/api-client-libraries/#client-libraries), send `POST` requests to the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#-client-libraries/#client-libraries).
 
 For example, to write a single point to the `mydb` database.
 The data consists of the [measurement](/influxdb/v1.8/concepts/glossary/#measurement) `cpu_load_short`, the [tag keys](/influxdb/v1.8/concepts/glossary/#tag-key) `host` and `region` with the [tag values](/influxdb/v1.8/concepts/glossary/#tag-value) `server01` and `us-west`, the [field key](/influxdb/v1.8/concepts/glossary/#field-key) `value` with a [field value](/influxdb/v1.8/concepts/glossary/#field-value) of `0.64`, and the [timestamp](/influxdb/v1.8/concepts/glossary/#timestamp) `1434055562000000000`.
 
 ```bash
-curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
+curl -i -XPOST 'http://localhost:8086/write?db=mydb' 
+--data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
+```
 
-//or to write data using new client libraries
+Alternatively, to write data using the InfluxDB 2.0 compatible endpoint
 
-curl -i -XPOST 'http://localhost:8086/api/v2/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
+```
+curl -i -XPOST 'http://localhost:8086/api/v2/write?bucket=db/rp&precision=ns' \
+  --header 'Authorization: Token username:password' \
+  --data-raw 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
 
 When writing points, you must specify an existing database in the `db` query parameter.

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -27,7 +27,7 @@ curl -i -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE m
 The InfluxDB API is the primary means of writing data into InfluxDB.
 
 - To write to an existing database, send `POST` requests to the `/write` endpoint.
-- To write to a database created in 1.8 or later using [InfluxDB client libraries (with InfluxDB 2.0 compatibility)](/influxdb/v1.8/tools/api-client-libraries/#client-libraries), send `POST` requests to the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#-client-libraries/#client-libraries).
+- To write to a database created in 1.8 or later using [InfluxDB client libraries (with InfluxDB 2.0 compatibility)](/influxdb/v1.8/tools/api_client_libraries/#client-libraries), send `POST` requests to the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#client-libraries).
 
 For example, to write a single point to the `mydb` database.
 The data consists of the [measurement](/influxdb/v1.8/concepts/glossary/#measurement) `cpu_load_short`, the [tag keys](/influxdb/v1.8/concepts/glossary/#tag-key) `host` and `region` with the [tag values](/influxdb/v1.8/concepts/glossary/#tag-value) `server01` and `us-west`, the [field key](/influxdb/v1.8/concepts/glossary/#field-key) `value` with a [field value](/influxdb/v1.8/concepts/glossary/#field-value) of `0.64`, and the [timestamp](/influxdb/v1.8/concepts/glossary/#timestamp) `1434055562000000000`.

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -24,28 +24,34 @@ curl -i -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE m
 
 ### Write data using the InfluxDB API
 
-The InfluxDB API is the primary means of writing data into InfluxDB, by sending `POST` requests to the `/write` endpoint.
+The InfluxDB API is the primary means of writing data into InfluxDB.
 
-The example below writes a single point to the `mydb` database.
-The data consist of the [measurement](/influxdb/v1.8/concepts/glossary/#measurement) `cpu_load_short`, the [tag keys](/influxdb/v1.8/concepts/glossary/#tag-key) `host` and `region` with the [tag values](/influxdb/v1.8/concepts/glossary/#tag-value) `server01` and `us-west`, the [field key](/influxdb/v1.8/concepts/glossary/#field-key) `value` with a [field value](/influxdb/v1.8/concepts/glossary/#field-value) of `0.64`, and the [timestamp](/influxdb/v1.8/concepts/glossary/#timestamp) `1434055562000000000`.
+- To write to a database created in 1.7 or earlier, send `POST` requests to the `/write` endpoint.
+- To write to a database created in 1.8 or later using InfluxDB client libraries (with InfluxDB 2.0 compatibility), send `POST` requests to the `/api/v2/write` endpoint.
+
+For example, to write a single point to the `mydb` database.
+The data consists of the [measurement](/influxdb/v1.8/concepts/glossary/#measurement) `cpu_load_short`, the [tag keys](/influxdb/v1.8/concepts/glossary/#tag-key) `host` and `region` with the [tag values](/influxdb/v1.8/concepts/glossary/#tag-value) `server01` and `us-west`, the [field key](/influxdb/v1.8/concepts/glossary/#field-key) `value` with a [field value](/influxdb/v1.8/concepts/glossary/#field-value) of `0.64`, and the [timestamp](/influxdb/v1.8/concepts/glossary/#timestamp) `1434055562000000000`.
 
 ```bash
 curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
+
+//or to write data using new client libraries
+
+curl -i -XPOST 'http://localhost:8086/api/v2/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
 
 When writing points, you must specify an existing database in the `db` query parameter.
 Points will be written to `db`'s default retention policy if you do not supply a retention policy via the `rp` query parameter.
 See the [InfluxDB API Reference](/influxdb/v1.8/tools/api/#write-http-endpoint) documentation for a complete list of the available query parameters.
 
-The body of the POST - we call this the [InfluxDB line protocol](/influxdb/v1.8/concepts/glossary/#influxdb-line-protocol) - contains the time-series data that you wish to store.
-They consist of a measurement, tags, fields, and a timestamp.
-InfluxDB requires a measurement name.
-Strictly speaking, tags are optional but most series include tags to differentiate data sources and to make querying both easy and efficient.
+The body of the POST or [InfluxDB line protocol](/influxdb/v1.8/concepts/glossary/#influxdb-line-protocol) contains the time series data that you want to store. Data includes:
+
+- **Measurement (required)**
+- **Tags**: Strictly speaking, tags are optional but most series include tags to differentiate data sources and to make querying both easy and efficient.
 Both tag keys and tag values are strings.
-Field keys are required and are always strings, and, [by default](/influxdb/v1.8/write_protocols/line_protocol_reference/#data-types), field values are floats.
-The timestamp - supplied at the end of the line in Unix time in nanoseconds since January 1, 1970 UTC - is optional.
-If you do not specify a timestamp InfluxDB uses the server's local nanosecond timestamp in Unix epoch.
-Anything that has to do with time in InfluxDB is always UTC.
+- **Fields (required)**: Field keys are required and are always strings, and, [by default](/influxdb/v1.8/write_protocols/line_protocol_reference/#data-types), field values are floats.
+- **Timestamp**: Supplied at the end of the line in Unix time in nanoseconds since January 1, 1970 UTC - is optional. If you do not specify a timestamp, InfluxDB uses the server's local nanosecond timestamp in Unix epoch.
+Time in InfluxDB is in UTC format by default.
 
 ### Configure gzip compression
 

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -39,7 +39,7 @@ curl -i -XPOST 'http://localhost:8086/write?db=mydb'
 
 Alternatively, to write data to InfluxDB 1.8+ using the InfluxDB 2.0 API, include the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#-client-libraries/#client-libraries) in your curl request:
 
-````bash
+```bash
 curl -i -XPOST 'http://localhost:8086/api/v2/write?bucket=db/rp&precision=ns' \
   --header 'Authorization: Token username:password' \
   --data-raw 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -33,11 +33,11 @@ For example, to write a single point to the `mydb` database.
 The data consists of the [measurement](/influxdb/v1.8/concepts/glossary/#measurement) `cpu_load_short`, the [tag keys](/influxdb/v1.8/concepts/glossary/#tag-key) `host` and `region` with the [tag values](/influxdb/v1.8/concepts/glossary/#tag-value) `server01` and `us-west`, the [field key](/influxdb/v1.8/concepts/glossary/#field-key) `value` with a [field value](/influxdb/v1.8/concepts/glossary/#field-value) of `0.64`, and the [timestamp](/influxdb/v1.8/concepts/glossary/#timestamp) `1434055562000000000`.
 
 ```bash
-curl -i -XPOST 'http://localhost:8086/write?db=mydb' 
+curl -i -XPOST 'http://localhost:8086/write?db=mydb'
 --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
 
-Alternatively, to write data using the InfluxDB 2.0 compatible endpoint
+Alternatively, to write data to InfluxDB 1.8+ using the InfluxDB 2.0 API, include the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#-client-libraries/#client-libraries) in your curl request:
 
 ```
 curl -i -XPOST 'http://localhost:8086/api/v2/write?bucket=db/rp&precision=ns' \

--- a/content/influxdb/v1.8/guides/write_data.md
+++ b/content/influxdb/v1.8/guides/write_data.md
@@ -39,7 +39,7 @@ curl -i -XPOST 'http://localhost:8086/write?db=mydb'
 
 Alternatively, to write data to InfluxDB 1.8+ using the InfluxDB 2.0 API, include the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api/#-client-libraries/#client-libraries) in your curl request:
 
-```
+````bash
 curl -i -XPOST 'http://localhost:8086/api/v2/write?bucket=db/rp&precision=ns' \
   --header 'Authorization: Token username:password' \
   --data-raw 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -86,6 +86,8 @@ Use a InfluxDB client library to integrate InfluxDB into your scripts and applic
       token=token,
    ```
 
+  >**Note:** The database (and retention policy, if applicable) are converted to a [bucket](https://v2.docs.influxdata.com/v2.0/reference/glossary/#bucket) data store compatible with InfluxDB 2.0.
+  
 5. Instantiate a writer object using the client object and the write_api method. Use the `write_api` method to configure the writer object.
 
    ```sh
@@ -99,5 +101,3 @@ Use a InfluxDB client library to integrate InfluxDB into your scripts and applic
       p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
        write_api.write(database:rp, record=p)
   ```
-
-The database (and retention policy, if applicable) are converted to a [bucket](https://v2.docs.influxdata.com/v2.0/reference/glossary/#bucket) data store compatible with InfluxDB 2.0.

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -19,6 +19,8 @@ For information about client libraries compatible with InfluxDB 1.7 and earlier,
 
 ## Client libraries
 
+Functionality varies between client libraries. Refer to client libraries on GitHub for specifics regarding each client library.
+
 ### Arduino
 - [InfluxDB Arduino Client](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino)
   - Contributed by [Tobias Schürg (tobiasschuerg)](https://github.com/tobiasschuerg)

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -13,7 +13,7 @@ menu:
 
 InfluxDB client libraries are language-specific packages that integrate with the InfluxDB 2.0 API and support both **InfluxDB 1.8+** and **InfluxDB 2.0**.
 
->**Note:** We recommend using the new client libraries on this page to write to the `/api/v2/write` endpoint and prepare for conversion to InfluxDB 2.0 and InfluxDB Cloud 2.0. For more information, see [InfluxDB 2.0 API compatibility endpoints](/influxdb/v1.8/tools/api/#influxdb-2.0-compatibility-endpoints). Client libraries for [InfluxDB 1.7 and earlier](/influxdb/v1.7/tools/api-client-libraries) may continue to work, but are not maintained by InfluxData.
+>**Note:** We recommend using the new client libraries on this page to write to the `/api/v2/write` endpoint and prepare for conversion to InfluxDB 2.0 and InfluxDB Cloud 2.0. For more information, see [InfluxDB 2.0 API compatibility endpoints](/influxdb/v1.8/tools/api/#influxdb-2.0-compatibility-endpoints). Client libraries for [InfluxDB 1.7 and earlier](/influxdb/v1.7/tools/api-client-libraries/) may continue to work, but are not maintained by InfluxData.
 
 ## Client libraries
 

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -1,6 +1,6 @@
 ---
 title: InfluxDB API client libraries
-description: InfluxDB API client libraries includes support for Arduino, Go, Haskell, Java, JavaScript/Node.js, Lisp, MATLAB, .Net, Perl, PHP, Python, R, Ruby, Rust, Scala, Sensu, and the SNMP agent.
+description: InfluxDB API client libraries includes support for Arduino, C#, Go, Java, JavaScript, PHP, Python, and Ruby.
 aliases:
     - /influxdb/v1.8/clients/api_client_libraries/
     - /influxdb/v1.8/clients/
@@ -47,14 +47,14 @@ For information about client libraries compatible with InfluxDB 1.7 and earlier,
 - [influxdb-client-php](https://github.com/influxdata/influxdb-client-php)
    - Maintained by [InfluxData](https://github.com/influxdata)
 
-### Ruby
-
-- [influxdb-client-ruby](https://github.com/influxdata/influxdb-client-ruby)
-   - Maintained by [InfluxData](https://github.com/influxdata)
-
 ### Python
 
 * [influxdb-client-python](https://github.com/influxdata/influxdb-client-python)
+   - Maintained by [InfluxData](https://github.com/influxdata)
+
+### Ruby
+
+- [influxdb-client-ruby](https://github.com/influxdata/influxdb-client-ruby)
    - Maintained by [InfluxData](https://github.com/influxdata)
 
 ## Use a client library

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -1,6 +1,6 @@
 ---
-title: InfluxDB API client libraries
-description: InfluxDB API client libraries includes support for Arduino, C#, Go, Java, JavaScript, PHP, Python, and Ruby.
+title: InfluxDB client libraries
+description: InfluxDB client libraries includes support for Arduino, C#, Go, Java, JavaScript, PHP, Python, and Ruby.
 aliases:
     - /influxdb/v1.8/clients/api_client_libraries/
     - /influxdb/v1.8/clients/

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -13,7 +13,7 @@ menu:
 
 InfluxDB client libraries are language-specific packages that integrate with the InfluxDB 2.0 API and support both **InfluxDB 1.8+** and **InfluxDB 2.0**.
 
->**Note:** We recommend using the new client libraries on this page to write to the `/api/v2/write` endpoint and prepare for conversion to InfluxDB 2.0 and InfluxDB Cloud 2.0. For more information, see [InfluxDB 2.0 API compatibility endpoints](/influxdb/v1.8/tools/api/#influxdb-2.0-compatibility-endpoints). Client libraries for [InfluxDB 1.7 and earlier](/influxdb/v1.7/tools/api-client-libraries/) may continue to work, but are not maintained by InfluxData.
+>**Note:** We recommend using the new client libraries on this page to write to the `/api/v2/write` endpoint and prepare for conversion to InfluxDB 2.0 and InfluxDB Cloud 2.0. For more information, see [InfluxDB 2.0 API compatibility endpoints](/influxdb/v1.8/tools/api/#influxdb-2.0-compatibility-endpoints). Client libraries for [InfluxDB 1.7 and earlier](/influxdb/v1.7/tools/api_client_libraries/) may continue to work, but are not maintained by InfluxData.
 
 ## Client libraries
 

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -11,9 +11,7 @@ menu:
     parent: Tools
 ---
 
-## Overview
-
-InfluxDB client libraries are language-specific packages that integrate with the InfluxDB API and support both InfluxDB 1.8+ and InfluxDB 2.0. The client libraries on this page are available for writing data to InfluxDB using the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api#api-v2-write-http-endpoint).
+InfluxDB client libraries are language-specific packages that integrate with the InfluxDB API and support both **InfluxDB 1.8+** and **InfluxDB 2.0**. The client libraries on this page are available for writing data to InfluxDB using the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api#api-v2-write-http-endpoint).
 
 For information about client libraries compatible with InfluxDB 1.7 and earlier, see [InfluxDB 1.7 API client libraries](/influxdb/v1.7/tools/api-client-libraries).
 
@@ -58,3 +56,25 @@ For information about client libraries compatible with InfluxDB 1.7 and earlier,
 
 * [influxdb-client-python](https://github.com/influxdata/influxdb-client-python)
    - Maintained by [InfluxData](https://github.com/influxdata)
+
+## Use a client library
+
+Use a InfluxDB client library to integrate InfluxDB into your scripts and applications.
+
+1. Install the client library.
+
+  For example, to install the InfluxDB Python client library:
+
+  ```sh
+      pip install influxd-client
+  ```
+
+2. Ensure that InfluxDB is running. If running InfluxDB locally, visit http://localhost:9999. (If using InfluxDB Cloud, visit the URL of your InfluxDB Cloud UI.)
+
+3. Import the client library. For example, to import the Python client library:
+
+```sh 
+   import influxdb_client`
+```
+
+For example, for Python program, import the InfluxDB client library and use it to write data to InfluxDB.

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -59,7 +59,7 @@ Functionality varies between client libraries. Refer to client libraries on GitH
 
 ## Use a client library
 
-Use a InfluxDB client library to integrate InfluxDB into your scripts and applications.
+Use an InfluxDB client library to integrate InfluxDB into your scripts and applications.
 
 1. Install the client library. Refer to the client library documentation for detail. For example, to install the Python client library:
 

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -1,6 +1,6 @@
 ---
 title: InfluxDB API client libraries
-description: InfluxDB API client libraries includes support for Elixir, Go, Haskell, Java, JavaScript/Node.js, Lisp, MATLAB, .Net, Perl, PHP, Python, R, Ruby, Rust, Scala, Sensu, and the SNMP agent.
+description: InfluxDB API client libraries includes support for Arduino, Go, Haskell, Java, JavaScript/Node.js, Lisp, MATLAB, .Net, Perl, PHP, Python, R, Ruby, Rust, Scala, Sensu, and the SNMP agent.
 aliases:
     - /influxdb/v1.8/clients/api_client_libraries/
     - /influxdb/v1.8/clients/
@@ -11,131 +11,50 @@ menu:
     parent: Tools
 ---
 
-InfluxDB client libraries are developed by the open source community and InfluxData.
-These client libraries support the InfluxDB API and should be fully compatible with InfluxDB version 1.5+.
-Functionality will vary as there are no standard features that all libraries must implement in order to be listed here.
+## Overview
 
-Thanks to the open source community for your contributions, commitment, and effort!
+InfluxDB client libraries are language-specific packages that integrate with the InfluxDB API and support both InfluxDB 1.8+ and InfluxDB 2.0. The client libraries on this page are available for writing data to InfluxDB using the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api#api-v2-write-http-endpoint).
 
-> [Client libraries](https://v2.docs.influxdata.com/v2.0/reference/api/client-libraries/) are also available for InfluxDB 2.0.
-> These are backwards-compatible with 1.8.0+ using the [`/api/v2/write` API endpoint](/influxdb/v1.8/tools/api#api-v2-write-http-endpoint).
+For information about client libraries compatible with InfluxDB 1.7 and earlier, see [InfluxDB 1.7 API client libraries](/influxdb/v1.7/tools/api-client-libraries).
 
-## C++
-* [influxdb-cxx](https://github.com/awegrzyn/influxdb-cxx.git)
-  * Maintained by [Adam Wegrzynek (awegrzyn)](https://github.com/awegrzyn)
+>**Note:** We highly recommend using these new client libraries to prepare for conversion to InfluxDB 2.0 and InfluxDB Cloud 2.0. When you write data to the `/api/v2/write` endpoint, you specify a database and retention policy, which is converted to a [bucket](https://v2.docs.influxdata.com/v2.0/reference/glossary/#bucket)--the new data store in InfluxDB 2.0.
 
-## Elixir
+## Client libraries
 
-* [Instream (instream)](https://github.com/mneudert/instream)
-  * Maintained by [Marc Neudert (mneudert)](https://github.com/mneudert)
+### Arduino
+- [InfluxDB Arduino Client](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino)
+  - Contributed by [Tobias Schürg (tobiasschuerg)](https://github.com/tobiasschuerg)
 
-## Erlang
+### #C
+- [influxdb-client-csharp](https://github.com/influxdata/influxdb-client-csharp)
+  - Maintained by [InfluxData](https://github.com/influxdata)
 
-* [Erlang InfluxDB UDP Writer](https://github.com/palkan/influx_udp)
-  * Maintained by [Vladimir Dementyev (palkan)](https://github.com/palkan)
-* [InfluxDB line encoder](https://github.com/emeter/influxdb_encoderl)
-  * Maintained by [Pouriya Jahanbakhsh (emeter)](https://github.com/emeter)
+### Go
 
-## Go
+- [influxdb-client-go](https://github.com/influxdata/influxdb-client-go)
+  - Maintained by [InfluxData](https://github.com/influxdata)
 
-* [InfluxDB Client](https://github.com/influxdata/influxdb1-client)
-  * Maintained by [InfluxData](https://github.com/influxdata)
+### Java
 
-## Haskell
+- [influxdb-client-java](https://github.com/influxdata/influxdb-client-java)
+   - Maintained by [InfluxData](https://github.com/influxdata)
 
-* [influxdb-haskell](https://github.com/maoe/influxdb-haskell)
-  * Maintained by [Mitsutoshi Aoe (maoe)](https://github.com/maoe)
+### JavaScript
 
-## Java
+* [influxdb-javascript](https://github.com/influxdata/influxdb-client-js)
+   - Maintained by [InfluxData](https://github.com/influxdata)
 
-* [influxdb-java](https://github.com/influxdb/influxdb-java)
-  * Maintained by [Stefan Majer (majst01)](https://github.com/majst01)
-* [Alpakka InfluxDB](https://doc.akka.io/docs/alpakka/current/influxdb.html)
-  * Maintained by the Alpakka community with help from [Lightbend](https://www.lightbend.com/)
+### PHP
 
-## JavaScript/Node.js
+- [influxdb-client-php](https://github.com/influxdata/influxdb-client-php)
+   - Maintained by [InfluxData](https://github.com/influxdata)
 
-* [node-influx](https://github.com/node-influx/node-influx)
-  * Maintained by [Ben Evans (bencevans)](https://github.com/bencevans) and [Connor Peet (connor4312)](https://github.com/connor4312)
+### Ruby
 
-## Lisp
+- [influxdb-client-ruby](https://github.com/influxdata/influxdb-client-ruby)
+   - Maintained by [InfluxData](https://github.com/influxdata)
 
-* [CL-INFLUXDB](https://github.com/mmaul/cl-influxdb)
-  * Maintained by [Mike Maul (mmaul)](https://github.com/mmaul)
+### Python
 
-## MATLAB
-
-* [influxdb-matlab](https://github.com/EnricSala/influxdb-matlab)
-  * Maintained by [Enric Sala (EnricSala)](https://github.com/EnricSala)
-
-## .Net
-
-* [InfluxDB.Client.Net](https://github.com/AdysTech/InfluxDB.Client.Net)
-  * Maintained by [Adarsha (mvadu)](https://github.com/mvadu)
-  * Supports .Net and .Net Core
-* [InfluxData.Net](https://github.com/pootzko/InfluxData.Net)
-  * Maintained by [Tijhomir Kit (pootzko)](https://github.com/pootzko)
-* [InfluxDB Client for .NET](https://github.com/MikaelGRA/InfluxDB.Client)
-  * Maintained by [Mikael Guldborg Rask Andersen (MikaelGRA)](https://github.com/MikaelGRA)
-* [InfluxClient](https://github.com/danesparza/InfluxClient)
-  * Maintained by [Dan Esparza (danesparza)](https://github.com/danesparza)
-
-## Perl
-
-* [AnyEvent::InfluxDB](https://github.com/ajgb/anyevent-influxdb)
-  * Maintained by [Alex Burzyński (ajgb)](https://github.com/ajgb)
-* [InfluxDB-LineProtocol](http://search.cpan.org/~domm/InfluxDB-LineProtocol/)
-  * Maintained by [Thomas Klausner (domm)](https://domm.plix.at/)
-* [InfluxDB::HTTP](https://github.com/raphaelthomas/InfluxDB-HTTP)
-  * Maintained by [Raphael Seebacher (raphaelthomas)](https://github.com/raphaelthomas)
-
-## PHP
-
-* [influxdb-php](https://github.com/influxdb/influxdb-php)
-  * Maintained by [TheCodeAssassin (thecodeassassin)](https://github.com/thecodeassassin) and [Gianluca Arbezzano (gianarb)](https://github.com/gianarb)
-* [InfluxDB PHP SDK (influxdb-php-sdk)](https://github.com/corley/influxdb-php-sdk)
-  * Maintained by [Corley (corley)](https://github.com/corley)
-
-## Python
-
-* [InfluxDB-Python (influxdb-python)](https://github.com/influxdb/influxdb-python)
-  * Maintained by [Alexandre Viau (aviau)](https://github.com/aviau), [xginn8](https://github.com/xginn8), and [Sebastian Borza (sebito91)](https://github.com/sebito91)
-
-## R
-
-* [influxdbr](https://cran.r-project.org/web/packages/influxdbr/)
-  * Maintained by [Dominik Leutnant (dleutant)](https://github.com/dleutnant)
-
-## Ruby
-
-* [influxdb-ruby](https://github.com/influxdb/influxdb-ruby)
-  * Maintained by [Todd Persen (toddboom)](https://github.com/toddboom) and [Dominik Menke (dmke)](https://github.com/dmke).
-* [Influxer (influxer)](https://github.com/palkan/influxer)
-  * Maintained by [Vladimir Dementyev (palkan)](https://github.com/palkan).
-
-## Rust
-
-* [Flux (flux)](https://crates.io/crates/flux)
-  * Maintained by [Chris Holcombe (cholcombe973)](https://crates.io/users/cholcombe973) and [Chris MacNaughton](https://crates.io/users/ChrisMacNaughton)
-* [Influent (influent)](https://crates.io/crates/influent)
-  * Maintained by [gobwas](https://crates.io/users/gobwas) and [Eijebong](https://crates.io/users/Eijebong).
-
-## Scala
-
-* [scala-influxdb-client](https://github.com/paulgoldbaum/scala-influxdb-client)
-  * Maintained by [Paul Goldbaum (paulgoldbaum)](https://github.com/paulgoldbaum)
-* [chronicler](https://github.com/fsanaulla/chronicler)
-  * Maintained by [Faiaz Sanaulla (fsanaulla)](https://github.com/fsanaulla)
-* [Alpakka InfluxDB](https://doc.akka.io/docs/alpakka/current/influxdb.html)
-  * Maintained by the Alpakka community with help from [Lightbend](https://www.lightbend.com/)
-
-## Sensu
-
-* [sensu-influxdb-extension](https://github.com/jhrv/sensu-influxdb-extension)
-  * Maintained by [Johnny Horvi (jhrv)](https://github.com/jhrv)
-
-## SNMP agent
-
-* [SnmpCollector (snmpcollector)](https://github.com/toni-moreno/snmpcollector)
-  * Maintained by [Toni Moreno (toni-moreno)](https://github.com/toni-moreno).
-  * A full featured Generic SNMP data collector with Web Administration Interface for InfluxDB.
+* [influxdb-client-python](https://github.com/influxdata/influxdb-client-python)
+   - Maintained by [InfluxData](https://github.com/influxdata)

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -71,33 +71,33 @@ Use a InfluxDB client library to integrate InfluxDB into your scripts and applic
 
 3. In your program, import the client library and use it to write data to InfluxDB. For example:
 
-  ```sh 
-    import influxdb_client
-    from influxdb_client.client.write_api import SYNCHRONOUS
+  ```sh
+     import influxdb_client
+     from influxdb_client.client.write_api import SYNCHRONOUS
   ```
 
 4. Define your database and token variables, and create a client and writer object. The InfluxDBClient object takes 2 parameters: `url` and `token`.
 
-   ```sh 
-     Database = "<my-db>"
-    token = "<my-token>"
-    client = influxdb_client.InfluxDBClient(
-    url="http://localhost:8086",
-    token=token,
+   ```sh
+      database = "<my-db>"
+      token = "<my-token>"
+      client = influxdb_client.InfluxDBClient(
+      url="http://localhost:8086",
+      token=token,
    ```
 
 5. Instantiate a writer object using the client object and the write_api method. Use the `write_api` method to configure the writer object.
 
-   ```sh 
-    client = influxdb_client.InfluxDBClient(url=url, token=token)
-    write_api = client.write_api(write_options=SYNCHRONOUS)
+   ```sh
+      client = influxdb_client.InfluxDBClient(url=url, token=token)
+      write_api = client.write_api(write_options=SYNCHRONOUS)
    ```
 
 6. Create a point object and write it to InfluxDB using the write method of the API writer object. The write method requires three parameters: database, (optional) retention policy, and record.
 
   ```sh 
-  p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
-  write_api.write(database:rp, record=p)
+      p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
+       write_api.write(database:rp, record=p)
   ```
 
 The database (and retention policy, if applicable) are converted to a [bucket](https://v2.docs.influxdata.com/v2.0/reference/glossary/#bucket) data store compatible with InfluxDB 2.0.

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -11,11 +11,9 @@ menu:
     parent: Tools
 ---
 
-InfluxDB client libraries are language-specific packages that integrate with the InfluxDB API and support both **InfluxDB 1.8+** and **InfluxDB 2.0**. The client libraries on this page are available for writing data to InfluxDB using the [`/api/v2/write` endpoint](/influxdb/v1.8/tools/api#api-v2-write-http-endpoint).
+InfluxDB client libraries are language-specific packages that integrate with the InfluxDB 2.0 API and support both **InfluxDB 1.8+** and **InfluxDB 2.0**.
 
-For information about client libraries compatible with InfluxDB 1.7 and earlier, see [InfluxDB 1.7 API client libraries](/influxdb/v1.7/tools/api-client-libraries).
-
->**Note:** We highly recommend using these new client libraries to prepare for conversion to InfluxDB 2.0 and InfluxDB Cloud 2.0. When you write data to the `/api/v2/write` endpoint, you specify a database and retention policy, which is converted to a [bucket](https://v2.docs.influxdata.com/v2.0/reference/glossary/#bucket)--the new data store in InfluxDB 2.0.
+>**Note:** We recommend using the new client libraries on this page to write to the `/api/v2/write` endpoint and prepare for conversion to InfluxDB 2.0 and InfluxDB Cloud 2.0. For more information, see [InfluxDB 2.0 API compatibility endpoints](/influxdb/v1.8/tools/api/#influxdb-2.0-compatibility-endpoints). Client libraries for [InfluxDB 1.7 and earlier](/influxdb/v1.7/tools/api-client-libraries) may continue to work, but are not maintained by InfluxData.
 
 ## Client libraries
 

--- a/content/influxdb/v1.8/tools/api_client_libraries.md
+++ b/content/influxdb/v1.8/tools/api_client_libraries.md
@@ -61,20 +61,43 @@ For information about client libraries compatible with InfluxDB 1.7 and earlier,
 
 Use a InfluxDB client library to integrate InfluxDB into your scripts and applications.
 
-1. Install the client library.
-
-  For example, to install the InfluxDB Python client library:
+1. Install the client library. Refer to the client library documentation for detail. For example, to install the Python client library:
 
   ```sh
       pip install influxd-client
   ```
 
-2. Ensure that InfluxDB is running. If running InfluxDB locally, visit http://localhost:9999. (If using InfluxDB Cloud, visit the URL of your InfluxDB Cloud UI.)
+2. Ensure that InfluxDB is running. If running InfluxDB locally, visit http://localhost:8086. (If using InfluxDB Cloud, visit the URL of your InfluxDB Cloud UI.)
 
-3. Import the client library. For example, to import the Python client library:
+3. In your program, import the client library and use it to write data to InfluxDB. For example:
 
-```sh 
-   import influxdb_client`
-```
+  ```sh 
+    import influxdb_client
+    from influxdb_client.client.write_api import SYNCHRONOUS
+  ```
 
-For example, for Python program, import the InfluxDB client library and use it to write data to InfluxDB.
+4. Define your database and token variables, and create a client and writer object. The InfluxDBClient object takes 2 parameters: `url` and `token`.
+
+   ```sh 
+     Database = "<my-db>"
+    token = "<my-token>"
+    client = influxdb_client.InfluxDBClient(
+    url="http://localhost:8086",
+    token=token,
+   ```
+
+5. Instantiate a writer object using the client object and the write_api method. Use the `write_api` method to configure the writer object.
+
+   ```sh 
+    client = influxdb_client.InfluxDBClient(url=url, token=token)
+    write_api = client.write_api(write_options=SYNCHRONOUS)
+   ```
+
+6. Create a point object and write it to InfluxDB using the write method of the API writer object. The write method requires three parameters: database, (optional) retention policy, and record.
+
+  ```sh 
+  p = influxdb_client.Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)
+  write_api.write(database:rp, record=p)
+  ```
+
+The database (and retention policy, if applicable) are converted to a [bucket](https://v2.docs.influxdata.com/v2.0/reference/glossary/#bucket) data store compatible with InfluxDB 2.0.


### PR DESCRIPTION
Update procedures for writing data using 1.8 client libraries with new `/api/v2/write` endpoint.
