### PR TITLE
Add OSS to Enterprise migration links in OSS docs

### DIFF
--- a/content/influxdb/v1.7/administration/upgrading.md
+++ b/content/influxdb/v1.7/administration/upgrading.md
@@ -15,6 +15,12 @@ We recommend enabling Time Series Index (TSI) (step 3 of Upgrade to InfluxDB 1.7
 
 > **_Note:_** The default InfluxDB configuration continues to use in-memory indexes (`inmem`) (as in earlier versions).
 
+{{% note %}}
+### Upgrade to InfluxDB Enterprise
+To upgrade from InfluxDB OSS to InfluxDB Enterprise, [contact InfluxData Sales](https://www.influxdata.com/contact-sales/)
+and see [Migrate to InfluxDB Enterprise](/enterprise_influxdb/v1.7/guides/migration/).
+{{% /note %}}
+
 ## Upgrade to InfluxDB 1.7.x
 
 1. [Download](https://portal.influxdata.com/downloads) InfluxDB 1.7.x and [install the upgrade](/influxdb/v1.7/introduction/installation).

--- a/content/influxdb/v1.7/guides/_index.md
+++ b/content/influxdb/v1.7/guides/_index.md
@@ -7,10 +7,4 @@ menu:
 
 ---
 
-## [Writing data with the InfluxDB API](/influxdb/v1.7/guides/writing_data/)
-
-## [Querying data with the InfluxDB API](/influxdb/v1.7/guides/querying_data/)
-
-## [Downsampling and data retention](/influxdb/v1.7/guides/downsampling_and_retention/)
-
-## [Hardware sizing guidelines](/influxdb/v1.7/guides/hardware_sizing/)
+{{< children type="list" >}}

--- a/content/influxdb/v1.7/guides/migrate-to-enterprise.md
+++ b/content/influxdb/v1.7/guides/migrate-to-enterprise.md
@@ -1,0 +1,11 @@
+---
+title: Migrate from InfluxDB OSS to InfluxDB Enterprise
+description: >
+  Migrate your InfluxDB OSS instance with your data and users to InfluxDB Enterprise.
+menu:
+  influxdb_1_7:
+    weight: 50
+    parent: Guides
+    name: Migrate to InfluxDB Enterprise
+    url: /enterprise_influxdb/v1.7/guides/migration/
+---

--- a/content/influxdb/v1.8/administration/upgrading.md
+++ b/content/influxdb/v1.8/administration/upgrading.md
@@ -16,6 +16,12 @@ We recommend enabling Time Series Index (TSI) (step 3 of Upgrade to InfluxDB 1.8
 
 > **_Note:_** The default configuration continues to use TSM-based shards with in-memory indexes (as in earlier versions).
 
+{{% note %}}
+### Upgrade to InfluxDB Enterprise
+To upgrade from InfluxDB OSS to InfluxDB Enterprise, [contact InfluxData Sales](https://www.influxdata.com/contact-sales/)
+and see [Migrate to InfluxDB Enterprise](/enterprise_influxdb/latest/guides/migration/).
+{{% /note %}}
+
 ## Upgrade to InfluxDB 1.8.x
 
 1. [Download](https://portal.influxdata.com/downloads) InfluxDB version 1.8.x and [install the upgrade](/influxdb/v1.8/introduction/installation).

--- a/content/influxdb/v1.8/guides/_index.md
+++ b/content/influxdb/v1.8/guides/_index.md
@@ -7,10 +7,4 @@ menu:
 
 ---
 
-## [Writing data with the InfluxDB API](/influxdb/v1.8/guides/writing_data/)
-
-## [Querying data with the InfluxDB API](/influxdb/v1.8/guides/querying_data/)
-
-## [Downsampling and data retention](/influxdb/v1.8/guides/downsampling_and_retention/)
-
-## [Hardware sizing guidelines](/influxdb/v1.8/guides/hardware_sizing/)
+{{< children type="list">}}

--- a/content/influxdb/v1.8/guides/migrate-to-enterprise.md
+++ b/content/influxdb/v1.8/guides/migrate-to-enterprise.md
@@ -1,0 +1,11 @@
+---
+title: Migrate from InfluxDB OSS to InfluxDB Enterprise
+description: >
+  Migrate your InfluxDB OSS instance with your data and users to InfluxDB Enterprise.
+menu:
+  influxdb_1_8:
+    weight: 50
+    parent: Guides
+    name: Migrate to InfluxDB Enterprise
+    url: /enterprise_influxdb/v1.8/guides/migration/
+---


### PR DESCRIPTION
Resolves #2828 

With this change, a **Migrate to Enterprise** link appears in the Guides section of the OSS docs. This link simply links to the existing migration doc in the Enterprise docs.