### PR TITLE
add info about OFFSET and WHERE in subqueries

### DIFF
--- a/content/influxdb/v1.8/query_language/explore-data.md
+++ b/content/influxdb/v1.8/query_language/explore-data.md
@@ -707,7 +707,7 @@ SELECT_clause FROM_clause [WHERE_clause] GROUP BY [* | <tag_key>[,<tag_key]]
 The order of the [tag keys](/influxdb/v1.8/concepts/glossary/#tag-key) is irrelevant.
 
 If the query includes a [`WHERE` clause](#the-where-clause) the `GROUP BY`
-clause must appear after the `WHERE` clause.
+clause must appear after the `WHERE` clause. 
 
 Other supported features: [Regular Expressions](#regular-expressions)
 

--- a/content/influxdb/v1.8/query_language/explore-data.md
+++ b/content/influxdb/v1.8/query_language/explore-data.md
@@ -3141,6 +3141,16 @@ Use a subquery to apply a query as a condition in the enclosing query.
 Subqueries offer functionality similar to nested functions and SQL
 [`HAVING` clauses](https://en.wikipedia.org/wiki/Having_%28SQL%29).
 
+{{% warn %}}
+Subqueries **do not support** WHERE or OFFSET. Include **WHERE or OFFSET outside a subquery**. For example:
+
+```sh
+SELECT process, addCount
+FROM (SELECT_statement) [subqueries]
+WHERE time > '2020-04-01T00:00:00Z' AND time <= '2020-04-15T23:23:59Z'
+```
+{{% /warn %}}
+
 ### Syntax
 
 ```sql
@@ -3325,3 +3335,12 @@ SELECT_clause FROM (SELECT_statement; SELECT_statement) [...]
 ```
 
 The system returns a parsing error if a subquery includes multiple `SELECT` statements.
+
+#### WHERE or OFFSET clause in a subquery
+
+Including the WHERE or OFFSET clause in a subquery can return incorrect results.InfluxQL supports the WHERE and OFFSET in main queries only. For example:
+
+```sh
+SELECT_clause FROM (SELECT_statement) [subqueries...]
+WHERE time > '2020-04-01T00:00:00Z' AND time <= '2020-04-15T23:23:59Z'
+```


### PR DESCRIPTION
Closes https://github.com/influxdata/DAR/issues/90

Hi @ayang64 @jsteenb2 I was curious whether we should remove this note--or does this note still apply for "main" queries...just not valid for subqueries?