### PR TITLE
Fix docs about outputs and fieldpass/fielddrop

### DIFF
--- a/content/telegraf/v1.14/administration/configuration.md
+++ b/content/telegraf/v1.14/administration/configuration.md
@@ -184,10 +184,10 @@ The inverse of `namepass`.  If a match is found the point is discarded. This
 is tested on points after they have passed the `namepass` test.
 * **fieldpass**:
 An array of glob pattern strings.  Only fields whose field key matches a
-pattern in this list are emitted.  Not available for outputs.
+pattern in this list are emitted.
 * **fielddrop**:
 The inverse of `fieldpass`. Fields with a field key matching one of the
-patterns will be discarded from the point.  Not available for outputs.
+patterns will be discarded from the point.
 * **tagpass**:
 A table mapping tag keys to arrays of glob pattern strings.  Only points
 that contain a tag key in the table and a tag value matching one of its


### PR DESCRIPTION
This has been allowed since 1.1.0 - the corresponding docs fix in telegraf is in commit [bcf1cf59c134c88](https://github.com/influxdata/telegraf/commit/bcf1cf59c134c887a0a3d8f4cd480a7d370147be).