### PR TITLE
update to highlight invalid token errors

### DIFF
--- a/content/kapacitor/v1.5/event_handlers/alerta.md
+++ b/content/kapacitor/v1.5/event_handlers/alerta.md
@@ -37,7 +37,7 @@ Default Alerta authentication token.
 
 #### `token-prefix`
 Default token prefix.
-_If you are on older versions of Alerta you may need to change this to "Key"._
+_If you receive invalid token errors, you may need to change this to "Key"._
 
 #### `environment`
 Default Alerta environment.


### PR DESCRIPTION
Update per https://github.com/influxdata/docs.influxdata.com/issues/2881. Believe it's related to https://github.com/influxdata/kapacitor/issues/1165 sounds like the issue may not be a new/old version of Alerta.