### PR TITLE
fixed int() TICKscript function description removing duration, resolves #2936

### DIFF
--- a/content/kapacitor/v1.5/tick/syntax.md
+++ b/content/kapacitor/v1.5/tick/syntax.md
@@ -519,7 +519,7 @@ For more specific information, see [Alert node](/kapacitor/v1.5/nodes/alert_node
 Within lambda expressions it is possible to use stateless conversion functions to convert values between types.
 
    * `bool()` - converts a string, int64 or float64 to Boolean.
-   * `int()` - converts a string, float64, Boolean or duration type to an int64.
+   * `int()` - converts a string, float64 or Boolean to an int64.
    * `float()` - converts a string, int64 or Boolean to float64.
    * `string()` - converts an int64, float64, Boolean or duration value to a string.
    * `duration()` - converts an int64, float64 or string to a duration type.


### PR DESCRIPTION
If you try to convert a **duration** into an **int64** running a Kapacitor TICKscript then you'll get an error.
The documentation states this is possible, but it's not.
Just corrected this in v1.5 documentation, not sure if it has to be corrected in v1.4 documentation too.