### PR TITLE
Re-organize Telegraf Windows Service docs

### DIFF
--- a/content/telegraf/v1.15/administration/windows_service.md
+++ b/content/telegraf/v1.15/administration/windows_service.md
@@ -8,37 +8,9 @@ menu:
     parent: Administration
 ---
 
-# Running Telegraf as a Windows service
+Telegraf natively supports running as a Windows service.
 
-Telegraf natively supports running as a Windows service. Outlined below are
-the general steps to set it up.
-
-1. Obtain the Telegraf distribution for Windows.
-2. Create the directory `C:\Program Files\Telegraf` (if you install in a different location, specify the `-config` parameter with the desired location)
-3. Place the `telegraf.exe` and the `telegraf.conf` files into `C:\Program Files\Telegraf`.
-4. To install the service into the Windows Service Manager, run the following in PowerShell as an administrator. If necessary, you can wrap any spaces in the file directories in double quotes `"<file directory>"`:
-
-   ```
-   > C:\"Program Files"\Telegraf\telegraf.exe --service install
-   ```
-
-5. Edit the configuration file to meet your requirements.
-
-6. To verify that it works, run:
-
-   ```
-   > C:\"Program Files"\Telegraf\telegraf.exe --config C:\"Program Files"\Telegraf\telegraf.conf --test
-   ```
-
-7. To start collecting data, run:
-
-   ```
-   > net start telegraf
-   ```
-
-## Other supported operations
-
-Telegraf can manage its own service through the `--service` flag:
+The following commands are available:
 
 | Command                            | Effect                        |
 |------------------------------------|-------------------------------|
@@ -46,3 +18,49 @@ Telegraf can manage its own service through the `--service` flag:
 | `telegraf.exe --service uninstall` | Remove the telegraf service   |
 | `telegraf.exe --service start`     | Start the telegraf service    |
 | `telegraf.exe --service stop`      | Stop the telegraf service     |
+
+Outlined below are the general steps to install Telegraf as a Service.
+
+{{% note %}}
+Installing a Windows service requires administrative permissions.
+Be sure to [launch Powershell as administrator](
+https://docs.microsoft.com/en-us/powershell/scripting/windows-powershell/starting-windows-powershell?view=powershell-7#with-administrative-privileges-run-as-administrator).
+{{% /note %}}
+
+1. Download the Telegraf binary and unzip its contents to `C:\Program Files\InfluxData\Telegraf`.
+2. In PowerShell, run the following as an administrator:
+   ```powershell
+   > cd "C:\Program Files\InfluxData\Telegraf"
+   > .\telegraf.exe --service install --config "C:\Program Files\InfluxData\Telegraf\telegraf.conf"
+   ```
+   When installing as service in Windows, always double check to specify full, correct path of the config file.
+   Otherwise the Windows service may fail to start.
+3. To test that the installation works, run:
+
+   ```powershell
+   > C:\"Program Files"\Telegraf\telegraf.exe --config C:\"Program Files"\Telegraf\telegraf.conf --test
+   ```
+
+4. To start collecting data, run:
+
+   ```powershell
+   telegraf.exe --service start
+   ```
+
+<!--
+#### Config Directory
+
+You can also specify a `--config-directory` for the service to use:
+
+1. Create a directory for configuration snippets: `C:\Program Files\Telegraf\telegraf.d`
+2. Include the `--config-directory` option when registering the service:
+   ```
+   > C:\"Program Files"\Telegraf\telegraf.exe --service install --config C:\"Program Files"\Telegraf\telegraf.conf --config-directory C:\"Program Files"\Telegraf\telegraf.d
+   ```
+-->
+
+{{% note %}}
+## Logging and troubleshooting
+When Telegraf runs as a Windows service, Telegraf logs messages to Windows event logs.
+If the Telegraf service fails on start, view error logs by selecting **Event Viewer**→**Windows Logs**→**Application**.
+{{% /note %}}

--- a/content/telegraf/v1.15/introduction/installation.md
+++ b/content/telegraf/v1.15/introduction/installation.md
@@ -383,62 +383,7 @@ Once configured, run the following commands in PowerShell to begin sending metri
 ```
 ## Install Telegraf as a Windows Service
 
-Telegraf natively supports running as a Windows service.
-
-The following commands are available:
-
-| Command                            | Effect                        |
-|------------------------------------|-------------------------------|
-| `telegraf.exe --service install`   | Install telegraf as a service |
-| `telegraf.exe --service uninstall` | Remove the telegraf service   |
-| `telegraf.exe --service start`     | Start the telegraf service    |
-| `telegraf.exe --service stop`      | Stop the telegraf service     |
-
-Outlined below are the general steps to install Telegraf as a Service.
-
-{{% note %}}
-Installing a Windows service requires administrative permissions.
-Be sure to [launch Powershell as administrator](
-https://docs.microsoft.com/en-us/powershell/scripting/windows-powershell/starting-windows-powershell?view=powershell-7#with-administrative-privileges-run-as-administrator).
-{{% /note %}}
-
-1. Download the Telegraf binary and unzip its contents to `C:\Program Files\InfluxData\Telegraf`.
-2. In PowerShell, run the following as an administrator:
-   ```powershell
-   > cd "C:\Program Files\InfluxData\Telegraf"
-   > .\telegraf.exe --service install --config "C:\Program Files\InfluxData\Telegraf\telegraf.conf"
-   ```
-   When installing as service in Windows, always double check to specify full, correct path of the config file.
-   Otherwise the Windows service may fail to start.
-3. To test that the installation works, run:
-
-   ```powershell
-   > C:\"Program Files"\Telegraf\telegraf.exe --config C:\"Program Files"\Telegraf\telegraf.conf --test
-   ```
-
-4. To start collecting data, run:
-
-   ```powershell
-   telegraf.exe --service start
-   ```
-
-<!--
-#### Config Directory
-
-You can also specify a `--config-directory` for the service to use:
-
-1. Create a directory for configuration snippets: `C:\Program Files\Telegraf\telegraf.d`
-2. Include the `--config-directory` option when registering the service:
-   ```
-   > C:\"Program Files"\Telegraf\telegraf.exe --service install --config C:\"Program Files"\Telegraf\telegraf.conf --config-directory C:\"Program Files"\Telegraf\telegraf.d
-   ```
--->
-
-{{% note %}}
-##### Logging and troubleshooting
-When Telegraf runs as a Windows service, Telegraf logs messages to Windows event logs.
-If the Telegraf service fails on start, view error logs by selecting **Event Viewer**→**Windows Logs**→**Application**.
-{{% /note %}}
+See [Running Telegraf as a Windows service](/telegraf/v1.15/administration/windows_service).
 
 {{< /tab-content-container >}}
 {{< /tab-labels >}}


### PR DESCRIPTION
Closes #2935.

## To reviewers

The diff is a bit confusing: this just moves the existing content [here](https://docs.influxdata.com/telegraf/v1.15/introduction/installation/) to [here](https://docs.influxdata.com/telegraf/v1.15/administration/windows_service/) and links to it.