### PR TITLE
Added default values for compact-throughput

### DIFF
--- a/content/influxdb/v1.8/administration/config.md
+++ b/content/influxdb/v1.8/administration/config.md
@@ -313,14 +313,14 @@ Environment variable: `INFLUXDB_DATA_MAX_CONCURRENT_COMPACTIONS`
 
 #### `compact-throughput = "48m"`
 
-The rate limit, in bytes per second, that we will allow TSM compactions to write to disk.
+The rate limit, in bytes per second, that we will allow TSM compactions to write to disk. The default value for this is '48 minutes'.
 Note that short bursts are allowed to happen at a possibly larger value, set by `compact-throughput-burst`.
 
 Environment variable: `INFLUXDB_DATA_COMPACT_THROUGHPUT`  
 
 #### `compact-throughput-burst = "48m"`
 
-The rate limit, in bytes per second, that we allow TSM compactions to write to disk.
+The rate limit, in bytes per second, that we allow TSM compactions to write to disk. The default value for this is '48 minutes'.
 
 Environment variable: `INFLUXDB_DATA_COMPACT_THROUGHPUT_BURST`  
 


### PR DESCRIPTION
Specifically stating what the default values are for compact-throughput.