### PR TITLE
Kapacitor 1.5.7 Release Notes draft

### DIFF
--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -5,6 +5,17 @@ menu:
     parent: about_the_project
 ---
 
+## v1.5.7 [2020-08-27]
+
+## Features
+
+- Add templating for the url in the `httpPost` node and the `alert().post()` node.
+- Upgrade `github.com/gorhill/cronexpr`, thanks @wuguanyu!
+
+### Bug fixes
+
+- Added missing err check of a buf scanner, thanks @johncming!
+
 ## v1.5.6 [2020-07-17]
 
 ## Features

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -9,7 +9,9 @@ menu:
 
 ## Features
 
-- Add templating for the URL in the [`httpPost` node]() and the [`alert().post()` node]().
+- Add templating for URLs in the [`httpPost` node](/kapacitor/v1.5/nodes/http_post_node/) and the [`alert` node](/kapacitor/v1.5/nodes/alert_node/). To set up an template:
+  - For the `alert` node, see [alert templates](/kapacitor/v1.5/event_handlers/post/#alert-templates).
+  - For the `http post` node see [row templates](/kapacitor/v1.5/event_handlers/post/#row-templates).
 - Upgrade `github.com/gorhill/cronexpr`, thanks @wuguanyu!
 
 ### Bug fixes
@@ -20,8 +22,8 @@ menu:
 
 ## Features
 
-- Add [Microsoft Teams event handler](/kapacitor/1.5/event_handlers/microsoftteams/), thanks @mmindenhall!
-- Add [Discord event handler](/kapacitor/1.5/event_handler/discord/), thanks @mattnotmitt!
+- Add [Microsoft Teams event handler](/kapacitor/v1.5/event_handlers/microsoftteams/), thanks @mmindenhall!
+- Add [Discord event handler](/kapacitor/v1.5/event_handler/discord/), thanks @mattnotmitt!
 - Add [support for TLS 1.3](/kapacitor/v1.5/administration/configuration/#transport-layer-security-tls-settings).
 
 ### Bug fixes

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -14,7 +14,7 @@ menu:
 
 ### Bug fixes
 
-- Added missing err check of a buf scanner, thanks @johncming!
+- Add missing `err` check of a buffer scanner, thanks @johncming!
 
 ## v1.5.6 [2020-07-17]
 

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -9,7 +9,7 @@ menu:
 
 ## Features
 
-- Add templating for the url in the `httpPost` node and the `alert().post()` node.
+- Add templating for the URL in the [`httpPost` node]() and the [`alert().post()` node]().
 - Upgrade `github.com/gorhill/cronexpr`, thanks @wuguanyu!
 
 ### Bug fixes

--- a/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
+++ b/content/kapacitor/v1.5/about_the_project/releasenotes-changelog.md
@@ -9,9 +9,9 @@ menu:
 
 ## Features
 
-- Add templating for URLs in the [`httpPost` node](/kapacitor/v1.5/nodes/http_post_node/) and the [`alert` node](/kapacitor/v1.5/nodes/alert_node/). To set up an template:
+- Add support for templating URLs in the [`httpPost` node](/kapacitor/v1.5/nodes/http_post_node/) and [`alert` node](/kapacitor/v1.5/nodes/alert_node/). To set up an template:
   - For the `alert` node, see [alert templates](/kapacitor/v1.5/event_handlers/post/#alert-templates).
-  - For the `http post` node see [row templates](/kapacitor/v1.5/event_handlers/post/#row-templates).
+  - For the `http post` node, see [row templates](/kapacitor/v1.5/event_handlers/post/#row-templates).
 - Upgrade `github.com/gorhill/cronexpr`, thanks @wuguanyu!
 
 ### Bug fixes

--- a/content/kapacitor/v1.5/event_handlers/post.md
+++ b/content/kapacitor/v1.5/event_handlers/post.md
@@ -11,11 +11,13 @@ menu:
 The post event handler posts JSON encoded data to an HTTP endpoint.
 
 ## Configuration
+
 Configuration as well as default [option](#options) values for the post event
 handler are set in your `kapacitor.conf`.
 Below is an example configuration:
 
 ### Post Settings in kapacitor.conf
+
 ```toml
 [[httppost]]
   endpoint = "example"
@@ -29,40 +31,49 @@ Below is an example configuration:
 ```
 
 #### `endpoint`
+
 Name of a configured HTTP POST endpoint that acts as an identifier for `[[httppost]]`
 configurations when multiple are present.
 _Endpoints are identifiers only. They are not appended to HTTP POST URLs._
 
 #### `url`
+
 The URL to which the alert data will be posted.
 
 #### `headers`
+
 Set of extra header values to set on the POST request.
 
 #### `basic-auth`
+
 Set of authentication credentials to set on the POST request.
 
 #### `alert-template`
-Alert template for constructing a custom HTTP body.
+
+Alert template for constructing a custom HTTP body or url.
 Alert templates are only used with post [alert](/kapacitor/v1.5/nodes/alert_node/)
 handlers as they consume alert data.
 _Skip to [alert templating](#alert-templates)._
 
 #### `alert-template-file`
+
 Absolute path to an alert template file.
 _Skip to [alert templating](#alert-templates)._
 
 #### `row-template`
-Row template for constructing a custom HTTP body.
+
+Row template for constructing a custom HTTP body or url.
 Row templates are only used with the [httpPost node](/kapacitor/v1.5/nodes/http_post_node/)
 pipeline nodes as they consume a row at a time.
 _Skip to [row templating](#row-templates)._
 
 #### `row-template-file`
+
 Absolute path to a row template file.
 _Skip to [row templating](#row-templates)._
 
 ### Defining configuration options with environment variables
+
 The `endpoint`, `url`, and `headers` configuration options can be defined with
 environment variables:
 
@@ -74,6 +85,7 @@ KAPACITOR_HTTPPOST_0_HEADERS_Example2 = "header2"
 ```
 
 ### Configuring and using multiple HTTP POST endpoints
+
 The `kapacitor.conf` supports multiple `[[httppost]]` sections.
 The [`endpoint`](#endpoint) configuration option of each acts as a unique identifier for that specific configuration.
 To use a specific `[[httppost]]` configuration with the Post alert handler,
@@ -109,6 +121,7 @@ KAPACITOR_HTTPPOST_1_HEADERS_Example2 = "header2"
 ```
 
 ## Options
+
 The following post event handler options can be set in a
 [handler file](/kapacitor/v1.5/event_handlers/#handler-file) or when using
 `.post()` in a TICKscript.
@@ -171,6 +184,7 @@ options:
 ```
 
 ## Using the Post event handler
+
 The post event handler can be used in both TICKscripts and handler files to post
 alert and HTTP POST data to an HTTP endpoint.
 The examples below deal with alerts and use the same `[[httppost]]` configuration
@@ -186,6 +200,7 @@ _**HTTP POST settings in kapacitor.conf**_
 ```
 
 ### Post alerts from a TICKscript
+
 The following TICKscripts use the `.post()` event handler to post the message,
 "Hey, check your CPU", whenever idle CPU usage drops below 10%.
 
@@ -220,8 +235,8 @@ stream
       .skipSSLVerification()
 ```
 
-
 ### Post alerts from a defined handler
+
 The following setup sends an alert to the `cpu` topic with the message, "Hey,
 check your CPU".
 A post handler is added that subscribes to the `cpu` topic and posts all alert
@@ -269,13 +284,14 @@ Add the handler:
 kapacitor define-topic-handler post_cpu_handler.yaml
 ```
 
-
 ## Post templating
-The post event handler allows you to customize the content and structure of
+
+The post event handler lets you customize the content and structure of
 POSTs with alert and row templates.
 
 ### Alert templates
-Alert templates are used to construct a custom HTTP body.
+
+Use alert templates to construct a custom HTTP body or URL.
 They are only used with post [alert](/kapacitor/v1.5/nodes/alert_node/) handlers
 as they consume alert data.
 Templates are defined either inline in the `kapacitor.conf` using the
@@ -298,20 +314,22 @@ have access to the following fields:
 | .Recoverable   | Indicates whether or not the alert is auto-recoverable.       |
 
 #### Inline alert template
+
 _**kapacitor.conf**_
 ```toml
 [[httppost]]
-  endpoint = "example"
-  url = "http://example.com/path"
+  endpoint = "host"
+  url = "host={{index .ID \"host\"}}{{range .Duration}} {{index . "time"}} {{index . "value"}}{{end}}"
   alert-template = "{{.Message}}:{{range .Data.Series}}{{.Tags}},{{range .Values}}{{.}}{{end}}{{end}}"
 ```
 
 #### Alert template file
+
 _**kapacitor.conf**_
 ```toml
 [[httppost]]
-  endpoint = "example"
-  url = "http://example.com/path"
+  endpoint = "host"
+  url = "host={{index .ID \"host\"}}{{range .Duration}} {{index . "time"}} {{index . "value"}}{{end}}"
   alert-template-file = "/etc/templates/alert.html"
 ```
 
@@ -321,7 +339,8 @@ _**/etc/templates/alert.html**_
 ```
 
 ### Row templates
-Row templates are used to construct a custom HTTP body.
+
+Use row templates to construct a custom HTTP body or URL.
 They are only used with [httpPost](/kapacitor/v1.5/nodes/http_post_node/)
 handlers as they consume a row at a time.
 Templates are defined either inline in the `kapacitor.conf` using the
@@ -338,20 +357,22 @@ have access to the following fields:
 | .Values | A list of values; each a map containing a "time" key for the time of the point and keys for all other fields on the point. |
 
 #### Inline row template
+
 _**kapacitor.conf**_
 ```toml
 [[httppost]]
-  endpoint = "example"
-  url = "http://example.com/path"
+  endpoint = "host"
+  url = "host={{index .Tags \"host\"}}{{range .Values}} {{index . "time"}} {{index . "value"}}{{end}}"
   row-template = '{{.Name}} host={{index .Tags "host"}}{{range .Values}} {{index . "time"}} {{index . "value"}}{{end}}'
 ```
 
 #### Row template file
+
 _**kapacitor.conf**_
 ```toml
 [[httppost]]
-  endpoint = "example"
-  url = "http://example.com/path"
+  endpoint = "host"
+  url = "host={{index .Tags \"host\"}}{{range .Values}} {{index . "time"}} {{index . "value"}}{{end}}"
   row-template-file = "/etc/templates/row.html"
 ```
 

--- a/content/kapacitor/v1.5/event_handlers/post.md
+++ b/content/kapacitor/v1.5/event_handlers/post.md
@@ -319,7 +319,7 @@ _**kapacitor.conf**_
 ```toml
 [[httppost]]
   endpoint = "host"
-  url = "host={{index .ID \"host\"}}{{range .Duration}} {{index . "time"}} {{index . "value"}}{{end}}"
+  url = "host={{index .ID \"host\"}}{{index . "time"}}{{end}}}"
   alert-template = "{{.Message}}:{{range .Data.Series}}{{.Tags}},{{range .Values}}{{.}}{{end}}{{end}}"
 ```
 
@@ -329,7 +329,7 @@ _**kapacitor.conf**_
 ```toml
 [[httppost]]
   endpoint = "host"
-  url = "host={{index .ID \"host\"}}{{range .Duration}} {{index . "time"}} {{index . "value"}}{{end}}"
+  url = "host={{index .ID \"host\"}}{{index . "time"}}{{end}}"
   alert-template-file = "/etc/templates/alert.html"
 ```
 

--- a/content/kapacitor/v1.5/nodes/alert_node.md
+++ b/content/kapacitor/v1.5/nodes/alert_node.md
@@ -22,7 +22,7 @@ and [AlertNode.Crit](/kapacitor/v1.5/nodes/alert_node/#crit) below.
 
 | Chaining method | Description |
 |:---------|:---------|
-| **alert&nbsp;(&nbsp;)** | Create an alert node, which can trigger alerts. <br> <br>To set GET path parameters or URLs dynamically on a per-window or per-group basis, use the following **template**: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')` <br> <br>|
+| **alert&nbsp;(&nbsp;)** | Create an alert node, which can trigger alerts. <br> <br>To set GET path parameters or URLs dynamically on a per-window or per-group basis, use the following **template**, replacing `host` with your hostname and `cpu` with your tags: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')` <br> <br>|
 
 ### Property methods
 

--- a/content/kapacitor/v1.5/nodes/alert_node.md
+++ b/content/kapacitor/v1.5/nodes/alert_node.md
@@ -22,7 +22,7 @@ and [AlertNode.Crit](/kapacitor/v1.5/nodes/alert_node/#crit) below.
 
 | Chaining method | Description |
 |:---------|:---------|
-| **alert&nbsp;(&nbsp;)** | Create an alert node, which can trigger alerts. <br> <br>To set GET path parameters or URLs dynamically on a per-window or per-group basis, use the following **template**, replacing `host` with your hostname and `cpu` with your tags: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')` <br> <br>|
+| **alert&nbsp;(&nbsp;)** | Create an alert node, which can trigger alerts. <br> <br>To dynamically construct a custom HTTP body or URL, use an [**alert template**](/kapacitor/v1.5/event_handlers/post/#alert-templates). For example, `httpPost('localhost/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')`. <br> <br>|
 
 ### Property methods
 
@@ -72,8 +72,6 @@ and [AlertNode.Crit](/kapacitor/v1.5/nodes/alert_node/#crit) below.
 | **[victorOps](#victorops)&nbsp;(&nbsp;)** | Send alert to VictorOps. |
 | **[warn](#warn)&nbsp;(&nbsp;`value`&nbsp;`ast.LambdaNode`)** | Filter expression for the WARNING alert level. An empty value indicates the level is invalid and is skipped.  |
 | **[warnReset](#warnreset)&nbsp;(&nbsp;`value`&nbsp;`ast.LambdaNode`)** | Filter expression for resetting the WARNING alert level to lower level.  |
-
-
 
 ### Chaining methods
 [Alert](#alert),
@@ -128,7 +126,6 @@ and [AlertNode.Crit](/kapacitor/v1.5/nodes/alert_node/#crit) below.
 
 ---
 
-
 #### Available event handlers
 
 Different event handlers can be configured for each [AlertNode.](/kapacitor/v1.5/nodes/alert_node/)
@@ -158,7 +155,6 @@ option, `global`, that indicates that all alerts implicitly use the handler.
 | [tcp](#tcp)                   | Send data to a specified address via raw TCP.                                         |
 | [Telegram](#telegram)         | Post alert message to Telegram client.                                                |
 | [VictorOps](#victorops)       | Send alert to VictorOps.                                                              |
-
 
 #### Alert event data
 

--- a/content/kapacitor/v1.5/nodes/alert_node.md
+++ b/content/kapacitor/v1.5/nodes/alert_node.md
@@ -18,12 +18,11 @@ See [AlertNode.Info](/kapacitor/v1.5/nodes/alert_node/#info),
 [AlertNode.Warn](/kapacitor/v1.5/nodes/alert_node/#warn),
 and [AlertNode.Crit](/kapacitor/v1.5/nodes/alert_node/#crit) below.
 
-
 ### Constructor
 
 | Chaining method | Description |
 |:---------|:---------|
-| **alert&nbsp;(&nbsp;)** | Create an alert node, which can trigger alerts.  |
+| **alert&nbsp;(&nbsp;)** | Create an alert node, which can trigger alerts. <br> <br>To set GET path parameters or URLs dynamically on a per-window or per-group basis, use the following **template**: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')` <br> <br>|
 
 ### Property methods
 

--- a/content/kapacitor/v1.5/nodes/http_post_node.md
+++ b/content/kapacitor/v1.5/nodes/http_post_node.md
@@ -44,7 +44,7 @@ stream
 
 | Chaining Method                                  | Description |
 |:----------------                                 |:----------- |
-| **httpPost&nbsp;(&nbsp;`url`&nbsp;`...string`)** | Creates an HTTP Post node that POSTS received data to the provided HTTP endpoint. HttpPost expects 0 or 1 arguments. If 0 arguments are provided, you must specify an endpoint property method. <br> <br>To set GET path parameters or URLs dynamically on a per-window or per-group basis, use the following **template**: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')`<br><br>|
+| **httpPost&nbsp;(&nbsp;`url`&nbsp;`...string`)** | Creates an HTTP Post node that POSTS received data to the provided HTTP endpoint. HttpPost expects 0 or 1 arguments. If 0 arguments are provided, you must specify an endpoint property method.<br> <br>To dynamically construct a custom HTTP body or URL, use a [**row template**](/kapacitor/v1.5/event_handlers/post/#row-templates        ). For example, `httpPost('localhost/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')`.
 
 ### Property Methods
 

--- a/content/kapacitor/v1.5/nodes/http_post_node.md
+++ b/content/kapacitor/v1.5/nodes/http_post_node.md
@@ -17,7 +17,6 @@ method on httpPost. Multiple endpoint property methods may be specified.
 
 Example:
 
-
 ```js
 stream
   |window()
@@ -30,7 +29,6 @@ stream
 
 Example:
 
-
 ```js
 stream
   |window()
@@ -42,12 +40,11 @@ stream
     .endpoint('example')
 ```
 
-
 ### Constructor
 
-| Chaining Method | Description |
-|:---------|:---------|
-| **httpPost&nbsp;(&nbsp;`url`&nbsp;`...string`)** | Creates an HTTP Post node that POSTS received data to the provided HTTP endpoint. HttpPost expects 0 or 1 arguments. If 0 arguments are provided, you must specify an endpoint property method.  |
+| Chaining Method                                  | Description |
+|:----------------                                 |:----------- |
+| **httpPost&nbsp;(&nbsp;`url`&nbsp;`...string`)** | Creates an HTTP Post node that POSTS received data to the provided HTTP endpoint. HttpPost expects 0 or 1 arguments. If 0 arguments are provided, you must specify an endpoint property method. <br> <br>To set GET parameter paths or URLs dynamically on a per-window or per-group basis, use the following **template**: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')`|
 
 ### Property Methods
 

--- a/content/kapacitor/v1.5/nodes/http_post_node.md
+++ b/content/kapacitor/v1.5/nodes/http_post_node.md
@@ -44,7 +44,7 @@ stream
 
 | Chaining Method                                  | Description |
 |:----------------                                 |:----------- |
-| **httpPost&nbsp;(&nbsp;`url`&nbsp;`...string`)** | Creates an HTTP Post node that POSTS received data to the provided HTTP endpoint. HttpPost expects 0 or 1 arguments. If 0 arguments are provided, you must specify an endpoint property method. <br> <br>To set GET parameter paths or URLs dynamically on a per-window or per-group basis, use the following **template**: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')`|
+| **httpPost&nbsp;(&nbsp;`url`&nbsp;`...string`)** | Creates an HTTP Post node that POSTS received data to the provided HTTP endpoint. HttpPost expects 0 or 1 arguments. If 0 arguments are provided, you must specify an endpoint property method. <br> <br>To set GET parameter paths or URLs dynamically on a per-window or per-group basis, use the following **template**: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')`<br><br>|
 
 ### Property Methods
 

--- a/content/kapacitor/v1.5/nodes/http_post_node.md
+++ b/content/kapacitor/v1.5/nodes/http_post_node.md
@@ -44,7 +44,7 @@ stream
 
 | Chaining Method                                  | Description |
 |:----------------                                 |:----------- |
-| **httpPost&nbsp;(&nbsp;`url`&nbsp;`...string`)** | Creates an HTTP Post node that POSTS received data to the provided HTTP endpoint. HttpPost expects 0 or 1 arguments. If 0 arguments are provided, you must specify an endpoint property method. <br> <br>To set GET parameter paths or URLs dynamically on a per-window or per-group basis, use the following **template**: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')`<br><br>|
+| **httpPost&nbsp;(&nbsp;`url`&nbsp;`...string`)** | Creates an HTTP Post node that POSTS received data to the provided HTTP endpoint. HttpPost expects 0 or 1 arguments. If 0 arguments are provided, you must specify an endpoint property method. <br> <br>To set GET path parameters or URLs dynamically on a per-window or per-group basis, use the following **template**: `httpPost('localhost/{{ .Name }}/?host={{ index .Tags "host"}}&cpu={{ index .Tags "cpu" }}')`<br><br>|
 
 ### Property Methods
 


### PR DESCRIPTION
Closing this PR and moved updates to[ docs-v2](https://github.com/influxdata/docs-v2/pull/1458)

Add 1.5.7 release notes.
Add docs for URL templating to httpPost and alertPost nodes.